### PR TITLE
Add icon to context menu entries

### DIFF
--- a/applications/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
+++ b/applications/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.phoebus.applications.email.EmailApp;
 import org.phoebus.framework.selection.Selection;
-import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.ContextMenuEntry;
 import org.phoebus.framework.workbench.ApplicationService;
 
@@ -27,11 +26,6 @@ public class ContextCreateEmail implements ContextMenuEntry {
     @Override
     public Object callWithSelection(Selection selection) {
         ApplicationService.findApplication(EmailApp.NAME).create();
-        return null;
-    }
-
-    @Override
-    public Object getIcon() {
         return null;
     }
 

--- a/applications/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
+++ b/applications/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
@@ -47,11 +47,6 @@ public class ContextLaunchProbe implements ContextMenuEntry {
     }
 
     @Override
-    public Object getIcon() {
-        return null;
-    }
-
-    @Override
     public List<Class> getSupportedTypes() {
         return supportedTypes;
     }

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtable;
 
+import java.io.InputStream;
 import java.util.List;
 
 import org.phoebus.core.types.ProcessVariable;
@@ -30,9 +31,9 @@ public class ContextMenuPVTableLauncher implements ContextMenuEntry<ProcessVaria
     }
 
     @Override
-    public Object getIcon()
+    public InputStream getIcon()
     {
-        return null;
+        return PVTableApplication.getIconStream("pvtable.png");
     }
 
     @Override

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableApplication.java
@@ -10,6 +10,7 @@ package org.phoebus.applications.pvtable;
 import static org.phoebus.framework.util.ResourceParser.createAppURI;
 import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
 
+import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +117,14 @@ public class PVTableApplication implements AppResourceDescriptor
      */
     public static Image getIcon(final String name)
     {
-        return new Image(PVTableApplication.class.getResourceAsStream("/icons/" + name));
+        return new Image(getIconStream(name));
+    }
+
+    /** @param name Name of the icon
+     *  @return InputStream for icon
+     */
+    public static InputStream getIconStream(final String name)
+    {
+        return PVTableApplication.class.getResourceAsStream("/icons/" + name);
     }
 }

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree;
 
+import java.io.InputStream;
 import java.util.List;
 
 import org.phoebus.core.types.ProcessVariable;
@@ -18,8 +19,7 @@ import org.phoebus.framework.workbench.ApplicationService;
  *
  *  @author Kay Kasemir
  */
-// @ProviderFor(ContextMenuEntry.class)
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "nls", "rawtypes" })
 public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariable>
 {
     private static final List<Class> supportedTypes = List.of(ProcessVariable.class);
@@ -31,9 +31,9 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariab
     }
 
     @Override
-    public Object getIcon()
+    public InputStream getIcon()
     {
-        return null;
+        return getClass().getResourceAsStream("/icons/pvtree.png");
     }
 
     @Override

--- a/core/framework/src/main/java/org/phoebus/framework/spi/ContextMenuEntry.java
+++ b/core/framework/src/main/java/org/phoebus/framework/spi/ContextMenuEntry.java
@@ -1,10 +1,9 @@
 package org.phoebus.framework.spi;
 
+import java.io.InputStream;
 import java.util.List;
 
 import org.phoebus.framework.selection.Selection;
-
-import javafx.stage.Stage;
 
 /**
  * Context menu entry service interface
@@ -17,16 +16,18 @@ public interface ContextMenuEntry<V> {
 
     /**
      * The display name of the context menu entry
-     * 
+     *
      * @return the display name
      */
     public String getName();
 
     /**
-     * 
-     * @return
+     * @return Stream for icon, or <code>null</code>
      */
-    public Object getIcon();
+    public default InputStream getIcon()
+    {
+        return null;
+    }
 
     /**
      * @return Selection types for which this entry should be displayed
@@ -35,7 +36,7 @@ public interface ContextMenuEntry<V> {
 
     /**
      * Invoke the context menu
-     * 
+     *
      * @param (TODO replace with the use of selectionService.getCurrentSelection(); ) selection Current selection
      * @return (TODO What does it return?? )
      * @throws Exception on error

--- a/core/logging/src/main/java/org/phoebus/logging/actions/contextMenuLogging.java
+++ b/core/logging/src/main/java/org/phoebus/logging/actions/contextMenuLogging.java
@@ -45,11 +45,6 @@ public class contextMenuLogging implements ContextMenuEntry {
     }
 
     @Override
-    public Object getIcon() {
-        return null;
-    }
-
-    @Override
     public List<Class> getSupportedTypes() {
         return supportedTypes;
     }

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -9,6 +9,7 @@ package org.phoebus.ui.application;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 
+import java.io.InputStream;
 import java.util.logging.Level;
 
 import org.phoebus.framework.selection.SelectionService;
@@ -19,6 +20,8 @@ import org.phoebus.ui.docking.DockStage;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
@@ -54,6 +57,10 @@ public class ContextMenuHelper
         for (ContextMenuEntry<?> entry : ContextMenuService.getInstance().listSupportedContextMenuEntries())
         {
             final MenuItem item = new MenuItem(entry.getName());
+
+            final InputStream icon = entry.getIcon();
+            if (icon != null)
+                item.setGraphic(new ImageView(new Image(icon)));
             item.setOnAction(e ->
             {
                 try


### PR DESCRIPTION
`ContextMenuEntry` had `Object getIcon()`, unclear what that object would be.
Changed that into
```
    /** @return Stream for icon, or <code>null</code> */
    public default InputStream getIcon()
    {
        return null;
    }
```
and adding that icon - if one is provided - to the context menu entry.

For now PV Tree and PV Table hand out icons.