### PR TITLE
Master project explicitly named to "phoebus".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
   <artifactId>parent</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <name>phoebus</name>
 
   <properties>
     <maven.repo.local>${project.build.directory}/.m2</maven.repo.local>


### PR DESCRIPTION
In NetBeans (and possibly in other IDEs), when the master pom is opened, the corresponding project will be named "parent", and this is very confusing.