### PR TITLE
Save/restore tabs and their state (for PV Tree)

### DIFF
--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
@@ -14,8 +14,6 @@ import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.spi.ContextMenuEntry;
 
-import javafx.stage.Stage;
-
 /** Entry for context menues that starts PV Tree for selected ProcessVariable
  *
  *  @author Kay Kasemir
@@ -29,13 +27,12 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariab
     @Override
     public String getName()
     {
-        return PVTree.NAME;
+        return PVTreeApplication.NAME;
     }
 
     @Override
     public Object getIcon()
     {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -50,11 +47,8 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariab
     {
         final List<ProcessVariable> pvs = selection.getSelections();
         for (ProcessVariable pv : pvs)
-        {
-            final PVTree pv_tree = new PVTree();
-            pv_tree.start();
-            pv_tree.setPVName(pv.getName());
-        }
+            new PVTreeApplication().openPVTreeTab().setPVName(pv.getName());
+
         return null;
     }
 }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTree.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTree.java
@@ -7,18 +7,18 @@
  *******************************************************************************/
 package org.phoebus.applications.pvtree;
 
+import static org.phoebus.applications.pvtree.PVTreeApplication.logger;
+
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.phoebus.applications.pvtree.ui.FXTree;
 import org.phoebus.applications.pvtree.ui.Messages;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.ui.dnd.DataFormats;
-import org.phoebus.ui.docking.DockItem;
-import org.phoebus.ui.docking.DockPane;
 
 import javafx.geometry.Insets;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -32,25 +32,16 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
-/** PV Tree Application
+/** PV Tree UI
  *  @author Kay Kasemir
  */
-// @ProviderFor(Application.class)
 @SuppressWarnings("nls")
 public class PVTree
 {
-    public static final Logger logger = Logger.getLogger(PVTree.class.getPackageName());
-    public static final String NAME = "PV Tree";
-
     private final TextField pv_name = new TextField();
     private final FXTree tree = new FXTree();
 
-    public String getName()
-    {
-        return NAME;
-    }
-
-    public void start()
+    public Node create()
     {
         final Label label = new Label(Messages.PV_Label);
         pv_name.setOnAction(event -> setPVName(pv_name.getText()));
@@ -90,10 +81,7 @@ public class PVTree
 
         hookDragDrop(layout);
 
-        final DockItem tab = new DockItem(getName(), layout);
-        DockPane.getActiveDockPane().addTab(tab);
-
-        tab.setOnClosed(event -> stop());
+        return layout;
     }
 
     private void hookDragDrop(final BorderPane layout)
@@ -129,7 +117,7 @@ public class PVTree
         });
     }
 
-    public void stop()
+    public void dispose()
     {
         logger.log(Level.INFO, "Stopping PV Tree...");
         tree.shutdown();
@@ -146,5 +134,10 @@ public class PVTree
         name = name.trim();
         pv_name.setText(name);
         tree.setPVName(name);
+    }
+
+    String getPVName()
+    {
+        return pv_name.getText();
     }
 }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.pvtree;
+
+import java.util.logging.Logger;
+
+import org.phoebus.framework.persistence.Memento;
+import org.phoebus.framework.spi.AppDescriptor;
+import org.phoebus.ui.docking.DockItem;
+import org.phoebus.ui.docking.DockPane;
+
+/** Application descriptor for PV Tree
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVTreeApplication implements AppDescriptor
+{
+    public static final Logger logger = Logger.getLogger(PVTree.class.getPackageName());
+
+    public static final String NAME = "PV Tree";
+
+    private PVTree pv_tree;
+
+    @Override
+    public String getName()
+    {
+        return "pv_tree";
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void open()
+    {
+        openPVTreeTab();
+    }
+
+    PVTree openPVTreeTab()
+    {
+        pv_tree = new PVTree();
+        final DockItem tab = new DockItem(this, pv_tree.create());
+        tab.addClosedNotification(() -> pv_tree.dispose());
+        DockPane.getActiveDockPane().addTab(tab);
+        return pv_tree;
+    }
+
+    @Override
+    public void restore(final Memento memento)
+    {
+        memento.getString("pv").ifPresent(name -> pv_tree.setPVName(name));
+    }
+
+    @Override
+    public void save(final Memento memento)
+    {
+        memento.setString("pv", pv_tree.getPVName());
+    }
+}

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeToolbarEntry.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeToolbarEntry.java
@@ -18,12 +18,12 @@ public class PVTreeToolbarEntry implements ToolbarEntry
     @Override
     public String getName()
     {
-        return PVTree.NAME;
+        return PVTreeApplication.NAME;
     }
 
     @Override
     public void call() throws Exception
     {
-        new PVTree().start();
+        new PVTreeApplication().open();
     }
 }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/Settings.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/Settings.java
@@ -7,12 +7,13 @@
  *******************************************************************************/
 package org.phoebus.applications.pvtree;
 
+import static org.phoebus.applications.pvtree.PVTreeApplication.logger;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.prefs.Preferences;
-
 /** Preference settings
  *  @author Kay Kasemir
  */
@@ -69,7 +70,7 @@ public class Settings
         }
         catch (Exception ex)
         {
-            PVTree.logger.log(Level.SEVERE, "Cannot parse fields from '" + spec + "'", ex);
+            logger.log(Level.SEVERE, "Cannot parse fields from '" + spec + "'", ex);
         }
         return Collections.emptyMap();
     }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree.model;
 
-import static org.phoebus.applications.pvtree.PVTree.logger;
+import static org.phoebus.applications.pvtree.PVTreeApplication.logger;
 
 import java.util.List;
 import java.util.Map;

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/FXTree.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/FXTree.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree.ui;
 
-import static org.phoebus.applications.pvtree.PVTree.logger;
+import static org.phoebus.applications.pvtree.PVTreeApplication.logger;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/TreeValueUpdateThrottle.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/TreeValueUpdateThrottle.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree.ui;
 
-import static org.phoebus.applications.pvtree.PVTree.logger;
+import static org.phoebus.applications.pvtree.PVTreeApplication.logger;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/core/framework/src/main/java/org/phoebus/framework/spi/AppDescriptor.java
+++ b/core/framework/src/main/java/org/phoebus/framework/spi/AppDescriptor.java
@@ -1,6 +1,6 @@
 package org.phoebus.framework.spi;
 
-import java.util.Map;
+import org.phoebus.framework.persistence.Memento;
 
 /**
  * Basic interface for defining phoebus applications via java services
@@ -44,6 +44,31 @@ public interface AppDescriptor {
      * Open the application without any specific resources
      */
     public void open();
+
+    /**
+     * If application instance that was just opened
+     * via call to `open` is an instance re-opened
+     * from a previous run,
+     * framework will call this method to allow
+     * instance to restore state from previously
+     * saved memento content. us instance from memento
+     *
+     * @param memento Memento where previous application instance saved state
+     */
+    public default void restore(Memento memento) {
+        // Default does nothing
+    }
+
+    /**
+     * When shutting down, the framework calls
+     * this method to allow application instances
+     * to save their state for restoral on restart.
+     *
+     * @param memento Memento to store state
+     */
+    public default void save(Memento memento) {
+        // Default does nothing
+    }
 
     /**
      * Cleanup the resources used by this application, also perform the action of

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -3,6 +3,7 @@ package org.phoebus.ui.application;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -10,6 +11,7 @@ import java.util.logging.Logger;
 
 import org.phoebus.framework.persistence.MementoTree;
 import org.phoebus.framework.persistence.XMLMementoTree;
+import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.framework.spi.MenuEntry;
 import org.phoebus.framework.workbench.MenuEntryService;
@@ -92,6 +94,8 @@ public class PhoebusApplication extends Application {
             // Else: At least one tab in one stage didn't want to close
             event.consume();
         });
+
+        DockPane.setActiveDockPane(DockStage.getDockPane(stage));
     }
 
     private MenuBar createMenu(final Stage stage) {
@@ -205,7 +209,7 @@ public class PhoebusApplication extends Application {
             //TODO currently uses he first registered application
             logger.log(Level.INFO, "Opening " + resource + " with " + applications.get(0).getName());
             applications.get(0).open(resource);
-        }            
+        }
     }
 
     /** Restore stages from memento */
@@ -332,14 +336,14 @@ public class PhoebusApplication extends Application {
         return true;
     }
 
-    private List<org.phoebus.framework.spi.AppDescriptor> applications;
+    private List<AppDescriptor> applications = Collections.emptyList();
 
-    /** 
+    /**
      * Stop all applications
-     * TODO currently the list of empty 
+     * TODO currently the list of empty
      */
     private void stopApplications() {
-        for (org.phoebus.framework.spi.AppDescriptor app : applications)
+        for (AppDescriptor app : applications)
             app.stop();
     }
 

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -236,7 +236,6 @@ public class PhoebusApplication extends Application {
                     stage.show();
                 }
                 MementoHelper.restoreStage(stage_memento, stage);
-                // TODO restore DockItems, their input, ..
             }
         }
         catch (Exception ex)
@@ -254,7 +253,6 @@ public class PhoebusApplication extends Application {
         {
             final XMLMementoTree memento = XMLMementoTree.create();
 
-            // TODO Persist all DockItems, their optional inputs, ..
             for (Stage stage : DockStage.getDockStages())
                 MementoHelper.saveStage(memento, stage);
 

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -18,6 +18,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 
+import org.phoebus.framework.spi.AppDescriptor;
+
 import javafx.beans.property.StringProperty;
 import javafx.event.Event;
 import javafx.event.EventHandler;
@@ -65,6 +67,9 @@ import javafx.stage.Stage;
 @SuppressWarnings("nls")
 public class DockItem extends Tab
 {
+    /** Property key used for the {@link AppDescriptor} */
+    public static final String KEY_APPLICATION = "application";
+
     private final static ImageView detach_icon;
 
     static
@@ -115,10 +120,23 @@ public class DockItem extends Tab
     /** Create dock item
      *  @param label Initial label
      *  @param content Initial content
+     *  @deprecated
      */
+    @Deprecated
     public DockItem(final String label, final Node content)
     {
         this(label);
+        setContent(content);
+    }
+
+    /** Create dock item for instance of an application
+     *  @param application {@link AppDescriptor}
+     *  @param content Content for this application instance
+     */
+    public DockItem(final AppDescriptor application, final Node content)
+    {
+        this(application.getDisplayName());
+        getProperties().put(KEY_APPLICATION, application);
         setContent(content);
     }
 
@@ -153,6 +171,12 @@ public class DockItem extends Tab
     public String getID()
     {
         return (String) getProperties().get(DockStage.KEY_ID);
+    }
+
+    /** @return Application descriptor of this dock item, may be <code>null</code> */
+    public AppDescriptor getApplication()
+    {
+        return (AppDescriptor) getProperties().get(KEY_APPLICATION);
     }
 
     /** Label of this item */

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -44,7 +44,7 @@ public class DockPane extends TabPane
     }
 
     // Called by DockStage within pachage
-    static void setActiveDockPane(final DockPane pane)
+    public static void setActiveDockPane(final DockPane pane)
     {
         active = pane;
     }

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -92,15 +92,16 @@ public class MementoHelper
             return;
 
         for (AppDescriptor app : ServiceLoader.load(AppDescriptor.class))
-        {
             if (app.getName().equals(app_id))
             {
                 DockPane.setActiveDockPane(pane);
+                // TODO CHeck what type of app it is: Basic AppDescriptor,
+                // or one that has resource, so in that case call open(with the resource)
                 app.open();
                 app.restore(item_memento);
                 return;
             }
-        }
+
         logger.log(Level.WARNING, "No application found for " + app_id);
     }
 }

--- a/core/ui/src/main/resources/META-INF/services/org.phoebus.framework.spi.AppDescriptor
+++ b/core/ui/src/main/resources/META-INF/services/org.phoebus.framework.spi.AppDescriptor
@@ -1,0 +1,1 @@
+org.phoebus.applications.pvtree.PVTreeApplication


### PR DESCRIPTION
New:
 * Each DockItem is associated with the AppDescriptor
 * AppDescriptor has save(Memento) and restore(Memento)

On shutdown, the framework can thus save the application name for each tab, and call save() for each app.

On startup, the framework can locate the application for each tab by name, open() that app and then call restore().

For now, only the PV Tree fully implements this support.

@shroffk , we need a hangout on some details of this