### PR TITLE
Display builder help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ logs.txt
 settings.xml
 nohup.out
 
+# Generated help files, html/generated
+generated/
 
 # Created by https://www.gitignore.io/api/maven,eclipse
 

--- a/app/alarm/examples/create_alarm_topics.sh
+++ b/app/alarm/examples/create_alarm_topics.sh
@@ -13,7 +13,7 @@ for topic in "$1" "${1}State"
 do
     kafka/bin/kafka-topics.sh  --zookeeper localhost:2181 --create --replication-factor 1 --partitions 1 --topic $topic
     kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --entity-type topics --alter --entity-name $topic \
-           --add-config cleanup.policy=[compact,delete],segment.ms=10000,min.cleanable.dirty.ratio=0.01,min.compaction.lag.ms=1000
+           --add-config cleanup.policy=compact,segment.ms=10000,min.cleanable.dirty.ratio=0.01,min.compaction.lag.ms=1000
 done
 
 # Create the deleted topics

--- a/app/display/editor/doc/index.rst
+++ b/app/display/editor/doc/index.rst
@@ -1,0 +1,29 @@
+Display Builder
+===============
+
+Install Examples
+----------------
+
+Invoke ``Install Example Display`` from the menu ``Applications``, ``Display``, ``Examples``
+to install the display builder examples.
+
+You will be prompted for a location where you wish to install them.
+
+Then use the menu ``File``, ``Open`` to open the file ``01_main.bob``
+from the examples to get started.  
+
+
+Create new Display
+------------------
+
+Use the menu option ``Applications``, ``Display``, ``New Display``
+to create a new display.
+
+
+Internals
+---------
+
+.. raw:: html
+
+   <a href="html/generated/index.html">Java Doc for scripts</a>
+   

--- a/app/display/editor/doc/javadoc_overview.html
+++ b/app/display/editor/doc/javadoc_overview.html
@@ -1,0 +1,18 @@
+<!-- Overview file for javadoc, included in generated files -->
+<body>
+<p>API for user code, for example scripts that interact with the display builder.</p>
+
+<p>Fundamental display model API:</p>
+<ul>
+<li>{@link org.csstudio.display.builder.model.Widget} - Base for each widget</li>
+<li>{@link org.csstudio.display.builder.model.DisplayModel} - Root of a display's widget tree</li>
+</ul>
+
+<p>Helpers for scripts:</p>
+<ul>
+<li>{@link org.csstudio.display.builder.runtime.script.ScriptUtil} - Other script helpers</li>
+<li>{@link org.csstudio.display.builder.runtime.script.PVUtil} - Read/decode value of a PV</li>
+<li>{@link org.csstudio.display.builder.runtime.script.ValueUtil} - Handle PV's values</li>
+</ul>
+
+</body>

--- a/app/display/editor/javadoc.xml
+++ b/app/display/editor/javadoc.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <!-- Ant file for generating javadoc for API
 
-     Will be invoked by pom.xml as well as build.xml.
-
      Execute manually as
 
        ant -f javadoc.xml clean all
@@ -19,7 +17,7 @@
   -->
 <project name="api" default="all">
   <!-- Output directory -->
-  <property name="out" value="doc/java"/>
+  <property name="out" value="doc/html/generated"/>
   <path id="classpath">
     <!--
         <fileset dir="/Kram/Eclipse/3_7_2/rcp/eclipse/plugins/org.junit_4.8.2.v4_8_2_v20110321-1705">

--- a/app/display/editor/javadoc.xml
+++ b/app/display/editor/javadoc.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!-- Ant file for generating javadoc for API
+
+     Will be invoked by pom.xml as well as build.xml.
+
+     Execute manually as
+
+       ant -f javadoc.xml clean all
+
+     to re-create the doc/java files.
+
+     The documentation is on purpose incomplete.
+     Instead of covering all the source code, it only includes
+     the essential Widget and script classes that are likely to
+     remain accessible from scripts, while everything beyond that API
+     is open to changes.
+     Since Java 9, the '-Xold' option is required because otherwise
+     the errors about missing packages abort the javadoc generation.
+  -->
+<project name="api" default="all">
+  <!-- Output directory -->
+  <property name="out" value="doc/java"/>
+  <path id="classpath">
+    <!--
+        <fileset dir="/Kram/Eclipse/3_7_2/rcp/eclipse/plugins/org.junit_4.8.2.v4_8_2_v20110321-1705">
+            <include name="**/*.jar"/>
+        </fileset>
+        -->
+  </path>
+  <!-- Remove all that might have been created -->
+  <target name="clean">
+    <delete dir="${out}"/>
+  </target>
+  <!-- Create Javadoc -->
+  <target name="javadoc">
+    <!-- Capture the path as a delimited property using the refid attribute -->
+    <property name="myclasspath" refid="classpath"/>
+    <!-- Emit the property to the ant console -->
+    <echo message="Classpath: ${myclasspath}"/>
+    <javadoc additionalparam="-Xold -notimestamp"
+             classpathref="classpath" destdir="${out}" author="false" access="public"
+             version="true" use="false" windowtitle="Display Builder API"
+             overview="doc/javadoc_overview.html"
+             useexternalfile="yes">
+      <doctitle><![CDATA[<h1>Display Builder API</h1>]]></doctitle>
+      <fileset dir="../../..">
+        <include name="core/framework/src/main/java/org/phoebus/framework/macros/Macros.java"/>
+        <include name="app/display/model/src/main/java/org/csstudio/display/builder/model/Widget.java"/>
+        <include name="app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java"/>
+        <include name="app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java"/>
+        <include name="app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java"/>
+        <include name="app/display/model/src/main/java/org/csstudio/display/builder/model/**/*Widget.java"/>
+        <include name="app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/*.java"/>
+        <include name="app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/RuntimePV.java"/>
+        <exclude name="**/WhateverThing.java"/>
+      </fileset>
+      <group title="Script API" packages="org.csstudio.display.builder.*"/>
+    </javadoc>
+  </target>
+  <!-- Run the whole chain -->
+  <target name="all" depends="javadoc">
+    <echo>=== Completed ${ant.project.name} ===</echo>
+  </target>
+</project>

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java
@@ -150,8 +150,8 @@ public abstract class PropertyChangeHandler<T extends Object>
        final int recursion_level = recursions.incrementAndGet();
        if (recursion_level > 1)
            logger.log(Level.WARNING,
-                      "Recursive update of property " + property.getName() + ", " +
-                      recursion_level + " deep");
+                      "Recursive update of property " + property.getWidget() + " " + property.getName() + ", " +
+                      recursion_level + " deep", new Exception("Recursive update of " + property));
        // Notify listeners
        for (BaseWidgetPropertyListener listener : safe_copy)
        {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
@@ -137,8 +137,20 @@ public class RuleToScript
                 result.append(" or ");
                 i += 1;
             }
-            else if (text.charAt(i) == '!'  &&  ! matches(text, i, "!="))
+            else if (matches(text, i, "!="))
+            {
+                result.append("!=");
+                i += 1;
+            }
+            else if (text.charAt(i) == '!')  // and not "!=" since we just checked for that
                 result.append(" not ");
+            else if (matches(text, i, "==")) // and not "!="
+            {
+                result.append("==");
+                i += 1;
+            }
+            else if (text.charAt(i) == '=') // and neither "==" nor "!="
+                result.append("==");
             else
                 result.append(text.charAt(i));
         }

--- a/app/display/model/src/test/java/org/csstudio/display/builder/model/rules/RuleToScript_ReplacementTests.java
+++ b/app/display/model/src/test/java/org/csstudio/display/builder/model/rules/RuleToScript_ReplacementTests.java
@@ -10,7 +10,6 @@ package org.csstudio.display.builder.model.rules;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import org.csstudio.display.builder.model.rules.RuleToScript;
 import org.junit.Test;
 
 /** Test replacement of logical operators in RuleToScript.
@@ -25,6 +24,13 @@ public class RuleToScript_ReplacementTests
         assertThat(RuleToScript.javascriptToPythonLogic(" true "), equalTo(" True "));
         assertThat(RuleToScript.javascriptToPythonLogic(" ! false "), equalTo("  not  False "));
         assertThat(RuleToScript.javascriptToPythonLogic("  \"false\"  "), equalTo("  \"false\"  "));
+    }
+
+    @Test
+    public void testEqual()
+    {
+        assertThat(RuleToScript.javascriptToPythonLogic("pv0!=3"), equalTo("pv0!=3"));
+        assertThat(RuleToScript.javascriptToPythonLogic("pv0=3"), equalTo("pv0==3"));
     }
 
     @Test

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TableRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TableRepresentation.java
@@ -217,6 +217,9 @@ public class TableRepresentation extends RegionBaseRepresentation<StringTable, T
     {
         if (updating_table)
             return;
+        // new_value == model_widget.runtimeValue().getValue() might be
+        // a List<List<String>> or a VTable.
+        // getValue() fetches either one as deep-copied List<List<String>>
         data = model_widget.getValue();
         if (new_value instanceof VTable)
         {   // Use table's column headers

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -105,7 +105,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
         super(name, listener);
         this.horizontal = horizontal;
         this.transform = Objects.requireNonNull(transform);
-        this.range = new AxisRange<T>(low_value, high_value);
+        this.range = new AxisRange<>(low_value, high_value);
         this.ticks = Objects.requireNonNull(ticks);
     }
 
@@ -270,11 +270,11 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
             // Can axis handle this range?
             if (! ticks.isSupportedRange(low, high))
             {
-                logger.log(Level.WARNING, "Axis {0}: Bad value range {1} ... {2}",
-                                          new Object[] { getName(), low, high });
+                logger.log(Level.CONFIG, "Axis {0}: Bad value range {1} ... {2}",
+                                         new Object[] { getName(), low, high });
                 return false;
             }
-            range = new AxisRange<T>(low, high);
+            range = new AxisRange<>(low, high);
             transform.config(low, high, low_screen, high_screen);
         }
         dirty_ticks = true;
@@ -345,7 +345,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
     /** @return Pixel range on screen */
     public AxisRange<Integer> getScreenRange()
     {
-        return new AxisRange<Integer>(low_screen, high_screen);
+        return new AxisRange<>(low_screen, high_screen);
     }
 
     /** @return Tick mark information. */

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/ImagePlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/ImagePlot.java
@@ -819,7 +819,7 @@ public class ImagePlot extends PlotCanvasBase
 
         if (!  (min < max))  // Implies min and max being finite, not-NaN
         {
-            logger.log(Level.WARNING, "Invalid value range {0} .. {1}", new Object[] { min, max });
+            logger.log(Level.CONFIG, "Invalid value range {0} .. {1}", new Object[] { min, max });
             min = 0.0;
             max = 1.0;
         }
@@ -1417,9 +1417,9 @@ public class ImagePlot extends PlotCanvasBase
     private static AxisRange<Double> getRestrictedRange(final double low, final double high, final double min, final double max)
     {
         if (min <= max)
-            return new AxisRange<Double>(Math.max(min, low), Math.min(max, high));
+            return new AxisRange<>(Math.max(min, low), Math.min(max, high));
         else
-            return new AxisRange<Double>(Math.min(min, low), Math.max(max, high));
+            return new AxisRange<>(Math.min(min, low), Math.max(max, high));
     }
 
     void fireChangedAxisRange(final Axis<Double> axis)

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
@@ -192,6 +192,8 @@ public class StringTable extends BorderPane
                 {
                     setText(null);
                     setGraphic(checkbox);
+                    // Enable checkbox for editable column
+                    checkbox.setDisable(! getTableColumn().isEditable());
                     checkbox.setSelected(item.equalsIgnoreCase("true"));
                     final int col = getTableView().getColumns().indexOf(getTableColumn());
                     setCellStyle(this, row, col);
@@ -573,7 +575,8 @@ public class StringTable extends BorderPane
             if (row.size() < columns)
             {
                 logger.log(Level.WARNING, "Table needs " + columns +
-                           " columns but got row with just " + row.size());
+                           " columns " + getHeaders() +
+                           " but got row with just " + row.size() + ": " + row);
                 for (int i=row.size(); i<columns; ++i)
                     row.add("");
             }


### PR DESCRIPTION
phoebus-doc was just extended to include `doc/html` content "as is".
This now allows generating the javadoc for the display builder scripting API again, and then include it in the online help.
Started app/display/editor/doc/index.rst help page, mostly so that there's a page that links to the javadoc.

Ongoing display builder updates.