### PR TITLE
Add RDBConnectionPool

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
+++ b/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.rdb;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import org.phoebus.framework.rdb.RDBInfo.Dialect;
+
+/** Pool for an RDB connection
+ *
+ *  <p>Maintains connections to a URL/name/password.
+ *  Connections returned to the pool are kept open
+ *  until they either get re-used within some time,
+ *  or released after a time out.
+ *
+ *  @author Kay Kasemir
+ */
+public class RDBConnectionPool
+{
+    /** Logger for the package */
+    public static final Logger logger = Logger.getLogger(RDBConnectionPool.class.getPackageName());
+
+    private static final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor();
+    private final RDBInfo info;
+    private final List<Connection> pool = new ArrayList<>();
+
+    private final AtomicReference<Future<?>> cleanup = new AtomicReference<>();
+
+    private volatile int timeout = 10;
+
+    /** Create conneciton pool
+    *
+    *  <p>URL format depends on the database dialect.
+    *
+    *  <p>For MySQL resp. Oracle, the formats are:
+    *  <pre>
+    *     jdbc:mysql://[host]:[port]/[database]?user=[user]&password=[password]
+    *     jdbc:oracle:thin:[user]/[password]@//[host]:[port]/[database]
+    *  </pre>
+    *
+    *  For Oracle, the port is usually 1521.
+    *
+    *  @param url Database URL
+    *  @param user User name or <code>null</code> if part of URL
+    *  @param password Password or <code>null</code> if part of URL
+    *  @throws Exception on error
+    */
+    public RDBConnectionPool(final String url, final String user, final String password) throws Exception
+    {
+        this.info = new RDBInfo(url, user, password);
+    }
+
+    /** @return Database dialect */
+    public Dialect getDialect()
+    {
+        return info.getDialect();
+    }
+
+    /** @param seconds Duration for keeping idle connections in pool */
+    public void setTimeout(final int seconds)
+    {
+        timeout = seconds;
+    }
+
+    /** @return Time for which idle connections are cached */
+    public int getTimeoutSeconds()
+    {
+        return timeout;
+    }
+
+    /** Get a connection
+     *
+     *  <p>The connection should not be closed
+     *  but returned to the pool.
+     *
+     *  @return {@link Connection}
+     *  @throws Exception on error
+     *  @see #releaseConnection(Connection)
+     */
+    public Connection getConnection() throws Exception
+    {
+        Connection connection = pop();
+        while (connection != null)
+        {   // Is existing connection still good?
+            if (connection.isValid(5))
+                return connection;
+            // Close it
+            close(connection);
+            // Check next existing connection
+            connection = pop();
+        }
+
+        // No suitable existing connection, create new one
+        return info.connect();
+    }
+
+    /** @param connection Connection that is released to the pool for re-use (or time out) */
+    public void releaseConnection(final Connection connection)
+    {
+        push(connection);
+        final Future<?> previous = cleanup.getAndSet(timer.schedule(this::clear, timeout, TimeUnit.SECONDS));
+        if (previous != null)
+            previous.cancel(false);
+    }
+
+    private synchronized void push(final Connection connection)
+    {
+        pool.add(connection);
+    }
+
+    private synchronized Connection pop()
+    {
+        int last = pool.size() - 1;
+        if (last >= 0)
+            return pool.remove(last);
+        return null;
+    }
+
+    /** Clear the pool, close all connections */
+    public synchronized void clear()
+    {
+        for (Connection connection : pool)
+            close(connection);
+        pool.clear();
+    }
+
+    private void close(final Connection connection)
+    {
+        try
+        {
+            connection.close();
+        }
+        catch (Exception ex)
+        {
+            // Ignore, closing anyway
+        }
+    }
+}

--- a/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
+++ b/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
@@ -41,23 +41,23 @@ public class RDBConnectionPool
 
     private volatile int timeout = 10;
 
-    /** Create conneciton pool
-    *
-    *  <p>URL format depends on the database dialect.
-    *
-    *  <p>For MySQL resp. Oracle, the formats are:
-    *  <pre>
-    *     jdbc:mysql://[host]:[port]/[database]?user=[user]&password=[password]
-    *     jdbc:oracle:thin:[user]/[password]@//[host]:[port]/[database]
-    *  </pre>
-    *
-    *  For Oracle, the port is usually 1521.
-    *
-    *  @param url Database URL
-    *  @param user User name or <code>null</code> if part of URL
-    *  @param password Password or <code>null</code> if part of URL
-    *  @throws Exception on error
-    */
+    /** Create connection pool
+     *
+     *  <p>URL format depends on the database dialect.
+     *
+     *  <p>For MySQL resp. Oracle, the formats are:
+     *  <pre>
+     *     jdbc:mysql://[host]:[port]/[database]?user=[user]&password=[password]
+     *     jdbc:oracle:thin:[user]/[password]@//[host]:[port]/[database]
+     *  </pre>
+     *
+     *  For Oracle, the port is usually 1521.
+     *
+     *  @param url Database URL
+     *  @param user User name or <code>null</code> if part of URL
+     *  @param password Password or <code>null</code> if part of URL
+     *  @throws Exception on error
+     */
     public RDBConnectionPool(final String url, final String user, final String password) throws Exception
     {
         this.info = new RDBInfo(url, user, password);

--- a/core/framework/src/main/java/org/phoebus/framework/rdb/RDBInfo.java
+++ b/core/framework/src/main/java/org/phoebus/framework/rdb/RDBInfo.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.rdb;
+
+import static org.phoebus.framework.rdb.RDBConnectionPool.logger;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Properties;
+import java.util.logging.Level;
+
+
+/** Information about an RDB connection
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class RDBInfo
+{
+    /** Start of MySQL URL */
+    private static final String JDBC_MYSQL = "jdbc:mysql://";
+
+    /** Start of PostgreSQL URL */
+    private static final String JDBC_POSTGRESQL = "jdbc:postgresql://";
+
+    /** Start of Oracle URL */
+    private static final String JDBC_ORACLE = "jdbc:oracle:";
+
+    /** Database dialect.
+     *  For starters, the connection mechanisms vary, and since
+     *  SQL isn't fully normed, there might be more differences
+     *  that we need to handle, so we keep track of the dialect.
+     */
+    public enum Dialect
+    {
+        /** Database that understands MySQL commands */
+        MySQL,
+        /** Database that understands Oracle commands */
+        Oracle,
+        /** Database that understands PostgreSQL commands */
+        PostgreSQL
+    };
+
+    private final String url, user, password;
+    private final Dialect dialect;
+
+    RDBInfo(final String url, final String user, final String password) throws Exception
+    {
+        this.url = url;
+        this.user = user;
+        this.password = password;
+
+        if (url.startsWith(JDBC_MYSQL))
+            dialect = Dialect.MySQL;
+        else if (url.startsWith(JDBC_POSTGRESQL))
+            dialect = Dialect.PostgreSQL;
+        else if (url.startsWith(JDBC_ORACLE))
+            dialect = Dialect.Oracle;
+        else
+            throw new Exception("Unknown database dialect " + url);
+    }
+
+    public Dialect getDialect()
+    {
+        return dialect;
+    }
+
+    Connection connect() throws Exception
+    {
+        Connection connection = null;
+
+        final Properties prop = new Properties();
+        if (user != null)
+            prop.put("user", user);
+        if (password != null)
+            prop.put("password", password);
+
+        if (dialect == Dialect.Oracle)
+        {
+            // Get class loader to find the driver
+            // Class.forName("oracle.jdbc.driver.OracleDriver").getDeclaredConstructor().newInstance();
+            // Connect such that Java float and double map to Oracle
+            // BINARY_FLOAT resp. BINARY_DOUBLE
+            prop.put("SetFloatAndDoubleUseBinary", "true");
+        }
+        else if (dialect == Dialect.MySQL)
+        {
+            if (url.startsWith("jdbc:mysql:replication"))
+            {
+                // Use ReplicationDriver based on code by Laurent Philippe
+                // in org.csstudio.platform.utility.rdb.internal.MySQL_RDB
+                Driver driver = (Driver)Class.forName("com.mysql.jdbc.ReplicationDriver").getDeclaredConstructor().newInstance();
+
+                // We want this for failover on the slaves
+                prop.put("autoReconnect", "true");
+
+                // We want to load balance between the slaves
+                prop.put("roundRobinLoadBalance", "true");
+
+                connection = driver.connect(url, prop);
+            }
+        }
+        else if (dialect == Dialect.PostgreSQL)
+        {
+            // Required to locate driver?
+            Class.forName("org.postgresql.Driver").getDeclaredConstructor().newInstance();
+        }
+
+        // Unless connection was created by dialect-specific code,
+        // use generic driver manager
+        if (connection == null)
+            connection = DriverManager.getConnection(url, prop);
+
+        // Basic database info
+        if (logger.isLoggable(Level.FINE))
+        {
+            final DatabaseMetaData meta = connection.getMetaData();
+            logger.fine(dialect + " connection: " +
+                        meta.getDatabaseProductName() + " " + meta.getDatabaseProductVersion());
+        }
+        return connection;
+    }
+}


### PR DESCRIPTION
Common API for connecting to any RDB (Oracle, MySQL, Postgres) in a way
that existing connection can be re-used.

Used by SNS product's implementation for PV name lookup from local RDB.
To be used by RDB archive data reader.