### PR TITLE
Docking: Hide single tab header; drag tab 'out' to detach

### DIFF
--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -642,8 +642,10 @@ public class PVTable extends BorderPane
         {
             if (event.getDragboard().hasString() ||
                 event.getDragboard().hasContent(DataFormats.ProcessVariables))
+            {
                 event.acceptTransferModes(TransferMode.COPY);
-            event.consume();
+                event.consume();
+            }
         });
 
         table.setOnDragDropped(event ->
@@ -684,9 +686,11 @@ public class PVTable extends BorderPane
                 else if (db.hasString())
                 {   // Add new items from string
                     addPVsFromString(existing, db.getString());
-                    event.setDropCompleted(true);
                 }
+                else
+                    return; // Don't accept, pass event on
             }
+            event.setDropCompleted(true);
             event.consume();
         });
     }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTree.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTree.java
@@ -104,8 +104,10 @@ public class PVTree
             final Dragboard db = event.getDragboard();
             if (db.hasContent(DataFormats.ProcessVariables) ||
                 db.hasString())
+            {
                 event.acceptTransferModes(TransferMode.COPY_OR_MOVE);
-            event.consume();
+                event.consume();
+            }
         });
         layout.setOnDragDropped(event ->
         {
@@ -120,6 +122,8 @@ public class PVTree
             }
             else if (db.hasString())
                 setPVName(db.getString());
+            else
+                return; // Don't consume the event, pass on
             event.setDropCompleted(true);
             event.consume();
         });

--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,7 @@
     <delete dir="applications/greetings/${build}"/>
     <delete dir="applications/probe/${build}"/>
     <delete dir="applications/logbook/inmemory/${build}"/>
-    <delete dir="applications/applications-logConfiguration/${build}"/>
+    <delete dir="applications/logConfiguration/${build}"/>
     <delete dir="applications/pvtable/${build}"/>
     <delete dir="applications/pvtree/${build}"/>
     <delete dir="phoebus-product/${build}"/>
@@ -199,8 +199,9 @@
   <target name="applications-logConfiguration" depends="core-all">
     <mkdir dir="applications/logConfiguration/${classes}"/>
     <javac srcdir="applications/logConfiguration/${src}" destdir="applications/logConfiguration/${classes}" classpathref="app-classpath"/>
-    <jar destfile="applications/logConfiguration/${build}/inmemory-${version}.jar">
+    <jar destfile="applications/logConfiguration/${build}/logConfiguration-${version}.jar">
       <fileset dir="applications/logConfiguration/${classes}"/>
+      <fileset dir="applications/logConfiguration/${resources}"/>
     </jar>
   </target>
 

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -148,6 +148,12 @@ public class DockItem extends Tab
         return name;
     }
 
+    /** @return Label node, limited to in-package access */
+    Label getNameNode()
+    {
+        return name_tab;
+    }
+
     /** @param label Label of this item */
     public void setLabel(final String label)
     {

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -9,6 +9,9 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.docking.DockPane.logger;
 
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.PointerInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,7 +41,6 @@ import javafx.scene.layout.BorderStrokeStyle;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 
 /** Item for a {@link DockPane}
  *
@@ -259,11 +261,16 @@ public class DockItem extends Tab
         if (item != null  &&  !event.isDropCompleted())
         {
             // Would like to position new stage where the mouse was released,
-            // but don't have those coords -> Place somewhat next to existing window.
+            // but event.getX(), getSceneX(), getScreenX() are all 0.0.
+            // --> Using MouseInfo, which is actually AWT code
             final Stage other = item.detach();
-            final Window window = item.getTabPane().getScene().getWindow();
-            other.setX(window.getX() + 50.0);
-            other.setY(window.getY() + 50.0);
+            final PointerInfo pi = MouseInfo.getPointerInfo();
+            if (pi != null)
+            {
+                final Point loc = pi.getLocation();
+                other.setX(loc.getX());
+                other.setY(loc.getY());
+            }
         }
         event.consume();
     }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 
+import javafx.beans.property.StringProperty;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventHandler;
@@ -148,10 +149,10 @@ public class DockItem extends Tab
         return name;
     }
 
-    /** @return Label node, limited to in-package access */
-    Label getNameNode()
+    /** @return Label node text, limited to in-package access */
+    StringProperty labelTextProperty()
     {
-        return name_tab;
+        return name_tab.textProperty();
     }
 
     /** @param label Label of this item */

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -22,6 +22,7 @@ import javafx.scene.input.DragEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.Border;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
 
 /** Pane that contains {@link DockItem}s
  *
@@ -87,13 +88,26 @@ public class DockPane extends TabPane
         autoHideTabs();
         super.layoutChildren();
     }
-    
+
     public void autoHideTabs()
     {
         // Hack from https://www.snip2code.com/Snippet/300911/A-trick-to-hide-the-tab-area-in-a-JavaFX:
         final StackPane header = (StackPane) lookup(".tab-header-area");
+        final boolean single = getTabs().size() == 1;
         if (header != null)
-            header.setPrefHeight(getTabs().size() == 1  ?  0  :  -1);
+            header.setPrefHeight(single  ?  0  :  -1);
+
+        // TODO Get actual header, which for DockItemWithInput may contain 'dirty' marker
+        // TODO When DockItem* updates its label, re-run this code to update title
+
+        // If header for single tab is not shown,
+        // put its label into the window tile
+        final String title = single
+           ? ((DockItem)getTabs().get(0)).getLabel()
+           : "Phoebus";
+
+        final Stage stage = ((Stage) getScene().getWindow());
+        stage.setTitle(title);
     }
 
     /** @param tabs One or more tabs to add */

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -146,7 +146,7 @@ public class DockPane extends TabPane
     /** Accept a dropped tab */
     private void handleDrop(final DragEvent event)
     {
-        final DockItem item = DockItem.dragged_item.get();
+        final DockItem item = DockItem.dragged_item.getAndSet(null);
         if (item == null)
             logger.log(Level.SEVERE, "Empty drop, " + event);
         else
@@ -164,6 +164,7 @@ public class DockPane extends TabPane
             // Select the new item
             getSelectionModel().select(item);
         }
+        System.out.println("Dropped into Pane");
         event.setDropCompleted(true);
         event.consume();
     }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -10,12 +10,7 @@ package org.phoebus.ui.docking;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.phoebus.ui.jobs.JobManager;
-
-import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
-import javafx.collections.ListChangeListener;
-import javafx.event.EventType;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.DragEvent;
@@ -37,7 +32,7 @@ public class DockPane extends TabPane
 {
     /** Logger for all docking related messages */
     public static final Logger logger = Logger.getLogger(DockPane.class.getName());
-    
+
     private static DockPane active = null;
 
     /** @return The last known active dock pane */
@@ -62,7 +57,7 @@ public class DockPane extends TabPane
         setOnDragEntered(this::handleDragEntered);
         setOnDragExited(this::handleDragExited);
         setOnDragDropped(this::handleDrop);
-        
+
         // This pane, just opened, is the active one for now
         active = this;
 
@@ -76,7 +71,7 @@ public class DockPane extends TabPane
         // Show/hide tabs as tab count changes
         getTabs().addListener((InvalidationListener) change -> autoHideTabs());
     }
-    
+
     // lookup() in autoHideTabs() only works when the scene has been rendered.
     // Before, it returns null
     // There is no event for 'node has been rendered',
@@ -91,7 +86,7 @@ public class DockPane extends TabPane
 
     public void autoHideTabs()
     {
-        // Hack from https://www.snip2code.com/Snippet/300911/A-trick-to-hide-the-tab-area-in-a-JavaFX:
+        // Hack from https://www.snip2code.com/Snippet/300911/A-trick-to-hide-the-tab-area-in-a-JavaFX
         final StackPane header = (StackPane) lookup(".tab-header-area");
         final boolean single = getTabs().size() == 1;
         if (header != null)
@@ -99,11 +94,16 @@ public class DockPane extends TabPane
 
         // If header for single tab is not shown,
         // put its label into the window tile
+        if (! (getScene().getWindow() instanceof Stage))
+            throw new IllegalStateException("Expect Stage, got " + getScene().getWindow());
         final Stage stage = ((Stage) getScene().getWindow());
         if (single)
         {   // Bind to get actual header, which for DockItemWithInput may contain 'dirty' marker,
             // and keep updating as it changes
-            stage.titleProperty().bind(((DockItem)getTabs().get(0)).getNameNode().textProperty());
+            final Tab tab = getTabs().get(0);
+            if (! (tab instanceof DockItem))
+                throw new IllegalStateException("Expected DockItem, got " + tab);
+            stage.titleProperty().bind(((DockItem)tab).labelTextProperty());
         }
         else
         {   // Fixed title

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -97,17 +97,19 @@ public class DockPane extends TabPane
         if (header != null)
             header.setPrefHeight(single  ?  0  :  -1);
 
-        // TODO Get actual header, which for DockItemWithInput may contain 'dirty' marker
-        // TODO When DockItem* updates its label, re-run this code to update title
-
         // If header for single tab is not shown,
         // put its label into the window tile
-        final String title = single
-           ? ((DockItem)getTabs().get(0)).getLabel()
-           : "Phoebus";
-
         final Stage stage = ((Stage) getScene().getWindow());
-        stage.setTitle(title);
+        if (single)
+        {   // Bind to get actual header, which for DockItemWithInput may contain 'dirty' marker,
+            // and keep updating as it changes
+            stage.titleProperty().bind(((DockItem)getTabs().get(0)).getNameNode().textProperty());
+        }
+        else
+        {   // Fixed title
+            stage.titleProperty().unbind();
+            stage.setTitle("Phoebus");
+        }
     }
 
     /** @param tabs One or more tabs to add */


### PR DESCRIPTION
When a dockpane has only a single tab, the tab headers are hidden.
Once you drag in another tab, the tab headers are again shown.
#8

Could extend this a little more to update the title of the window instead of the (now hidden) label of the tab when there's only one tab.
