### PR TITLE
NLS: Move to framework, add test

### DIFF
--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/Messages.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/Messages.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtable.ui;
 
-import org.phoebus.ui.nls.NLS;
+import org.phoebus.framework.nls.NLS;
 
 public class Messages
 {

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/Messages.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/Messages.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree.ui;
 
-import org.phoebus.ui.nls.NLS;
+import org.phoebus.framework.nls.NLS;
 
 public class Messages extends NLS
 {

--- a/core/framework/src/test/java/org/phoebus/framework/nls/NLSMessagesTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/nls/NLSMessagesTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.nls;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** JUnit test of the {@link NLS} message initialization
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class NLSMessagesTest
+{
+    // A 'Messages' type of class needs public static String member variables
+    public static String Hello;
+    public static String Bye;
+
+    private Locale original;
+
+    // They are initialized from a "messages*.properties" file in the same package,
+    // typically using 'static' code like this:
+    //
+    // static
+    // {
+    //     NLS.initializeMessages(NLSMessagesTest.class);
+    // }
+    //
+    // For the test, we call NLS.initializeMessages with various locates
+    // in a non-static way
+
+    @Before
+    public void saveLocale()
+    {
+        original = Locale.getDefault();
+    }
+
+    /** Check if the expected messages were read */
+    @Test
+    public void testDefaultMessages()
+    {
+        Locale.setDefault(Locale.US);
+        NLS.initializeMessages(NLSMessagesTest.class);
+        System.out.println("Messages for '" + Locale.getDefault().getLanguage() + "': " + Hello + ", " + Bye);
+        assertThat(Hello, equalTo("Hello"));
+        assertThat(Bye, equalTo("Bye"));
+    }
+
+    /** Check if the expected messages were read */
+    @Test
+    public void testGermanMessages()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        NLS.initializeMessages(NLSMessagesTest.class);
+        System.out.println("Messages for '" + Locale.getDefault().getLanguage() + "': " + Hello + ", " + Bye);
+        assertThat(Hello, equalTo("Moin"));
+        assertThat(Bye, equalTo("Tschüss"));
+    }
+
+    @After
+    public void restoreLocale()
+    {
+        Locale.setDefault(original);
+    }
+}

--- a/core/framework/src/test/resources/org/phoebus/framework/nls/messages.properties
+++ b/core/framework/src/test/resources/org/phoebus/framework/nls/messages.properties
@@ -1,0 +1,2 @@
+Hello=Hello
+Bye=Bye

--- a/core/framework/src/test/resources/org/phoebus/framework/nls/messages_de.properties
+++ b/core/framework/src/test/resources/org/phoebus/framework/nls/messages_de.properties
@@ -1,0 +1,4 @@
+# Note: Property files use ISO 8859-1 character encoding (Latin1).
+# German Umlaut characters need to be represented by Unicode escape "\u1234"
+Hello=Moin
+Bye=Tsch\u00FCss


### PR DESCRIPTION
This moves the "NLS" class from core-ui to core-framework.

Starting the display builder import, I noticed that the 'model' doesn't have a UI, but it still has localized messages for widget names etc.
So placing the NLS class in the UI module was wrong, just like in the OSGi case NLS can also be used for "System.out.println" and is thus a non-UI idea
--> With that, the display builder "model" can depend on only core-framework, not core-ui.

While at it, I added a unit test and found out that *.property files use ISO 8859-1/Latin1 character encoding, not UTF-8. It's documented in Properties#load(). Eclipse also enforces it: Even if you generally select UTF-8 for all source code, the *.property files are edited with ISO 8859-1/Latin1, so it's best to enter for example Umlaut characters as "\u1234" unicode escapes.
Anyway, now there's a test that demonstrates proper loading of default (US) messages.properties vs. messages_de.properties.