### PR TITLE
Context menu sets active pane

### DIFF
--- a/applications/logbook/inmemory/.classpath
+++ b/applications/logbook/inmemory/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-logging"/>

--- a/applications/pvtable/.classpath
+++ b/applications/pvtable/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-types"/>

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -7,11 +7,8 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtable.ui;
 
-import static org.phoebus.applications.pvtable.PVTableApplication.logger;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -24,8 +21,7 @@ import org.phoebus.applications.pvtable.model.PVTableModelListener;
 import org.phoebus.applications.pvtable.model.VTypeHelper;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.SelectionService;
-import org.phoebus.framework.spi.ContextMenuEntry;
-import org.phoebus.framework.workbench.ContextMenuService;
+import org.phoebus.ui.application.ContextMenuHelper;
 import org.phoebus.ui.dialog.NumericInputDialog;
 
 import javafx.application.Platform;
@@ -58,8 +54,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
-import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.util.converter.DefaultStringConverter;
 
 /** PV Table and its toolbar
@@ -505,25 +499,8 @@ public class PVTable extends BorderPane
                     save, restore, new SeparatorMenuItem(),
                     add_row, remove_row, new SeparatorMenuItem(),
                     tolerance, timeout, new SeparatorMenuItem());
-            //Add PV entries
-            for (ContextMenuEntry entry : ContextMenuService.getInstance().listSupportedContextMenuEntries())
-            {
-                final MenuItem item = new MenuItem(entry.getName());
-                item.setOnAction(e ->
-                {
-                    try
-                    {
-                        final Window window = table.getScene().getWindow();
-                        final Stage stage = window instanceof Stage ? (Stage) window : null;
-                        entry.callWithSelection(stage, SelectionService.getInstance().getSelection());
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.log(Level.WARNING, "Cannot invoke context menu", ex);
-                    }
-                });
-                menu.getItems().add(item);
-            }
+            // Add PV entries
+            ContextMenuHelper.addSupportedEntries(table, menu);
         });
         table.setContextMenu(menu);
     }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
@@ -13,8 +13,6 @@ import java.util.List;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.spi.ContextMenuEntry;
-import org.phoebus.ui.docking.DockPane;
-import org.phoebus.ui.docking.DockStage;
 
 import javafx.stage.Stage;
 

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/FXTree.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/FXTree.java
@@ -20,13 +20,11 @@ import org.phoebus.applications.pvtree.model.TreeModelItem;
 import org.phoebus.applications.pvtree.model.TreeModelListener;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.SelectionService;
-import org.phoebus.framework.spi.ContextMenuEntry;
-import org.phoebus.framework.workbench.ContextMenuService;
+import org.phoebus.ui.application.ContextMenuHelper;
 
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
@@ -36,8 +34,6 @@ import javafx.scene.layout.BorderStrokeStyle;
 import javafx.scene.layout.BorderWidths;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.paint.Color;
-import javafx.stage.Stage;
-import javafx.stage.Window;
 
 /** Basic JFX Tree for {@link TreeModel}
  *
@@ -132,29 +128,13 @@ public class FXTree
         });
 
         // Provide context menu
+        final ContextMenu menu = new ContextMenu();
         tree_view.setOnContextMenuRequested(event ->
         {
-            final ContextMenu menu = new ContextMenu();
-            for (ContextMenuEntry entry : ContextMenuService.getInstance().listSupportedContextMenuEntries())
-            {
-                final MenuItem item = new MenuItem(entry.getName());
-                item.setOnAction(e ->
-                {
-                    try
-                    {
-                        final Window window = tree_view.getScene().getWindow();
-                        final Stage stage = window instanceof Stage ? (Stage) window : null;
-                        entry.callWithSelection(stage, SelectionService.getInstance().getSelection());
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.log(Level.WARNING, "Cannot invoke context menu", ex);
-                    }
-                });
-                menu.getItems().add(item);
-            }
-            tree_view.setContextMenu(menu);
+            menu.getItems().clear();
+            ContextMenuHelper.addSupportedEntries(tree_view, menu);
         });
+        tree_view.setContextMenu(menu);
 
         model.addListener(model_listener);
     }

--- a/core/logging/.classpath
+++ b/core/logging/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="src" output="target/classes" path="src/main/resources"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/core/types/.classpath
+++ b/core/types/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-logging"/>

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.ui.application;
+
+import static org.phoebus.ui.application.PhoebusApplication.logger;
+
+import java.util.logging.Level;
+
+import org.phoebus.framework.selection.SelectionService;
+import org.phoebus.framework.spi.ContextMenuEntry;
+import org.phoebus.framework.workbench.ContextMenuService;
+import org.phoebus.ui.docking.DockStage;
+
+import javafx.scene.Node;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+/** Helper for selection-based additions to context menu
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class ContextMenuHelper
+{
+    /** Add entries suitable for the current selection
+     *
+     *  <p>Invoke inside 'setOnContextMenuRequested' handler,
+     *  after adding application specific menu entries,
+     *  to add entries based on the current selection.
+     *
+     *  @param parent_node Parent node, usually owner of the context menu
+     *  @param menu Menu where selection-based entries will be added
+     */
+    public static void addSupportedEntries(Node parent_node, ContextMenu menu)
+    {
+        final Window window = parent_node.getScene().getWindow();
+        if (! (window instanceof Stage))
+        {
+            logger.log(Level.WARNING, "Expected 'Stage' for context menu, got " + window);
+            return;
+        }
+        final Stage stage = (Stage) window;
+        // Assert that this window's dock pane is the active one.
+        // (on Mac and Linux, invoking the context menu will not
+        //  always activate the stage)
+        DockStage.setActiveDockPane(stage);
+
+        for (ContextMenuEntry<?> entry : ContextMenuService.getInstance().listSupportedContextMenuEntries())
+        {
+            final MenuItem item = new MenuItem(entry.getName());
+            item.setOnAction(e ->
+            {
+                try
+                {
+                    entry.callWithSelection(stage, SelectionService.getInstance().getSelection());
+                }
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING, "Cannot invoke context menu", ex);
+                }
+            });
+            menu.getItems().add(item);
+        }
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -9,6 +9,7 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.docking.DockPane.logger;
 
+import java.util.Objects;
 import java.util.logging.Level;
 
 import javafx.scene.Node;
@@ -83,5 +84,12 @@ public class DockStage
         if (dock_pane instanceof DockPane)
             return (DockPane) dock_pane;
         throw new IllegalStateException("Expect DockPane, got " + dock_pane);
+    }
+
+    /** @param stage Stage that supports docking which should become the active stage */
+    public static void setActiveDockPane(final Stage stage)
+    {
+        final DockPane dock_pane = getDockPane(stage);
+        DockPane.setActiveDockPane(Objects.requireNonNull(dock_pane));
     }
 }


### PR DESCRIPTION
On Linux and Mac it is otherwise sometimes possible to invoke a context
menu in window B while window A is still 'active'.