### PR TITLE
Screenshot update

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/javafx/Screenshot.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/Screenshot.java
@@ -93,7 +93,7 @@ public class Screenshot
      * <p> Returns null if no image is on the clip board.
      * @return Image
      */
-    public static Image getImageFromClipBoard()
+    public static Image getImageFromClipboard()
     {
         Clipboard clipboard = Clipboard.getSystemClipboard();
         return clipboard.getImage();

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/Screenshot.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/Screenshot.java
@@ -15,7 +15,9 @@ import javax.imageio.ImageIO;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.image.Image;
 import javafx.scene.image.WritableImage;
+import javafx.scene.input.Clipboard;
 
 /** Create screenshot of a JavaFX scene
  *  @author Kay Kasemir
@@ -32,17 +34,30 @@ public class Screenshot
      */
     public Screenshot(final Scene scene)
     {
-        image = fromNode(scene.getRoot());
+        image = bufferFromNode(scene.getRoot());
     }
 
     public Screenshot(final Node node)
     {
-        image = fromNode(node);
+        image = bufferFromNode(node);
     }
 
-    public static BufferedImage fromNode(Node node)
+    /** Get a JavaFX Node Snapshot as a JavaFX Image 
+     * @param node
+     * @return Image
+     */
+    public static WritableImage imageFromNode(Node node)
     {
-        final WritableImage jfx = node.snapshot(null, null);
+        return node.snapshot(null, null);
+    }
+    
+    /** Get a JavaFX Node Snapshot as an AWT BufferedImage
+     * @param node
+     * @return BufferedImage
+     */
+    public static BufferedImage bufferFromNode(Node node)
+    {
+        final WritableImage jfx = imageFromNode(node);
         final BufferedImage img = new BufferedImage((int)jfx.getWidth(),
                 (int)jfx.getHeight(),
                 BufferedImage.TYPE_INT_ARGB);
@@ -51,6 +66,39 @@ public class Screenshot
         return img;
     }
 
+    /* Commented out because AWT causes issues, but remains as example of how it could be done.
+    /**
+     * Capture an image of the entire screen.
+     * @return Image
+     
+    public static Image captureScreen()
+    {
+        try {
+            Robot robot = new Robot();
+            
+            // Create an image of the main screen with the retrieved screen dimensions.
+            Rectangle screenDimensions = new Rectangle(Toolkit.getDefaultToolkit().getScreenSize());
+            BufferedImage screenCapture = robot.createScreenCapture(screenDimensions);
+            
+            return SwingFXUtils.toFXImage(screenCapture, null);
+        } catch (AWTException ex) {
+            logger.log(Level.WARNING, "Screen capture failed.", ex);
+        }
+        return null;
+    }
+    */
+    
+    /**
+     * Get an image from the clip board.
+     * <p> Returns null if no image is on the clip board.
+     * @return Image
+     */
+    public static Image getImageFromClipBoard()
+    {
+        Clipboard clipboard = Clipboard.getSystemClipboard();
+        return clipboard.getImage();
+    }
+    
     /** Write to file
      *  @param file Output file
      *  @throws Exception on error


### PR DESCRIPTION
This allows a user to get a plain JavaFX Image from the Node.snapshot method as well as an AWT BufferedImage. Added a getImageFromClipboard method as well. There is a commented out method that would facilitate a full screen capture of the primary screen. It is commented out because AWT can cause problems when mixed with JFX, but left in the code as an example should the need arise.