### PR TITLE
Ui monitoring

### DIFF
--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
@@ -10,6 +10,7 @@ package org.phoebus.applications.pvtable;
 import static org.phoebus.framework.util.ResourceParser.createAppURI;
 import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -18,6 +19,8 @@ import org.phoebus.applications.pvtable.persistence.PVTableAutosavePersistence;
 import org.phoebus.applications.pvtable.persistence.PVTableXMLPersistence;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.framework.util.ResourceParser;
+import org.phoebus.ui.docking.DockItemWithInput;
+import org.phoebus.ui.docking.DockStage;
 
 import javafx.scene.image.Image;
 import javafx.stage.FileChooser.ExtensionFilter;
@@ -88,8 +91,19 @@ public class PVTableApplication implements AppResourceDescriptor
         {
             for (String file : files)
             {
-                instance = create();
-                instance.loadResource(file);
+                final URL input = ResourceParser.createResourceURL(file);
+                // Check for existing instance with that input
+                final DockItemWithInput existing = DockStage.getDockItemWithInput(NAME, input);
+                if (existing != null)
+                {   // Found one, raise it
+                    instance = existing.getApplication();
+                    instance.raise();
+                }
+                else
+                {   // Nothing found, create new one
+                    instance = create();
+                    instance.loadResource(input);
+                }
             }
         }
         else

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
@@ -96,17 +96,17 @@ public class PVTableInstance implements AppInstance
         // Load files in background job
         JobManager.schedule("Load PV Table", monitor ->
         {
+            final PVTableModel load_model = new PVTableModel(false);
             try
             {
                 final URL input = ResourceParser.createResourceURL(resource);
                 monitor.updateTaskName("Load " + input);
-                final PVTableModel model = new PVTableModel();
-                PVTablePersistence.forFilename(input.toString()).read(model, input.openStream());
+                PVTablePersistence.forFilename(input.toString()).read(load_model, input.openStream());
 
                 // On success, update on UI
                 Platform.runLater(() ->
                 {
-                    transferModel(model);
+                    transferModel(load_model);
                     dock_item.setInput(input);
                 });
             }

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
@@ -98,6 +98,11 @@ public class PVTableInstance implements AppInstance
 
     void loadResource(final URL input)
     {
+        // Set input ASAP so that other requests to open this
+        // resource will find this instance and not start
+        // another instance
+        dock_item.setInput(input);
+
         // Load files in background job
         JobManager.schedule("Load PV Table", monitor ->
         {
@@ -111,7 +116,6 @@ public class PVTableInstance implements AppInstance
                 Platform.runLater(() ->
                 {
                     transferModel(load_model);
-                    dock_item.setInput(input);
                 });
             }
             catch (Exception ex)
@@ -121,7 +125,6 @@ public class PVTableInstance implements AppInstance
                 ExceptionDetailsErrorDialog.openError(app.getDisplayName(), message, ex);
             }
         });
-
     }
 
     private void doSave(final JobMonitor monitor) throws Exception

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
@@ -83,6 +83,11 @@ public class PVTableInstance implements AppInstance
         return model;
     }
 
+    public void raise()
+    {
+        dock_item.select();
+    }
+
     public void transferModel(final PVTableModel new_model)
     {
         // This sends a model update
@@ -91,7 +96,7 @@ public class PVTableInstance implements AppInstance
         dock_item.setDirty(false);
     }
 
-    void loadResource(final String resource)
+    void loadResource(final URL input)
     {
         // Load files in background job
         JobManager.schedule("Load PV Table", monitor ->
@@ -99,7 +104,6 @@ public class PVTableInstance implements AppInstance
             final PVTableModel load_model = new PVTableModel(false);
             try
             {
-                final URL input = ResourceParser.createResourceURL(resource);
                 monitor.updateTaskName("Load " + input);
                 PVTablePersistence.forFilename(input.toString()).read(load_model, input.openStream());
 
@@ -112,7 +116,7 @@ public class PVTableInstance implements AppInstance
             }
             catch (Exception ex)
             {
-                final String message = "Cannot open PV Table\n" + resource;
+                final String message = "Cannot open PV Table\n" + input;
                 logger.log(Level.WARNING, message, ex);
                 ExceptionDetailsErrorDialog.openError(app.getDisplayName(), message, ex);
             }

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/model/PVTableModel.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/model/PVTableModel.java
@@ -43,7 +43,7 @@ public class PVTableModel implements PVTableItemListener
 
     final private List<PVTableModelListener> listeners = new ArrayList<PVTableModelListener>();
 
-    final private Timer update_timer = new Timer("PVTableUpdate", true);
+    private Timer update_timer;
 
     /** @see #performUpdates() */
     private Set<PVTableItem> changed_items = new HashSet<PVTableItem>();
@@ -54,14 +54,26 @@ public class PVTableModel implements PVTableItemListener
     /** Initialize */
     public PVTableModel()
     {
-        update_timer.schedule(new TimerTask()
+        this(true);
+    }
+
+    /** Initialize
+     *  @param with_timer With timer to send events?
+     */
+    public PVTableModel(final boolean with_timer)
+    {
+        if (with_timer)
         {
-            @Override
-            public void run()
+            update_timer = new Timer("PVTableUpdate", true);
+            update_timer.schedule(new TimerTask()
             {
-                performUpdates();
-            }
-        }, UPDATE_PERIOD_MS, UPDATE_PERIOD_MS);
+                @Override
+                public void run()
+                {
+                    performUpdates();
+                }
+            }, UPDATE_PERIOD_MS, UPDATE_PERIOD_MS);
+        }
     }
 
     /** @param listener Listener to add */
@@ -180,7 +192,6 @@ public class PVTableModel implements PVTableItemListener
      */
     public void transferItems(final PVTableModel other_model)
     {
-        dispose();
         for (PVTableItem item : other_model.items)
         {
             item.listener = this;
@@ -316,6 +327,7 @@ public class PVTableModel implements PVTableItemListener
     /** Must be invoked when 'done' by the creator of the model. */
     public void dispose()
     {
+        update_timer.cancel();
         for (PVTableItem item : items)
             item.dispose();
         items.clear();

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/model/SavedScalarValue.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/model/SavedScalarValue.java
@@ -76,7 +76,7 @@ public class SavedScalarValue extends SavedValue
             else
                 pv.write(Double.parseDouble(saved_value));
         }
-        else if (pv_type instanceof VNumber)
+        else if (pv_type instanceof VNumber  ||  pv_type instanceof VEnum)
         {
             if (completion_timeout_secs > 0)
                 pv.asyncWrite(getSavedNumber(saved_value).longValue()).get(completion_timeout_secs, TimeUnit.SECONDS);

--- a/applications/pvtree/src/main/resources/pv_tree_preferences.properties
+++ b/applications/pvtree/src/main/resources/pv_tree_preferences.properties
@@ -1,6 +1,6 @@
-# ----------------------------------------
-# Package org.phoebus.applications.pvtable
-# ----------------------------------------
+# ---------------------------------------
+# Package org.phoebus.applications.pvtree
+# ---------------------------------------
 
 # The channel access DBR_STRING has a length limit of 40 chars.
 # Since EPICS base R3.14.11, reading fields with an added '$' returns

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -83,6 +84,8 @@ public class PhoebusApplication extends Application {
     public void start(final Stage initial_stage) throws Exception {
         // Show splash screen as soon as possible..
         final Splash splash = new Splash(initial_stage);
+
+        new ResponsivenessMonitor(500, TimeUnit.MILLISECONDS);
 
         // .. then read saved state etc. in background job
         JobManager.schedule("Startup", monitor ->
@@ -249,6 +252,17 @@ public class PhoebusApplication extends Application {
             final File file = new OpenFileDialog().promptForFile(stage, "Open File", null, null);
             if (file == null)
                 return;
+
+            // TODO Remove artificial delay for ResponsivenessMonitor test
+            try
+            {
+                Thread.sleep(4000);
+            }
+            catch (InterruptedException e)
+            {
+                e.printStackTrace();
+            }
+
             openResource(file.toString());
         });
         final MenuItem exit = new MenuItem("Exit");

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -36,6 +36,7 @@ import org.phoebus.ui.internal.MementoHelper;
 import org.phoebus.ui.jobs.JobManager;
 import org.phoebus.ui.jobs.JobMonitor;
 import org.phoebus.ui.jobs.SubJobMonitor;
+import org.phoebus.ui.monitoring.ResponsivenessMonitor;
 import org.phoebus.ui.welcome.Welcome;
 
 import javafx.application.Application;
@@ -252,17 +253,6 @@ public class PhoebusApplication extends Application {
             final File file = new OpenFileDialog().promptForFile(stage, "Open File", null, null);
             if (file == null)
                 return;
-
-            // TODO Remove artificial delay for ResponsivenessMonitor test
-            try
-            {
-                Thread.sleep(4000);
-            }
-            catch (InterruptedException e)
-            {
-                e.printStackTrace();
-            }
-
             openResource(file.toString());
         });
         final MenuItem exit = new MenuItem("Exit");

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -170,7 +170,14 @@ public class PhoebusApplication extends Application {
         monitor.worked(1);
 
         // In 'server' mode, handle parameters received from client instances
-        ApplicationServer.setOnReceivedArgument(this::handleClientParameters);
+        ApplicationServer.setOnReceivedArgument(parameters ->
+        {
+            // Invoked by received arguments from the OS's file browser,
+            // i.e. the file browser is currently in focus.
+            // Assert that the phoebus window is visible
+            Platform.runLater(() -> main_stage.toFront());
+            handleClientParameters(parameters);
+        });
 
         // Closing the primary window is like calling File/Exit.
         // When the primary window is the only open stage, that's OK.

--- a/core/ui/src/main/java/org/phoebus/ui/application/ResponsivenessMonitor.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ResponsivenessMonitor.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.ui.application;
+
+import static org.phoebus.ui.application.PhoebusApplication.logger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+import javafx.application.Platform;
+
+/** Responsiveness Monitor
+ *
+ *  <p>Checks if the UI thread is processing events,
+ *  logs stack traces when the UI thread is suspected
+ *  to be blocked.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class ResponsivenessMonitor
+{
+    // Compare org.eclipse.ui.monitoring
+    // https://github.com/eclipse/eclipse.platform.ui/tree/master/bundles/org.eclipse.ui.monitoring .
+    // It hooks into the SWT event loop to time the period between events.
+    //
+    // Didn't see a way to do that for JavaFX.
+    // Instead, periodically submitting runnable to Platform.Platform.runLater()
+    // and testing if it was invoked.
+
+    /** Timer for scheduling periodic test */
+    private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(runnable ->
+    {
+        final Thread thread = new Thread(runnable);
+        thread.setName("ResponsivenessMonitor");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final AtomicBoolean ui_thread_responded = new AtomicBoolean(true);
+    private final AtomicBoolean frozen = new AtomicBoolean(false);
+
+    private final long ui_thread_id;
+    private final ThreadMXBean thread_bean;
+    private final boolean dumpLockedMonitors, dumpLockedSynchronizers;
+
+
+    /** Create responsiveness monitor
+     *
+     *  @param period Period between tests, i.e. the minimum detected UI freeze duration
+     *  @param unit Units for the period
+     */
+    public ResponsivenessMonitor(final long period, final TimeUnit unit)
+    {
+        if (! Platform.isFxApplicationThread())
+            throw new IllegalStateException("Must create on UI thread");
+        ui_thread_id = Thread.currentThread().getId();
+        thread_bean = ManagementFactory.getThreadMXBean();
+        dumpLockedMonitors = thread_bean.isObjectMonitorUsageSupported();
+        dumpLockedSynchronizers = thread_bean.isSynchronizerUsageSupported();
+        timer.scheduleWithFixedDelay(this::check, period, period, unit);
+    }
+
+    private void check()
+    {
+        // Did the UI thread respond to the last 'ping'?
+        if (ui_thread_responded.getAndSet(false))
+        {
+            // Yes.
+            final boolean was_frozen = frozen.getAndSet(false);
+            if (was_frozen)
+                logger.log(Level.SEVERE, "UI Updates resume");
+            // Ping UI thread gain, see if it remains responsive
+            Platform.runLater(this::pingUI);
+        }
+        else
+        {
+            // UI did not respond
+            final boolean was_frozen = frozen.getAndSet(true);
+            if (! was_frozen)
+                reportUIFreeze();
+            // else: Log only once, then note when UI resumes
+        }
+    }
+
+    private void reportUIFreeze()
+    {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("UI Freezeup\n\n");
+        final ThreadInfo[] thread_infos = thread_bean.dumpAllThreads(dumpLockedMonitors, dumpLockedSynchronizers);
+        for (ThreadInfo info : thread_infos)
+        {
+            if (info.getThreadId() == Thread.currentThread().getId())
+            {
+                continue;
+            }
+            if (info.getThreadId() == ui_thread_id)
+            {
+                buf.append("\n");
+                buf.append("*********************************\n");
+                buf.append("*** JavaFX Application Thread ***\n");
+                buf.append("*********************************\n");
+            }
+            buf.append(info);
+        }
+
+        logger.log(Level.SEVERE, buf.toString());
+    }
+
+    /** Called by UI thread */
+    private void pingUI()
+    {
+        // Indicate that UI thread executed
+        ui_thread_responded.set(true);
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -164,9 +164,10 @@ public class DockItem extends Tab
     }
 
     /** @return Application instance of this dock item, may be <code>null</code> */
-    public AppInstance getApplication()
+    @SuppressWarnings("unchecked")
+    public <INST extends AppInstance> INST getApplication()
     {
-        return (AppInstance) getProperties().get(KEY_APPLICATION);
+        return (INST) getProperties().get(KEY_APPLICATION);
     }
 
     /** Label of this item */

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -64,7 +64,6 @@ public class DockItemWithInput extends DockItem
      *  @param content Initial content
      *  @param input URL for the input. May be <code>null</code>
      *  @param save_handler Will be called to 'save' the content
-     *  @
      */
     public DockItemWithInput(final AppInstance application, final Node content, final URL input, final JobRunnable save_handler)
     {
@@ -169,6 +168,6 @@ public class DockItemWithInput extends DockItem
     @Override
     public String toString()
     {
-        return "DockItem(\"" + getLabel() + "\")";
+        return "DockItemWithInput(\"" + getLabel() + "\", " + getInput() + ")";
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -42,10 +42,20 @@ public class DockPane extends TabPane
     /** @return The last known active dock pane */
     public static DockPane getActiveDockPane()
     {
+        if (! active.getScene().getWindow().isShowing())
+        {
+            // The Window for the previously active dock pane was closed
+            // Use the first one that's still open
+            for (Stage stage : DockStage.getDockStages())
+            {
+                active = DockStage.getDockPane(stage);
+                break;
+            }
+        }
         return active;
     }
 
-    // Called by DockStage within pachage
+    // Called by DockStage within package
     public static void setActiveDockPane(final DockPane pane)
     {
         active = pane;

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -9,6 +9,7 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.docking.DockPane.logger;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -176,5 +177,25 @@ public class DockStage
     {
         final DockPane dock_pane = getDockPane(stage);
         DockPane.setActiveDockPane(Objects.requireNonNull(dock_pane));
+    }
+
+    /** Locate DockItemWithInput for application and input
+     *  @param application_name Application name
+     *  @param input Input, must not be <code>null</code>
+     *  @return {@link DockItemWithInput} or <code>null</code> if not found
+     */
+    public static DockItemWithInput getDockItemWithInput(final String application_name, final URL input)
+    {
+        Objects.requireNonNull(input);
+        for (Stage stage : getDockStages())
+            for (DockItem tab : getDockPane(stage).getDockItems())
+                if (tab instanceof DockItemWithInput)
+                {
+                    final DockItemWithInput item = (DockItemWithInput) tab;
+                    if (input.equals(item.getInput()) &&
+                        item.getApplication().getAppDescriptor().getName().equals(application_name))
+                        return item;
+                }
+        return null;
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/monitoring/FreezeUI.java
+++ b/core/ui/src/main/java/org/phoebus/ui/monitoring/FreezeUI.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.ui.monitoring;
+
+import org.phoebus.framework.spi.MenuEntry;
+
+/** Menu entry to freeze UI for testing {@link ResponsivenessMonitor}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class FreezeUI implements MenuEntry
+{
+    @Override
+    public String getName()
+    {
+        return "Freeze UI";
+    }
+
+    @Override
+    public String getMenuPath()
+    {
+        return "Debug";
+    }
+
+    @Override
+    public Void call() throws Exception
+    {
+        Thread.sleep(2000);
+        return null;
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/monitoring/ResponsivenessMonitor.java
+++ b/core/ui/src/main/java/org/phoebus/ui/monitoring/ResponsivenessMonitor.java
@@ -48,11 +48,19 @@ public class ResponsivenessMonitor
         return thread;
     });
 
+    /** Set by UI 'ping' runnable */
     private final AtomicBoolean ui_thread_responded = new AtomicBoolean(true);
+
+    /** Is the UI thread frozen at this time? */
     private final AtomicBoolean frozen = new AtomicBoolean(false);
 
+    /** ID of UI thread */
     private final long ui_thread_id;
+
+    /** Beam for dumping thread infos */
     private final ThreadMXBean thread_bean;
+
+    /** Functionalities of ThreadMXBean */
     private final boolean dumpLockedMonitors, dumpLockedSynchronizers;
 
 
@@ -72,6 +80,7 @@ public class ResponsivenessMonitor
         timer.scheduleWithFixedDelay(this::check, period, period, unit);
     }
 
+    /** Called periodically to check if UI thread responds */
     private void check()
     {
         // Did the UI thread respond to the last 'ping'?
@@ -94,6 +103,7 @@ public class ResponsivenessMonitor
         }
     }
 
+    /** Log detail about UI freezeup */
     private void reportUIFreeze()
     {
         final StringBuilder buf = new StringBuilder();
@@ -103,6 +113,7 @@ public class ResponsivenessMonitor
         {
             if (info.getThreadId() == Thread.currentThread().getId())
             {
+                // Exclude the ResponsivenessMonitor thread
                 continue;
             }
             if (info.getThreadId() == ui_thread_id)

--- a/core/ui/src/main/java/org/phoebus/ui/monitoring/ResponsivenessMonitor.java
+++ b/core/ui/src/main/java/org/phoebus/ui/monitoring/ResponsivenessMonitor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
-package org.phoebus.ui.application;
+package org.phoebus.ui.monitoring;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 

--- a/core/ui/src/main/resources/META-INF/services/org.phoebus.framework.spi.MenuEntry
+++ b/core/ui/src/main/resources/META-INF/services/org.phoebus.framework.spi.MenuEntry
@@ -1,2 +1,3 @@
 org.phoebus.ui.pv.PVListMenuEntry
 org.phoebus.ui.jobs.JobViewerMenuEntry
+org.phoebus.ui.monitoring.FreezeUI

--- a/phoebus-product/build.xml
+++ b/phoebus-product/build.xml
@@ -57,6 +57,8 @@
       <zipfileset dir="${build}" includes="**/*.jar" prefix="phoebus-${version}"/>
       <zipfileset dir="." includes="phoebus.sh" fullpath="phoebus-${version}/phoebus.sh" filemode="755"/>
       <zipfileset dir="." includes="phoebus.bat" fullpath="phoebus-${version}/phoebus.bat"/>
+      <zipfileset dir="." includes="phoebus.xml" fullpath="phoebus-${version}/phoebus.xml"/>
+      <zipfileset dir="." includes="phoebus.desktop" fullpath="phoebus-${version}/phoebus.desktop"/>
       <zipfileset dir="${build}" includes="doc/**" prefix="phoebus-${version}"/>
     </zip>
   </target>

--- a/phoebus-product/phoebus.desktop
+++ b/phoebus-product/phoebus.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Terminal=false
+Name=Phoebus
+Exec=~/bin/phoebus -resource %f

--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -2,9 +2,13 @@
 #
 # Phoebus launcher for Linux or Mac OS X
 
-# When deploying, you might want to change "TOP"
+# When deploying, change "TOP"
 # to the absolute installation path
 TOP="."
+
+# Ideally, assert that Java is found
+# export JAVA_HOME=/opt/jdk-9
+# export PATH="$JAVA_HOME/bin:$PATH"
 
 if [ -d $TOP/target ]
 then
@@ -21,5 +25,8 @@ else
   JAR="${TOP}/product-${V}-SNAPSHOT.jar"
 fi
 
+# To get one instance, use server mode
+OPT="-server 4918"
+
 # Will eventually need --add-modules=ALL-SYSTEM?
-java -jar $JAR "$@"
+java -jar $JAR $OPT "$@" &

--- a/phoebus-product/phoebus.xml
+++ b/phoebus-product/phoebus.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Mine type definitions for Linux
+
+     sudo cp phoebus.xml /usr/share/mime/packages
+     sudo update-mime-database /usr/share/mime
+  -->
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/pvtable">
+    <comment>PV Table</comment>
+    <glob pattern="*.pvs"/>
+  </mime-type>
+  <mime-type type="application/pvtable">
+    <comment>PV Table</comment>
+    <glob pattern="*.sav"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
Adds `ResponsivenessMonitor`.

Similar to the RCP idea, this monitors the UI thread.
When it detects a freezeup, it logs a stack trace.

Compared to RCP implementation, it's simpler:
Fixed check rate of 500ms,
always logs just one stack trace when the freeze is detected,
then another message once UI thread resumes.

Added Menu entry Debug/Freeze UI to test/demo.

The log does add a header to the JFX thread, since that's the key one which blocks.
In this example, it points to FreezeUI invoked from the test/demo menu entry.

```
2017-09-29 16:16:35 SEVERE [org.phoebus.ui.application.PhoebusApplication] UI Freezeup

"PVMgr Worker 7" daemon prio=5 Id=42 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@4bdd5bba
	at java.base@9/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@4bdd5bba
	at java.base@9/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
	at java.base@9/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2062)
	at java.base@9/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1119)
	at java.base@9/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:848)
	at java.base@9/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1092)
	at java.base@9/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
	at java.base@9/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	...

...

*********************************
*** JavaFX Application Thread ***
*********************************
"JavaFX Application Thread" prio=5 Id=19 TIMED_WAITING
	at java.base@9/java.lang.Thread.sleep(Native Method)
	at app//org.phoebus.ui.monitoring.FreezeUI.call(FreezeUI.java:33)
	at app//org.phoebus.ui.monitoring.FreezeUI.call(FreezeUI.java:1)
	at app//org.phoebus.ui.application.PhoebusApplication.lambda$10(PhoebusApplication.java:317)
	at app//org.phoebus.ui.application.PhoebusApplication$$Lambda$338/513002640.handle(Unknown Source)
	at platform/javafx.base@9/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at platform/javafx.base@9/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at platform/javafx.base@9...

...


2017-09-29 16:16:37 SEVERE [org.phoebus.ui.application.PhoebusApplication] UI Updates resume


```