### PR TITLE
'Dependencies' example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - oracle-java9-installer
 
 script:
+  - mvn clean verify  -f dependencies/pom.xml
   - mvn clean install -f core/pom.xml
   - mvn clean install -f applications/probe/pom.xml
   - mvn clean install -f applications/logbook/pom.xml

--- a/applications/probe/pom.xml
+++ b/applications/probe/pom.xml
@@ -10,17 +10,31 @@
       <artifactId>framework</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+
     <dependency>
-      <groupId>org.diirt</groupId>
+      <groupId>datasource</groupId>
       <artifactId>datasource</artifactId>
       <version>3.0.0</version>
+      <scope>system</scope>
+      <systemPath>${basedir}/../../dependencies/target/lib/datasource-3.0.0.jar</systemPath>
     </dependency>
     
     <dependency>
-      <groupId>org.diirt</groupId>
+      <groupId>vtype</groupId>
       <artifactId>vtype</artifactId>
       <version>3.0.0</version>
+      <scope>system</scope>
+      <systemPath>${basedir}/../../dependencies/target/lib/vtype-3.0.0.jar</systemPath>
     </dependency>
+
+    <dependency>
+      <groupId>diirt-util</groupId>
+      <artifactId>diirt-util</artifactId>
+      <version>3.0.0</version>
+      <scope>system</scope>
+      <systemPath>${basedir}/../../dependencies/target/lib/diirt-util-3.0.0.jar</systemPath>
+    </dependency>
+
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>types</artifactId>

--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
     <pathelement path="core/framework/${build}/framework-${version}.jar"/>
     <pathelement path="core/logging/${build}/logging-${version}.jar"/>
     <pathelement path="core/types/${build}/types-${version}.jar"/>
-    <fileset dir="../dependencies">
+    <fileset dir="dependencies/target/lib">
       <include name="*.jar"/>
     </fileset>
   </path>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.phoebus</groupId>
+  <artifactId>dependencies</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.diirt</groupId>
+      <artifactId>datasource-sim</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.diirt</groupId>
+      <artifactId>datasource-sys</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.diirt</groupId>
+      <artifactId>datasource-loc</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.diirt.support</groupId>
+      <artifactId>diirt-ca</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.diirt.support</groupId>
+      <artifactId>diirt-pva</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -16,31 +16,6 @@
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>org.diirt</groupId>
-      <artifactId>datasource-sim</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.diirt</groupId>
-      <artifactId>datasource-sys</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.diirt</groupId>
-      <artifactId>datasource-loc</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.diirt.support</groupId>
-      <artifactId>diirt-ca</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.diirt.support</groupId>
-      <artifactId>diirt-pva</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>inmemory</artifactId>
       <version>0.0.1-SNAPSHOT</version>
@@ -54,6 +29,26 @@
           <source>1.9</source>
           <target>1.9</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <configuration>
+              <failOnError>true</failOnError>
+              <tasks>
+                <echo message="Adding dependencies to product"/>
+                <copy todir="${project.build.directory}/lib">
+                  <fileset dir="${basedir}/../dependencies/target/lib"/>
+                </copy>
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -4,6 +4,7 @@
   <groupId>org.phoebus</groupId>
   <artifactId>product</artifactId>
   <version>0.0.1-SNAPSHOT</version>
+
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
@@ -29,26 +30,6 @@
           <source>1.9</source>
           <target>1.9</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <configuration>
-              <failOnError>true</failOnError>
-              <tasks>
-                <echo message="Adding dependencies to product"/>
-                <copy todir="${project.build.directory}/lib">
-                  <fileset dir="${basedir}/../dependencies/target/lib"/>
-                </copy>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -79,11 +60,52 @@
               <classpathPrefix>lib</classpathPrefix>
               <mainClass>org.phoebus.product.Launcher</mainClass>
             </manifest>
-            <manifestEntries>
-              <Class-Path>lib/</Class-Path>
-            </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+
+      <!-- Above commands built the product.jar.
+           Need to add the dependency jar files
+           and then list all lib/* jars in the manifest classpath
+        -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <configuration>
+              <failOnError>true</failOnError>
+              <tasks>
+                <echo message="Adding dependencies to product"/>
+                <copy todir="${project.build.directory}/lib" verbose="true">
+                  <fileset dir="${basedir}/../dependencies/target/lib"/>
+                </copy>
+
+                <manifestclasspath property="manifest-classpath"
+                                   jarfile="${project.build.directory}/product-${project.version}.jar">
+                  <classpath>
+                    <path>
+                      <fileset dir="${project.build.directory}/lib">
+                        <include name="*.jar"/>
+                      </fileset>
+                    </path>
+                  </classpath>
+                </manifestclasspath>
+            
+                <!-- <echo message="Manifest classpath: ${manifest-classpath}"/> -->
+                <jar update="true" destfile="${project.build.directory}/product-${project.version}.jar">
+                  <manifest>
+                    <attribute name="Class-Path" value="${manifest-classpath}" />
+                  </manifest>
+                </jar>
+
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/run_maven.sh
+++ b/run_maven.sh
@@ -1,0 +1,8 @@
+mvn clean verify  -f dependencies/pom.xml
+mvn -o clean install -f core/pom.xml
+mvn -o clean install -f applications/probe/pom.xml
+mvn -o clean install -f applications/logbook/pom.xml
+mvn -o clean install -f applications/greetings/pom.xml
+mvn -o clean install -f phoebus-product/pom.xml
+
+(cd phoebus-product/target; java -jar product-0.0.1-SNAPSHOT.jar )

--- a/run_maven.sh
+++ b/run_maven.sh
@@ -3,6 +3,6 @@ mvn -o clean install -f core/pom.xml
 mvn -o clean install -f applications/probe/pom.xml
 mvn -o clean install -f applications/logbook/pom.xml
 mvn -o clean install -f applications/greetings/pom.xml
-mvn -o clean install -f phoebus-product/pom.xml
+mvn -o clean verify  -f phoebus-product/pom.xml
 
 (cd phoebus-product/target; java -jar product-0.0.1-SNAPSHOT.jar )


### PR DESCRIPTION
Hello @shroffk @claudio-rosati @willrogers:

This pull request shows the idea of a 'dependencies' project for phoebus.
It creates what Eclipse might call the target platform.
The content of the target platform is defined in the dependencies/pom.xml.

`mvn clean verify  -f dependencies/pom.xml` results in `dependencies/target/lib` to contain all the external jars:

```
antlr-2.7.7.jar
antlr-runtime-3.4.jar
caj-1.1.14.jar
datasource-3.0.0.jar
datasource-formula-3.0.0.jar
datasource-loc-3.0.0.jar
datasource-sim-3.0.0.jar
datasource-sys-3.0.0.jar
datasource-vtype-3.0.0.jar
diirt-ca-3.0.0.jar
diirt-pva-3.0.0.jar
diirt-util-3.0.0.jar
jca-2.3.6.jar
pvAccessJava-4.0.4.jar
pvDataJava-4.0.3.jar
service-3.0.0.jar
stringtemplate-3.2.1.jar
vtype-3.0.0.jar
```

The maven build of `dependencies` fetches the transient dependencies.
For example, dependencies/pom.xml mentions only the diirt-ca module, not jca and caj, but they're fetched because diirt-ca uses them.

**From now on, no more network access is necessary!!** 

All the other build steps can run offline.

For Maven, modules like `applications/probe` which need `vtype` or `datasource` list those as `system` dependencies in the pom, using that target platform directory.
For Ant, the target platform directory is added to the build path.

==> Either way, the content of the target platform is determined at the very first build step, and from then on it's all offline. It's easy to zip the target platform and archive it with a snapshot of the sources to later recreate the exact same build. Or transfer zipped target and sources to a computer that has no general internet access, and build/debug things there.

I see only one downside, and it would be for Maven:
In for example the probe pom, it would be nice to just say
```
   <dependency>
      <systemPath>${basedir}/../../dependencies/target/lib/diirt-util-3.0.0.jar</systemPath>
    </dependency>
```
to refer to a jar file in the target platform. Instead, you need to provide all the usual elements, which are redundant and their value actually doesn't matter since you already have the exact jar file:
```
   <dependency>
      <groupId>diirt-util</groupId>
      <artifactId>diirt-util</artifactId>
      <version>3.0.0</version>
      <scope>system</scope>
      <systemPath>${basedir}/../../dependencies/target/lib/diirt-util-3.0.0.jar</systemPath>
    </dependency>
```