### PR TITLE
Cmd args

### DIFF
--- a/applications/probe/src/main/java/org/phoebus/applications/probe/Probe.java
+++ b/applications/probe/src/main/java/org/phoebus/applications/probe/Probe.java
@@ -10,11 +10,12 @@ import java.util.Map;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
+import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.ui.docking.DockItem;
 import org.phoebus.ui.docking.DockPane;
 /**
- * 
+ *
  * @author Kunal Shroff
  *
  */
@@ -22,7 +23,6 @@ public class Probe implements AppResourceDescriptor {
 
     public static final String NAME = "probe";
     public static final String DISPLAYNAME = "Probe";
-    public static final String PVARG = "pv";
 
     @Override
     public String getName() {
@@ -34,9 +34,11 @@ public class Probe implements AppResourceDescriptor {
         return DISPLAYNAME;
     }
 
+    @Override
     public void start() {
     }
 
+    @Override
     public void stop() {
     }
 
@@ -52,7 +54,7 @@ public class Probe implements AppResourceDescriptor {
         final AppDescriptor app = ApplicationService.findApplication(Probe.NAME);
 
         Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
-        List<String> pvs = args.getOrDefault(PVARG, Collections.emptyList());
+        List<String> pvs = args.getOrDefault(ResourceParser.PV_ARG, Collections.emptyList());
         if (pvs.isEmpty()) {
             // Open an empty probe
             app.create();

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import org.phoebus.applications.pvtable.persistence.PVTableAutosavePersistence;
 import org.phoebus.applications.pvtable.persistence.PVTableXMLPersistence;
 import org.phoebus.framework.spi.AppResourceDescriptor;
+import org.phoebus.framework.util.ResourceParser;
 
 import javafx.scene.image.Image;
 import javafx.stage.FileChooser.ExtensionFilter;
@@ -75,8 +76,8 @@ public class PVTableApplication implements AppResourceDescriptor
         // -app pv_table?file=/some/file
         // but no mix of pv and file argument in one call
         final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
-        final List<String> pvs = args.get("pv");
-        final List<String> files = args.get("file");
+        final List<String> pvs = args.get(ResourceParser.PV_ARG);
+        final List<String> files = args.get(ResourceParser.FILE_ARG);
         if (pvs != null)
         {
             instance = create();

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
@@ -7,7 +7,11 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtable;
 
+import static org.phoebus.framework.util.ResourceParser.createAppURI;
+import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
+
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.phoebus.applications.pvtable.persistence.PVTableAutosavePersistence;
@@ -63,8 +67,32 @@ public class PVTableApplication implements AppResourceDescriptor
     @Override
     public PVTableInstance create(final String resource)
     {
-        final PVTableInstance instance = create();
-        instance.loadResource(resource);
+        PVTableInstance instance = null;
+
+        // Handles
+        // -app pv_table
+        // -app pv_table?pv=a&pv=b
+        // -app pv_table?file=/some/file
+        // but no mix of pv and file argument in one call
+        final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
+        final List<String> pvs = args.get("pv");
+        final List<String> files = args.get("file");
+        if (pvs != null)
+        {
+            instance = create();
+            for (String pv : pvs)
+                instance.getModel().addItem(pv);
+        }
+        else if (files != null)
+        {
+            for (String file : files)
+            {
+                instance = create();
+                instance.loadResource(file);
+            }
+        }
+        else
+            instance = create();
         return instance;
     }
 

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
@@ -7,10 +7,15 @@
  *******************************************************************************/
 package org.phoebus.applications.pvtree;
 
+import static org.phoebus.framework.util.ResourceParser.createAppURI;
+import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
+
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
-import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
+import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.ui.docking.DockItem;
 import org.phoebus.ui.docking.DockPane;
 
@@ -18,7 +23,7 @@ import org.phoebus.ui.docking.DockPane;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PVTreeApplication implements AppDescriptor
+public class PVTreeApplication implements AppResourceDescriptor
 {
     public static final Logger logger = Logger.getLogger(PVTree.class.getPackageName());
 
@@ -45,6 +50,25 @@ public class PVTreeApplication implements AppDescriptor
         final DockItem tab = new DockItem(pv_tree, pv_tree.create());
         tab.addClosedNotification(() -> pv_tree.dispose());
         DockPane.getActiveDockPane().addTab(tab);
+        return pv_tree;
+    }
+
+    @Override
+    public AppInstance create(final String resource)
+    {
+        PVTree pv_tree = null;
+
+        final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
+        final List<String> pvs = args.get("pv");
+        if (pvs == null)
+            pv_tree = (PVTree) create();
+        else
+            for (String pv : pvs)
+            {
+                pv_tree = (PVTree) create();
+                pv_tree.setPVName(pv);
+            }
+
         return pv_tree;
     }
 }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
@@ -44,7 +44,7 @@ public class PVTreeApplication implements AppResourceDescriptor
     }
 
     @Override
-    public AppInstance create()
+    public PVTree create()
     {
         final PVTree pv_tree = new PVTree(this);
         final DockItem tab = new DockItem(pv_tree, pv_tree.create());
@@ -61,11 +61,11 @@ public class PVTreeApplication implements AppResourceDescriptor
         final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
         final List<String> pvs = args.get("pv");
         if (pvs == null)
-            pv_tree = (PVTree) create();
+            pv_tree = create();
         else
             for (String pv : pvs)
             {
-                pv_tree = (PVTree) create();
+                pv_tree = create();
                 pv_tree.setPVName(pv);
             }
 

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
+import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.ui.docking.DockItem;
 import org.phoebus.ui.docking.DockPane;
 
@@ -59,7 +60,7 @@ public class PVTreeApplication implements AppResourceDescriptor
         PVTree pv_tree = null;
 
         final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
-        final List<String> pvs = args.get("pv");
+        final List<String> pvs = args.get(ResourceParser.PV_ARG);
         if (pvs == null)
             pv_tree = create();
         else

--- a/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
+++ b/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
@@ -26,6 +26,12 @@ import java.util.stream.Collectors;
 @SuppressWarnings("nls")
 public class ResourceParser {
 
+    /** Resource query key for PV names */
+    public static final String PV_ARG = "pv";
+
+    /** Resource query key for file names */
+    public static final String FILE_ARG = "file";
+
     /**
      * Creates a {@link URL} for the user entered resource path.
      *
@@ -86,7 +92,7 @@ public class ResourceParser {
 
     /**
      * Parse the app name from the given resource string
-     * 
+     *
      * @return String app name
      */
     public static String parseAppName(String resource) {
@@ -95,7 +101,7 @@ public class ResourceParser {
 
     /**
      * Parse the app name from the given resource URL
-     * 
+     *
      * @return String app name
      */
     public static String parseAppName(URI resource) {
@@ -104,7 +110,7 @@ public class ResourceParser {
 
     /**
      * Parse the query segment of a URI and return a {@link Map}
-     * 
+     *
      * @param uri resource path URI
      * @return {@link Map} a map of all the query parameters
      */
@@ -115,10 +121,10 @@ public class ResourceParser {
         return Arrays.stream(uri.getQuery().split("&")).map(ResourceParser::splitQueryParameter).collect(Collectors
                 .groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, toList())));
     }
-    
+
     /**
      * Parse the query segment of a URL and return a {@link Map}
-     * 
+     *
      * @param url resource path URL
      * @return {@link Map} a map of all the query parameters
      */

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -280,8 +280,9 @@ public class PhoebusApplication extends Application {
                 application = applications.get(options.indexOf(result.get()));
             }
 
-            logger.log(Level.INFO, "Opening " + resource + " with " + application.getDisplayName());
-            application.create(resource);
+            final String app_resource = application.getName() + "?" + ResourceParser.FILE_ARG + "=" + resource;
+            logger.log(Level.INFO, "Opening " + app_resource);
+            application.create(app_resource);
         }
     }
 
@@ -302,10 +303,10 @@ public class PhoebusApplication extends Application {
             logger.log(Level.SEVERE, "Unknown application '" + appName + "'");
             return;
         }
-        if (app instanceof AppResourceDescriptor) 
+        if (app instanceof AppResourceDescriptor)
         {
             ((AppResourceDescriptor)app).create(appLaunchString);
-        } else 
+        } else
         {
             app.create();
         }


### PR DESCRIPTION
Handles
 -app pv_tree
 -app pv_tree?pv=a&pv=b
 -app pv_table
 -app pv_table?pv=a&pv=b
 -app pv_table?file=/path/to/example.pvs

Since AppResourceDescriptor.create is called with the full "app?..." text, PhobusApplication.openResource now adds the app name and "?file=...".

