### PR TITLE
Resource uris 79

### DIFF
--- a/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeApplication.java
+++ b/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeApplication.java
@@ -7,19 +7,11 @@
  ******************************************************************************/
 package org.csstudio.display.builder.runtime.app;
 
-import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
-import static org.phoebus.framework.util.ResourceParser.createAppURI;
-import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
-
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
-import org.csstudio.display.builder.model.macros.Macros;
 import org.phoebus.framework.spi.AppResourceDescriptor;
-import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockStage;
 
@@ -57,39 +49,16 @@ public class DisplayRuntimeApplication implements AppResourceDescriptor
     }
 
     @Override
-    public DisplayRuntimeInstance create(final String resource)
+    public DisplayRuntimeInstance create(final URI resource)
     {
-        // Expect "display_runtime?file=file:/some/path&MACRO=Some+Value&X=2"
-        if (! resource.startsWith("display_runtime?file="))
-        {
-            logger.log(Level.SEVERE, "Expected '\"display_runtime?file=...\", ignoring " + resource);
-            return null;
-        }
-
-        // Get file path and maybe macros
-        final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
-        String path = null;
-        final Macros macros = new Macros();
-        for (Map.Entry<String, List<String>> entry : args.entrySet())
-        {
-            if (entry.getValue().size() != 1)
-                logger.log(Level.WARNING, "Expected 1 value for '" + entry.getKey() + "' but got " + entry.getValue());
-            else if (entry.getKey().equals(ResourceParser.FILE_ARG))
-                path = entry.getValue().get(0);
-            else
-                macros.add(entry.getKey(),  entry.getValue().get(0));
-        }
-        if (path == null)
-        {
-            logger.log(Level.WARNING, "Missing 'file=..' in " + resource);
-            return null;
-        }
-
         // Create display info
-        final DisplayInfo info = new DisplayInfo(path, null, macros, true);
-        // Display URL, normalized such that for example macros are alphabetically sorted,
-        // to uniquely identify an already running instance via its input
-        final URL input = info.toURL();
+        final DisplayInfo info = DisplayInfo.forURI(resource);
+
+        // Convert back into URI
+        // Content should be very similar, but normalized such that for example macros
+        // are alphabetically sorted to uniquely identify an already running instance
+        // via its input
+        final URI input = info.toURI();
 
         // Check for existing instance with that input, i.e. path & macros
         final DisplayRuntimeInstance instance;

--- a/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -131,7 +131,7 @@ public class DisplayRuntimeInstance implements AppInstance
         // Set input ASAP so that other requests to open this
         // resource will find this instance and not start
         // another instance
-        dock_item.setInput(info.toURL());
+        dock_item.setInput(info.toURI());
 
         // Now that old model is no longer represented,
         // show info.

--- a/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -232,6 +232,7 @@ public class DisplayRuntimeInstance implements AppInstance
           ( !old_info.getMacros().isEmpty()  &&  !old_info.getMacros().equals(info.getMacros())))
         {
             display_info = Optional.of(info);
+            dock_item.setInput(info.toURI());
         }
         dock_item.setLabel(info.getName());
 

--- a/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DockItemRepresentation.java
+++ b/applications/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DockItemRepresentation.java
@@ -1,10 +1,12 @@
 package org.csstudio.display.builder.runtime.app;
 
+import java.net.URI;
 import java.util.function.Consumer;
 
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.representation.ToolkitRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
+import org.phoebus.framework.workbench.ApplicationService;
 
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -27,8 +29,10 @@ public class DockItemRepresentation extends JFXRepresentation
     public ToolkitRepresentation<Parent, Node> openNewWindow(DisplayModel model,
             Consumer<DisplayModel> close_handler) throws Exception
     {
-        // TODO DisplayRuntimeApplication.create().represent(model)
-        return super.openNewWindow(model, close_handler);
+        final DisplayRuntimeApplication app = ApplicationService.findApplication(DisplayRuntimeApplication.NAME);
+        final URI resource = DisplayInfo.forModel(model).toURI();
+        final DisplayRuntimeInstance instance = app.create(resource);
+        return instance.getRepresentation();
     }
 
     @Override

--- a/applications/display/runtime/src/test/java/org/csstudio/display/builder/runtime/test/DisplayInfoTest.java
+++ b/applications/display/runtime/src/test/java/org/csstudio/display/builder/runtime/test/DisplayInfoTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.csstudio.display.builder.model.macros.Macros;
 import org.csstudio.display.builder.runtime.app.DisplayInfo;
@@ -30,35 +30,49 @@ public class DisplayInfoTest
         DisplayInfo info = new DisplayInfo("/some/path/file.bob",  null, new Macros(), true);
         assertThat(info.getPath(), equalTo("/some/path/file.bob"));
         assertThat(info.getName(), equalTo("file.bob"));
+
+        info = new DisplayInfo("http://my.site/some/path/file.bob",  null, new Macros(), true);
+        assertThat(info.getPath(), equalTo("http://my.site/some/path/file.bob"));
+        assertThat(info.getName(), equalTo("file.bob"));
+
     }
 
     @Test
-    public void testURL2DisplayInfo() throws Exception
+    public void testURI2DisplayInfo() throws Exception
     {
         // Simple example
-        URL url = new URL("file:/some/path/xx.bob");
-        DisplayInfo info = DisplayInfo.forURL(url);
+        URI url = URI.create("file:/some/path/xx.bob");
+        DisplayInfo info = DisplayInfo.forURI(url);
         System.out.println(info);
 
         assertThat(info.getPath(), equalTo("/some/path/xx.bob"));
 
         // .. with macros
-        url = new URL("file:/some/path/xx.bob?X=Fred+Harvey%20Newman&Y=2");
-        info = DisplayInfo.forURL(url);
+        url = URI.create("file:/some/path/xx.bob?X=Fred+Harvey%20Newman&Y=2");
+        info = DisplayInfo.forURI(url);
         System.out.println(info);
 
         assertThat(info.getPath(), equalTo("/some/path/xx.bob"));
         assertThat(info.getMacros().getValue("X"), equalTo("Fred Harvey Newman"));
         assertThat(info.getMacros().getValue("Y"), equalTo("2"));
+
+        // Web URL
+        url = URI.create("http://my.site/some/path/xx.bob?X=Fred+Harvey%20Newman&Y=2");
+        info = DisplayInfo.forURI(url);
+        System.out.println(info);
+
+        assertThat(info.getPath(), equalTo("http://my.site/some/path/xx.bob"));
+        assertThat(info.getMacros().getValue("X"), equalTo("Fred Harvey Newman"));
+        assertThat(info.getMacros().getValue("Y"), equalTo("2"));
     }
 
     @Test
-    public void testDisplayInfo2URL() throws Exception
+    public void testDisplayInfo2URI() throws Exception
     {
         // Plain path
         final Macros macros = new Macros();
         DisplayInfo info = new DisplayInfo("/some/path/xx.bob", null, macros, false);
-        URL url = info.toURL();
+        URI url = info.toURI();
         System.out.println(url);
         assertThat(url.toString(), equalTo("file:/some/path/xx.bob"));
 
@@ -66,7 +80,7 @@ public class DisplayInfoTest
         macros.add("X", "Fred Harvey Newman");
         macros.add("Y", "2");
         info = new DisplayInfo("file:/some/path/xx.bob", null, macros, false);
-        url = info.toURL();
+        url = info.toURI();
         System.out.println(url);
 
         assertThat(url.toString(), equalTo("file:/some/path/xx.bob?X=Fred+Harvey+Newman&Y=2"));
@@ -75,21 +89,21 @@ public class DisplayInfoTest
     @Test
     public void testUniqueness() throws Exception
     {
-        // URLs using the same macros, but different order
-        final URL url1 = new URL("file:/some/path/xx.bob?X=Fred+Harvey%20Newman&Y=2&Z=1");
-        final URL url2 = new URL("file:/some/path/xx.bob?Z=1&X=Fred+Harvey%20Newman&Y=2");
+        // URIs using the same macros, but different order
+        final URI url1 = new URI("file:/some/path/xx.bob?X=Fred+Harvey%20Newman&Y=2&Z=1");
+        final URI url2 = new URI("file:/some/path/xx.bob?Z=1&X=Fred+Harvey%20Newman&Y=2");
 
         // Should result in equal DisplayInfos
-        DisplayInfo info1 = DisplayInfo.forURL(url1);
-        DisplayInfo info2 = DisplayInfo.forURL(url2);
+        DisplayInfo info1 = DisplayInfo.forURI(url1);
+        DisplayInfo info2 = DisplayInfo.forURI(url2);
         System.out.println(info1);
         System.out.println(info2);
         assertThat(info1, equalTo(info2));
         assertThat(info1, not(sameInstance(info2)));
 
-        // When turned back into a URL, they use the alphabetical ordered macros
+        // When turned back into a URI, they use the alphabetical ordered macros
         // (like url1, but with '+' for spaces)
-        assertThat(info1.toURL().toString(), equalTo(info2.toURL().toString()));
-        assertThat(info2.toURL().toString(), equalTo("file:/some/path/xx.bob?X=Fred+Harvey+Newman&Y=2&Z=1"));
+        assertThat(info1.toURI().toString(), equalTo(info2.toURI().toString()));
+        assertThat(info2.toURI().toString(), equalTo("file:/some/path/xx.bob?X=Fred+Harvey+Newman&Y=2&Z=1"));
     }
 }

--- a/applications/email/src/main/java/org/phoebus/applications/email/EmailApp.java
+++ b/applications/email/src/main/java/org/phoebus/applications/email/EmailApp.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package org.phoebus.applications.email;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -95,12 +96,12 @@ public class EmailApp implements AppResourceDescriptor {
      * Handle resources like mailto:shroffk@....
      */
     @Override
-    public AppInstance create(String resource) {
+    public AppInstance create(URI resource) {
         return create();
     }
 
     /**
-     * 
+     *
      * @return {@link Session} connection factory needed to create and send emails.
      */
     public Session getSession() {

--- a/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
+++ b/applications/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
@@ -12,7 +12,7 @@ import static org.phoebus.applications.pvtable.PVTableApplication.logger;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.logging.Level;
 
 import org.phoebus.applications.pvtable.model.PVTableItem;
@@ -96,7 +96,7 @@ public class PVTableInstance implements AppInstance
         dock_item.setDirty(false);
     }
 
-    void loadResource(final URL input)
+    void loadResource(final URI input)
     {
         // Set input ASAP so that other requests to open this
         // resource will find this instance and not start
@@ -110,7 +110,8 @@ public class PVTableInstance implements AppInstance
             try
             {
                 monitor.updateTaskName("Load " + input);
-                PVTablePersistence.forFilename(input.toString()).read(load_model, input.openStream());
+                PVTablePersistence.forFilename(input.getPath())
+                                  .read(load_model, ResourceParser.getContent(input));
 
                 // On success, update on UI
                 Platform.runLater(() ->
@@ -136,7 +137,7 @@ public class PVTableInstance implements AppInstance
             if (file == null)
                 return;
         }
-        dock_item.setInput(ResourceParser.getURL(file));
+        dock_item.setInput(ResourceParser.getURI(file));
         try
         (
             final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file));

--- a/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
+++ b/applications/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeApplication.java
@@ -7,11 +7,9 @@
  *******************************************************************************/
 package org.phoebus.applications.pvtree;
 
-import static org.phoebus.framework.util.ResourceParser.createAppURI;
-import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
-
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.phoebus.framework.spi.AppInstance;
@@ -55,20 +53,26 @@ public class PVTreeApplication implements AppResourceDescriptor
     }
 
     @Override
-    public AppInstance create(final String resource)
+    public AppInstance create(final URI resource)
     {
         PVTree pv_tree = null;
 
-        final Map<String, List<String>> args = parseQueryArgs(createAppURI(resource));
-        final List<String> pvs = args.get(ResourceParser.PV_ARG);
-        if (pvs == null)
-            pv_tree = create();
-        else
-            for (String pv : pvs)
-            {
+        try
+        {
+            final List<String> pvs = ResourceParser.parsePVs(resource);
+            if (pvs.isEmpty())
                 pv_tree = create();
-                pv_tree.setPVName(pv);
-            }
+            else
+                for (String pv : pvs)
+                {
+                    pv_tree = create();
+                    pv_tree.setPVName(pv);
+                }
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.WARNING, "Cannot create PV Tree", ex);
+        }
 
         return pv_tree;
     }

--- a/core/framework/src/main/java/org/phoebus/framework/spi/AppResourceDescriptor.java
+++ b/core/framework/src/main/java/org/phoebus/framework/spi/AppResourceDescriptor.java
@@ -1,5 +1,6 @@
 package org.phoebus.framework.spi;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,6 +54,6 @@ public interface AppResourceDescriptor extends AppDescriptor {
      * path or url to a configuration file like .bob or .plt or it can be a list of
      * pv names, or a channelfinder query
      */
-    public AppInstance create(String resource);
+    public AppInstance create(URI resource);
 
 }

--- a/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
+++ b/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
@@ -15,16 +15,143 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A utility class for parsing user defined resources
  *
  * @author Kunal Shroff
- *
+ * @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class ResourceParser {
+    /** URI schema for PV names */
+    public static final String PV_SCHEMA = "pv";
+
+    /** URI query tag used to specify the application name */
+    private static final String APP_QUERY_TAG = "app=";
+
+
+    /** Create URI for a resource
+     *
+     *  <p>Takes the resource passed by the user,
+     *  typically on the command line,
+     *  and turns it into a URI.
+     *
+     *  <p>Supported are URI strings
+     *  like "http:/..." or "file:...".
+     *  Plain strings that do not start with a 'schema'
+     *  are assumed to be files,
+     *  and are resolved as a path in the local file system.
+     *  Relative paths are resolved relative to the
+     *  "current working directory",
+     *  which may not be known when the application is running,
+     *  so that it generally a bad idea.
+     *
+     *  <p>The file must NOT exist, the "file://.." URI
+     *  will be created even if the file does not exist,
+     *  because the caller may use the URI to then create
+     *  the resource.
+     *
+     *  @param resource Resource text from user
+     *  @return URI for the resource
+     *  @throws Exception on error
+     */
+    public static URI createResourceURI(final String resource) throws Exception
+    {
+        try
+        {
+            final URI uri = URI.create(resource);
+            // Received complete URL, starting with scheme?
+            if (uri.getScheme() != null)
+                return uri;
+            else
+            {
+                // Treat it like a file resource
+                //
+                // By default the following is used by the default Paths.get(...) which should
+                // be the directory from which the program was executed
+                // FileSystem fs = FileSystems.getDefault();
+                // System.out.println(fs.toString());
+                final Path fileResource = Paths.get(resource);
+                return fileResource.toUri();
+            }
+        }
+        catch (Throwable ex)
+        {
+            throw new Exception("Cannot create URI for '" + resource + "'", ex);
+        }
+    }
+
+
+    /** Get file for URI
+     *  @return URI for the resource
+     *  @return {@link File} if URL represents a file, otherwise <code>null</code>
+     */
+    public static File getFile(final URI resource) throws Exception
+    {
+        if (resource == null  ||  !resource.getScheme().equals("file"))
+            return null;
+        return new File(resource);
+    }
+
+    /** Get URI for file
+     *  @param file {@link File}
+     *  @return {@link URI} for that file
+     */
+    public static URI getURI(final File file)
+    {
+        return file.toURI();
+    }
+
+    /** Get list of PVs from a "pv://?PV1&PV2" type URL
+     *
+     *  <p>If the URI is simply no "pv:" URI, an empty list
+     *  if returned.
+     *  If it is a "pv:" URI, at least one PV is expected,
+     *  otherwise an exception is thrown.
+     *
+     *  @param resource "pv://?PV1&PV2" type URL
+     *  @return List of PVs parsed from the resource
+     *  @throws Exception on error, including no PVs
+     */
+    public static List<String> parsePVs(final URI resource) throws Exception
+    {
+        if (! resource.getScheme().equals(PV_SCHEMA))
+            return List.of();
+        final List<String> pvs = getQueryStream(resource).filter(pv -> !pv.startsWith(APP_QUERY_TAG))
+                                                         .collect(Collectors.toList());
+        if (pvs.isEmpty())
+            throw new Exception("No PVs found in '" + resource + "'");
+        return pvs;
+    }
+
+    /** Get application name hint from resource
+     *  @param resource URI that might contain "?...app=the_app_name"
+     *  @return "the_app_name" or empty result.
+     */
+    public static Optional<String> getAppName(final URI resource)
+    {
+        return getQueryStream(resource).filter(q -> q.startsWith(APP_QUERY_TAG))
+                                       .map(app_name -> app_name.substring(APP_QUERY_TAG.length()))
+                                       .findFirst();
+    }
+
+    /** @param resource URI for resource
+     *  @return Stream for all query items
+     */
+    private static Stream<String> getQueryStream(final URI resource)
+    {
+        final String query = resource.getQuery();
+        if (query == null)
+            return Stream.empty();
+        return Arrays.stream(query.split("&"));
+    }
+
+    // ------------------------------------
+
 
     /** Resource query key for PV names */
     public static final String PV_ARG = "pv";
@@ -71,7 +198,7 @@ public class ResourceParser {
     }
 
     /**
-     * Get file for URL
+     * Get file for URLSN=220416
      *
      * @param url {@link URL}
      * @return {@link File} if URL represents a file, otherwise <code>null</code>
@@ -119,20 +246,6 @@ public class ResourceParser {
             return Collections.emptyMap();
         }
         return Arrays.stream(uri.getQuery().split("&")).map(ResourceParser::splitQueryParameter).collect(Collectors
-                .groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, toList())));
-    }
-
-    /**
-     * Parse the query segment of a URL and return a {@link Map}
-     *
-     * @param url resource path URL
-     * @return {@link Map} a map of all the query parameters
-     */
-    public static Map<String, List<String>> parseQueryArgs(URL url) {
-        if (url.getQuery() == null || url.getQuery().isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return Arrays.stream(url.getQuery().split("&")).map(ResourceParser::splitQueryParameter).collect(Collectors
                 .groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, toList())));
     }
 

--- a/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
+++ b/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 /**
@@ -136,13 +135,14 @@ public class ResourceParser
 
     /** Get application name hint from resource
      *  @param resource URI that might contain "?...app=the_app_name"
-     *  @return "the_app_name" or empty result.
+     *  @return "the_app_name" or <code>null</code>
      */
-    public static Optional<String> getAppName(final URI resource)
+    public static String getAppName(final URI resource)
     {
         return getQueryStream(resource).filter(q -> q.startsWith(APP_QUERY_TAG))
                                        .map(app_name -> app_name.substring(APP_QUERY_TAG.length()))
-                                       .findFirst();
+                                       .findFirst()
+                                       .orElse(null);
     }
 
     /** Get stream of query items

--- a/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
+++ b/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
@@ -130,7 +130,8 @@ public class ResourceParser
      */
     public static List<String> parsePVs(final URI resource) throws Exception
     {
-        if (! resource.getScheme().equals(PV_SCHEMA))
+        final String scheme = resource.getScheme();
+        if (! PV_SCHEMA.equals(scheme))
             return List.of();
         final List<String> pvs = getQueryStream(resource).filter(pv -> !pv.startsWith(APP_QUERY_TAG))
                                                          .collect(Collectors.toList());

--- a/core/framework/src/main/java/org/phoebus/framework/workbench/ApplicationService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/ApplicationService.java
@@ -60,8 +60,9 @@ public class ApplicationService
      *  @param name Application name
      *  @return {@link AppDescriptor} or <code>null</code> if not found
      */
-    public static AppDescriptor findApplication(final String name)
+    @SuppressWarnings("unchecked")
+    public static <AD extends AppDescriptor> AD findApplication(final String name)
     {
-        return INSTANCE.apps.get(name);
+        return (AD) INSTANCE.apps.get(name);
     }
 }

--- a/core/framework/src/main/java/org/phoebus/framework/workbench/ResourceHandlerService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/ResourceHandlerService.java
@@ -1,9 +1,9 @@
 /**
- * 
+ *
  */
 package org.phoebus.framework.workbench;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,12 +15,11 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.phoebus.framework.spi.AppResourceDescriptor;
-import org.phoebus.framework.util.ResourceParser;
 
 /**
  * A service to discover, register, and invoke apps which handle resources.
  * {@link AppResourceDescriptor}
- * 
+ *
  * @author Kunal Shroff
  *
  */
@@ -51,24 +50,14 @@ public class ResourceHandlerService {
     }
 
     /**
-     * Find applications for this resource string 
-     * 
-     * @param resource String resource
+     * Find applications for this resource string
+     *
+     * @param resource Resource URI
      * @return List of Applications that can open this resource
      */
-    public static List<AppResourceDescriptor> getApplications(String resource) {
-        return getApplications(ResourceParser.createResourceURL(resource));
-    }
-
-    /**
-     * Find applications for this resource URL
-     * 
-     * @param resource URL to describing the application and the associated resources to be launched using it
-     * @return List of Applications that can open this resource
-     */
-    public static List<AppResourceDescriptor> getApplications(URL resource) {
-        String path = resource.getPath();
-        String ext = path.substring(path.lastIndexOf(".") + 1);
+    public static List<AppResourceDescriptor> getApplications(URI resource) {
+        final String path = resource.getPath();
+        final String ext = path.substring(path.lastIndexOf(".") + 1);
         if (resourceMap.containsKey(ext)) {
             return resourceMap.get(ext);
         } else {

--- a/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
@@ -1,27 +1,165 @@
 package org.phoebus.framework.util;
 
-import static org.phoebus.framework.util.ResourceParser.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.phoebus.framework.util.ResourceParser.PV_SCHEMA;
+import static org.phoebus.framework.util.ResourceParser.createAppURI;
+import static org.phoebus.framework.util.ResourceParser.createResourceURI;
+import static org.phoebus.framework.util.ResourceParser.createResourceURL;
+import static org.phoebus.framework.util.ResourceParser.getAppName;
+import static org.phoebus.framework.util.ResourceParser.getFile;
+import static org.phoebus.framework.util.ResourceParser.getURI;
+import static org.phoebus.framework.util.ResourceParser.parseAppName;
+import static org.phoebus.framework.util.ResourceParser.parsePVs;
+import static org.phoebus.framework.util.ResourceParser.parseQueryArgs;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.Test;
 
 /**
- * A utility class for parsing user defined resources
- * 
- * @author Kunal Shroff
+ * JUnit test of {@link ResourceParser}
  *
+ * @author Kunal Shroff
+ * @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class ResourceParserTest {
+    @Test
+    public void checkFileToURI() throws Exception
+    {
+        // File URL
+        URI uri = createResourceURI("file:/some/file/path");
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo("file"));
+        assertThat(uri.getPath(), equalTo("/some/file/path"));
+
+        // File URL with application hint
+        uri = createResourceURI("file:/some/file/path?app=probe");
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo("file"));
+        // File stays the same, the app hint in the query doesn't change that
+        assertThat(uri.getPath(), equalTo("/some/file/path"));
+
+        // A test resource relative to where this test is running
+        final String relative = "src/test/resources/test.plt";
+
+        // Absolute file path
+        final File file = new File(".", relative).getCanonicalFile();
+        final String absolute = file.getCanonicalPath();
+
+        // Test if absolute path is turned into URI
+        uri = createResourceURI(absolute);
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo("file"));
+        assertThat(uri.getPath(), equalTo(absolute));
+
+        // Turn relative file path into URI, which should then be absolute
+        uri = createResourceURI(relative);
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo("file"));
+        assertThat(uri.getPath(), equalTo(absolute));
+
+        // Convert between File and URI
+        assertThat(getFile(uri), equalTo(file));
+        assertThat(getURI(file), equalTo(uri));
+
+        // Nonexisting file
+        uri = createResourceURI("some/bogus/file");
+        assertThat(uri, not(nullValue()));
+        final File bogus = getFile(uri);
+        System.out.println(bogus);
+        assertThat(bogus.exists(), equalTo(false));
+    }
+
+    @Test
+    public void checkWebToURI() throws Exception
+    {
+        // Web URL
+        URI uri = createResourceURI("http://some.site/file/path");
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo("http"));
+        assertThat(uri.getHost(), equalTo("some.site"));
+        assertThat(uri.getPath(), equalTo("/file/path"));
+    }
+
+    @Test
+    public void checkPVs() throws Exception
+    {
+        // PV URL with one PV
+        URI uri = createResourceURI("pv://?Fred");
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo(PV_SCHEMA));
+
+        List<String> pvs = parsePVs(uri);
+        System.out.println(pvs);
+        assertThat(pvs.size(), equalTo(1));
+        assertThat(pvs, hasItems("Fred"));
+
+        // Several PVs (but don't include the application hint)
+        uri = createResourceURI("pv://?Fred&Jane&AnotherPV&app=probe");
+        System.out.println(uri);
+        assertThat(uri.getScheme(), equalTo(PV_SCHEMA));
+
+        pvs = parsePVs(uri);
+        System.out.println(pvs);
+        assertThat(pvs.size(), equalTo(3));
+        assertThat(pvs, hasItems("Fred", "Jane" , "AnotherPV"));
+
+        // Not a PV URL -> empty result
+        pvs = parsePVs(createResourceURI("http://some.site"));
+        assertThat(pvs.size(), equalTo(0));
+
+        // Check errors
+        try
+        {   // "pvs://" without actual PVs
+            parsePVs(createResourceURI("pv://some.site"));
+            fail("Failed to detect missing PVs");
+        }
+        catch (Exception ex)
+        {
+            // Good, got exception
+            System.out.println(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void checkApplicationHint() throws Exception
+    {
+        // Plain URL, no application hint
+        URI uri = createResourceURI("pv://?Fred");
+        Optional<String> app = getAppName(uri);
+        assertThat(app.isPresent(), equalTo(false));
+
+        // PVs with application hint
+        uri = createResourceURI("pv://?Fred&app=probe");
+        app = getAppName(uri);
+        assertThat(app.isPresent(), equalTo(true));
+        assertThat(app.get(), equalTo("probe"));
+
+        // File URL with application hint
+        uri = createResourceURI("file:/path/to/file?app=probe");
+        app = getAppName(uri);
+        assertThat(app.isPresent(), equalTo(true));
+        assertThat(app.get(), equalTo("probe"));
+    }
+
+
+    // ------------------------------------
 
     @Test
     public void checkResourcePathUtil() {
@@ -61,7 +199,7 @@ public class ResourceParserTest {
                 "Failed to parse app launcher string expected: " + queryArgs + " returned: "
                         + parseQueryArgs(createAppURI(resourceURI)),
                 queryArgs, parseQueryArgs(createAppURI(resourceURI)));
-        
+
         // the app name and arguments are provided
         resourceURI = "probe?pv=sim://noise&pv=sim://sine";
         queryArgs = new HashMap<>();
@@ -70,9 +208,9 @@ public class ResourceParserTest {
                 "Failed to parse app launcher string expected: " + queryArgs + " returned: "
                         + parseQueryArgs(createAppURI(resourceURI)),
                 queryArgs, parseQueryArgs(createAppURI(resourceURI)));
-        
+
     }
-    
+
     @Test
     public void checkFileParsing() {
 //        File file = new File("test");

--- a/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
@@ -168,7 +168,7 @@ public class ResourceParserTest
     public void checkQueryItems() throws Exception
     {
         // URI with a bunch of query itens
-        URI uri = createResourceURI("file://some/file?Fred&X=1&Y=2&app=probe&Z=47");
+        URI uri = createResourceURI("file://some/file?Fred&X=1&Y=2+3&app=probe&Z=2%2B3");
 
         final Map<String, List<String>> items = parseQueryArgs(uri);
         System.out.println(items);
@@ -182,6 +182,10 @@ public class ResourceParserTest
 
         values = items.get("Y");
         assertThat(values.size(), equalTo(1));
-        assertThat(values.get(0), equalTo("2"));
+        assertThat(values.get(0), equalTo("2 3"));
+
+        values = items.get("Z");
+        assertThat(values.size(), equalTo(1));
+        assertThat(values.get(0), equalTo("2+3"));
     }
 }

--- a/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.Test;
 
@@ -151,20 +150,18 @@ public class ResourceParserTest
     {
         // Plain URL, no application hint
         URI uri = createResourceURI("pv://?Fred");
-        Optional<String> app = getAppName(uri);
-        assertThat(app.isPresent(), equalTo(false));
+        String app = getAppName(uri);
+        assertThat(app, nullValue());
 
         // PVs with application hint
         uri = createResourceURI("pv://?Fred&app=probe");
         app = getAppName(uri);
-        assertThat(app.isPresent(), equalTo(true));
-        assertThat(app.get(), equalTo("probe"));
+        assertThat(app, equalTo("probe"));
 
         // File URL with application hint
         uri = createResourceURI("file:/path/to/file?app=probe");
         app = getAppName(uri);
-        assertThat(app.isPresent(), equalTo(true));
-        assertThat(app.get(), equalTo("probe"));
+        assertThat(app, equalTo("probe"));
     }
 
     @Test

--- a/core/ui/src/main/java/org/phoebus/ui/application/ApplicationServer.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ApplicationServer.java
@@ -42,7 +42,8 @@ import java.util.stream.Collectors;
  *  as one line, ending in '\n'.
  *  Parameters on that line are separated by '|'.
  *  Example:
- *  "-app|pv_tree?pv=some_pv\n".
+ *  "-resource|/some/example.pvs\n".
+ *  "-app|pv_tree\n".
  *
  *  XXX The serialization of parameters may change.
  *  The format

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -218,9 +218,11 @@ public class PhoebusApplication extends Application {
     private void handleParameters(final List<String> parameters) throws Exception
     {
         // List of applications to launch as specified via cmd line args
-        final List<String> launchApps = new ArrayList<String>();
+        final List<String> launchApps = new ArrayList<>();
+
         // List of resources to launch as specified via cmd line args
-        final List<String> launchResources = new ArrayList<String>();
+        final List<URI> launchResources = new ArrayList<>();
+
         final Iterator<String> parametersIterator = parameters.iterator();
         while (parametersIterator.hasNext()) {
             final String cmd = parametersIterator.next();
@@ -232,8 +234,8 @@ public class PhoebusApplication extends Application {
             } else if (cmd.equals("-resource")) {
                 if (!parametersIterator.hasNext())
                     throw new Exception("Missing -resource resource file name");
-                final String filename = parametersIterator.next();
-                launchResources.add(filename);
+                final URI resource = ResourceParser.createResourceURI(parametersIterator.next());
+                launchResources.add(resource);
             }
         }
 
@@ -242,8 +244,8 @@ public class PhoebusApplication extends Application {
         Platform.runLater(() ->
         {
             // Handle requests to open resource from command line
-            for (String resource : launchResources)
-                openResource(URI.create(resource));
+            for (URI resource : launchResources)
+                openResource(resource);
 
             // Handle requests to open application from command line
             for (String app_name : launchApps)

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -3,6 +3,7 @@ package org.phoebus.ui.application;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -226,8 +227,8 @@ public class PhoebusApplication extends Application {
             if (cmd.equals("-app")) {
                 if (!parametersIterator.hasNext())
                     throw new Exception("Missing -app application name");
-                final String filename = parametersIterator.next();
-                launchApps.add(filename);
+                final String app_name = parametersIterator.next();
+                launchApps.add(app_name);
             } else if (cmd.equals("-resource")) {
                 if (!parametersIterator.hasNext())
                     throw new Exception("Missing -resource resource file name");
@@ -242,11 +243,11 @@ public class PhoebusApplication extends Application {
         {
             // Handle requests to open resource from command line
             for (String resource : launchResources)
-                openResource(resource);
+                openResource(URI.create(resource));
 
-            // Handle requests to open resource from command line
-            for (String appLaunchString : launchApps)
-                launchApp(appLaunchString);
+            // Handle requests to open application from command line
+            for (String app_name : launchApps)
+                launchApp(app_name);
         });
     }
 
@@ -260,7 +261,7 @@ public class PhoebusApplication extends Application {
             final File file = new OpenFileDialog().promptForFile(stage, "Open File", null, null);
             if (file == null)
                 return;
-            openResource(file.toString());
+            openResource(ResourceParser.getURI(file));
         });
         final MenuItem exit = new MenuItem("Exit");
         exit.setOnAction(event -> {
@@ -384,12 +385,33 @@ public class PhoebusApplication extends Application {
     /**
      * @param resource Resource received as command line argument
      */
-    private void openResource(final String resource) {
-        List<AppResourceDescriptor> applications = ResourceHandlerService.getApplications(resource);
-        if (applications.isEmpty()) {
-            logger.log(Level.WARNING, "No application found for opening " + resource);
-        } else {
-            final AppResourceDescriptor application;
+    private void openResource(final URI resource)
+    {
+        AppResourceDescriptor application = null;
+
+        // Does resource request a specific application?
+        String app_name = ResourceParser.getAppName(resource);
+        if (app_name != null)
+        {
+            final AppDescriptor app = ApplicationService.findApplication(app_name);
+            if (app instanceof AppResourceDescriptor)
+                application = (AppResourceDescriptor) app;
+            else
+            {
+                logger.log(Level.WARNING, "'" + app_name + "' application does not handle resources");
+                return;
+            }
+        }
+
+        if (application == null)
+        {   // Check all applications
+            final List<AppResourceDescriptor> applications = ResourceHandlerService.getApplications(resource);
+            if (applications.isEmpty())
+            {
+                logger.log(Level.WARNING, "No application found for opening " + resource);
+                return;
+            }
+
             if (applications.size() == 1)
                 application = applications.get(0);
             else
@@ -403,37 +425,25 @@ public class PhoebusApplication extends Application {
                     return;
                 application = applications.get(options.indexOf(result.get()));
             }
-
-            final String app_resource = application.getName() + "?" + ResourceParser.FILE_ARG + "=" + resource;
-            logger.log(Level.INFO, "Opening " + app_resource);
-            application.create(app_resource);
         }
+        logger.log(Level.INFO, "Opening " + resource + " with " + application.getName());
+        application.create(resource);
     }
 
     /**
-     * Launch applications with
+     * Launch application
      *
-     * @param appLaunchString
-     *            application launch string received as command line argument which
-     *            contains the app name and the arguments that the applications
-     *            should be launched with , this has to be in the format of a valid
-     *            URL. e.g. probe?pv=sim://noise&pv=sim://ramp
+     * @param appName
+     *            Application name received as '-app ..' command line argument
      */
-    private void launchApp(final String appLaunchString) {
-        String appName = ResourceParser.parseAppName(appLaunchString);
+    private void launchApp(final String appName) {
         final AppDescriptor app = ApplicationService.findApplication(appName);
         if (app == null)
         {
             logger.log(Level.SEVERE, "Unknown application '" + appName + "'");
             return;
         }
-        if (app instanceof AppResourceDescriptor)
-        {
-            ((AppResourceDescriptor)app).create(appLaunchString);
-        } else
-        {
-            app.create();
-        }
+        app.create();
     }
 
     /** @param monitor

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -396,6 +396,11 @@ public class PhoebusApplication extends Application {
         if (app_name != null)
         {
             final AppDescriptor app = ApplicationService.findApplication(app_name);
+            if (app == null)
+            {
+                logger.log(Level.WARNING, "Unknown application '" + app_name + "'");
+                return;
+            }
             if (app instanceof AppResourceDescriptor)
                 application = (AppResourceDescriptor) app;
             else

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -45,6 +45,7 @@ import javafx.scene.layout.BorderStrokeStyle;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 
 /** Item for a {@link DockPane}
  *
@@ -327,7 +328,15 @@ public class DockItem extends Tab
     /** Select this tab, i.e. raise it in case another tab is currently visible */
     public void select()
     {
-        getTabPane().getSelectionModel().select(this);
+        final TabPane pane = getTabPane();
+        final Window window = pane.getScene().getWindow();
+        if (window instanceof Stage)
+        {
+            Stage stage = (Stage) window;
+            if (stage.isShowing())
+                stage.toFront();
+        }
+        pane.getSelectionModel().select(this);
     }
 
     /** Register check for closing the tab

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -9,7 +9,7 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 
-import java.net.URL;
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 
@@ -28,7 +28,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.Tab;
 import javafx.scene.control.Tooltip;
 
-/** Item for a {@link DockPane} that has an 'input' file or URL.
+/** Item for a {@link DockPane} that has an 'input' file or URI.
  *
  *  <p>While technically a {@link Tab},
  *  only the methods declared in here and
@@ -46,7 +46,7 @@ public class DockItemWithInput extends DockItem
 
     private final JobRunnable save_handler;
 
-    private volatile URL input;
+    private volatile URI input;
 
     /** Create dock item
      *
@@ -62,10 +62,10 @@ public class DockItemWithInput extends DockItem
      *
      *  @param application {@link AppInstance}
      *  @param content Initial content
-     *  @param input URL for the input. May be <code>null</code>
+     *  @param input URI for the input. May be <code>null</code>
      *  @param save_handler Will be called to 'save' the content. May be <code>null</code> if never calling <code>setDirty(true)</code>
      */
-    public DockItemWithInput(final AppInstance application, final Node content, final URL input, final JobRunnable save_handler)
+    public DockItemWithInput(final AppInstance application, final Node content, final URI input, final JobRunnable save_handler)
     {
         super(application, content);
         this.save_handler = save_handler;
@@ -86,7 +86,7 @@ public class DockItemWithInput extends DockItem
     }
 
     /** @param input Input */
-    public void setInput(final URL input)
+    public void setInput(final URI input)
     {
         this.input = input;
         if (input == null)
@@ -96,7 +96,7 @@ public class DockItemWithInput extends DockItem
     }
 
     /** @return Input, which may be <code>null</code> (OK to call from any thread) */
-    public URL getInput()
+    public URI getInput()
     {
         return input;
     }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -9,7 +9,7 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.docking.DockPane.logger;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -184,7 +184,7 @@ public class DockStage
      *  @param input Input, must not be <code>null</code>
      *  @return {@link DockItemWithInput} or <code>null</code> if not found
      */
-    public static DockItemWithInput getDockItemWithInput(final String application_name, final URL input)
+    public static DockItemWithInput getDockItemWithInput(final String application_name, final URI input)
     {
         Objects.requireNonNull(input);
         for (Stage stage : getDockStages())

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -9,14 +9,13 @@ package org.phoebus.ui.internal;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.logging.Level;
 
 import org.phoebus.framework.persistence.MementoTree;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
-import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.ui.docking.DockItem;
 import org.phoebus.ui.docking.DockItemWithInput;
@@ -33,7 +32,7 @@ public class MementoHelper
 {
     private static final String FULLSCREEN = "fullscreen";
     private static final String HEIGHT = "height";
-    private static final String INPUT_URL = "input_url";
+    private static final String INPUT_URI = "input_uri";
     private static final String MAXIMIZED = "maximized";
     private static final String MINIMIZED = "minimized";
     private static final String SELECTED = "selected";
@@ -83,9 +82,9 @@ public class MementoHelper
 
         if (item instanceof DockItemWithInput)
         {
-            final URL input = ((DockItemWithInput)item).getInput();
+            final URI input = ((DockItemWithInput)item).getInput();
             if (input != null)
-                item_memento.setString(INPUT_URL, input.toString());
+                item_memento.setString(INPUT_URI, input.toString());
         }
 
         try
@@ -141,8 +140,6 @@ public class MementoHelper
     {
         final String app_id = item_memento.getString(DockItem.KEY_APPLICATION).orElse(null);
 
-
-
         if (app_id == null)
             return false;
 
@@ -158,10 +155,10 @@ public class MementoHelper
         if (app instanceof AppResourceDescriptor)
         {
             final AppResourceDescriptor app_res = (AppResourceDescriptor) app;
-            final String input = item_memento.getString(INPUT_URL).orElse(null);
+            final String input = item_memento.getString(INPUT_URI).orElse(null);
             instance = input == null
                     ? app_res.create()
-                    : app_res.create(app_res.getName() + "?" + ResourceParser.FILE_ARG + "=" + input);
+                    : app_res.create(URI.create(input));
         }
         else
             instance = app.create();

--- a/core/util/src/test/java/org/phoebus/util/text/NumberFormatsTest.java
+++ b/core/util/src/test/java/org/phoebus/util/text/NumberFormatsTest.java
@@ -4,12 +4,14 @@
  */
 package org.phoebus.util.text;
 
-import java.text.NumberFormat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
-import org.phoebus.util.text.NumberFormats;
-import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -18,6 +20,7 @@ import static org.hamcrest.Matchers.*;
 public class NumberFormatsTest {
 
     public NumberFormatsTest() {
+        Locale.setDefault(Locale.US);
     }
 
     @Test

--- a/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
+++ b/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
@@ -142,11 +142,25 @@ public class Launcher
         System.out.println("-settings settings.xml                  -  Import settings from file, either exported XML or property file format");
         System.out.println("-export_settings settings.xml           -  Export settings to file");
         System.out.println("-list                                   -  List available application features");
-        System.out.println("-app \"probe?pv=pv_name1&pv=pv_name2\"    -  Launch an application with input arguments");
+        System.out.println("-app \"probe\"                           -  Launch an application with input arguments");
         System.out.println("-resource  /tmp/example.plt             -  Open an application configuration file with the default application");
         System.out.println("-server port                            -  Create instance server on given TCP port");
         System.out.println();
         System.out.println("In 'server' mode, first instance opens UI.");
         System.out.println("Additional calls to open resources are then forwarded to the initial instance.");
+        System.out.println();
+        System.out.println("The '-resource' parameter can be a URI for a file or web link.");
+        System.out.println("The schema 'pv://?PV1&PV2&PV3' is used to pass PV names,");
+        System.out.println("and the 'app=..' query parameter picks a specific app for opening the resource.");
+        System.out.println();
+        System.out.println("Examples:");
+        System.out.println("-resource /path/to/file                                                    - Opens that file with the default application.");
+        System.out.println("-resource file:/path/to/file                                               - Same, but makes the 'file' schema specific.");
+        System.out.println("-resource http://my.site/path/to/file                                      - Reads web link, opens with default application.");
+        System.out.println("-resource file:/path/to/file?app=display_runtime&MACRO1=value+1&MACRO2=abc - Opens file with 'display_runtime' app, passing macros.");
+        System.out.println("-resource pv://?sim://sine&app=probe                                       - Opens the 'sim://sine' PV with 'probe'.");
+        System.out.println("-resource pv://?Fred&sim://sine&app=pv_table                               - Opens two PVs PV with 'pv_table'.");
+
+
     }
 }


### PR DESCRIPTION
This fixes #79 :

The 'input' to a DockItemWithInput is now a URI.
It's the same URI that can be passed via the "-resource /some/file.opi?MACRO=value" command line.
The "app=.." is treated as a special query parameter in case the resource needs to be opened with a specific application: "-resource /some/file.opi?app=some_app&MACRO=value".

The memento saves and restores that URI without changes, and the save/restore of display files with macros now works.

Documentation needs to be updated, and as I work further on the display builder there may be more tweaks, but this snapshot seems to be at least as good as what we had before.