### PR TITLE
Log entry view

### DIFF
--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.logbook.ui;
+
+import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.logbook.ui.write.LogEntryModel;
+
+/** Preference settings for logbook.ui
+ *  @author Evan Smith
+ */
+@SuppressWarnings("nls")
+public class LogbookUiPreferences
+{
+    public static final String[] default_logbooks;
+    public static final boolean save_credentials;
+
+    static
+    {
+        PreferencesReader prefs = new PreferencesReader(LogEntryModel.class, "/log_ui_preferences.properties");
+
+        // Split the comma separated list.
+        default_logbooks = prefs.get("default_logbooks").split("(\\s)*,(\\s)*");
+        save_credentials = prefs.getBoolean("save_credentials");
+    }
+}

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/contextMenuLogging.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/contextMenuLogging.java
@@ -41,7 +41,7 @@ public class contextMenuLogging implements ContextMenuEntry {
                 });
             });
         });
-        LogService.getInstance().createLogEntry(adaptedSelections);
+        LogService.getInstance().createLogEntry(adaptedSelections, null);
         return null;
     }
 

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
@@ -84,9 +84,11 @@ public class SendLogbookAction extends MenuItem
             logger.log(Level.WARNING, "Default log entry attachment creation failed.", ex);
         }
         
+        // TODO Get the default log books
         LogEntryBuilder logEntryBuilder = new LogEntryBuilder();
         LogEntry template = logEntryBuilder.appendDescription(default_text)
                        .attach(attachment)
+                       //.appendToLogbook(default_logbook)
                        .createdDate(Instant.now())
                        .build();
         

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
@@ -84,11 +84,9 @@ public class SendLogbookAction extends MenuItem
             logger.log(Level.WARNING, "Default log entry attachment creation failed.", ex);
         }
         
-        // TODO Get the default log books
         LogEntryBuilder logEntryBuilder = new LogEntryBuilder();
         LogEntry template = logEntryBuilder.appendDescription(default_text)
                        .attach(attachment)
-                       //.appendToLogbook(default_logbook)
                        .createdDate(Instant.now())
                        .build();
         

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryDialog.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryDialog.java
@@ -85,8 +85,8 @@ public class LogEntryDialog extends Dialog<LogEntry>
         // Let the Text Area grow to the bottom.
         VBox.setVgrow(logEntryFields,  Priority.ALWAYS);
 
-        VBox.setMargin(credentialEntry,       new Insets(10, 0,  0, 0));
-        VBox.setMargin(logEntryFields,        new Insets( 0, 0, 10, 0));
+        VBox.setMargin(credentialEntry, new Insets(10, 0,  0, 0));
+        VBox.setMargin(logEntryFields,  new Insets( 0, 0, 10, 0));
         
         content.setSpacing(10);
         content.getChildren().addAll(credentialEntry, dateAndLevel, logEntryFields, attachmentsView);
@@ -111,7 +111,6 @@ public class LogEntryDialog extends Dialog<LogEntry>
             {
                 return button == submit ? model.submitEntry() : null;
             } 
-            
             catch (IOException ex)
             {
                 logger.log(Level.WARNING, "Log Entry Submission Failed!", ex);
@@ -131,27 +130,13 @@ public class LogEntryDialog extends Dialog<LogEntry>
         Collection<Logbook> logbooks = template.getLogbooks();
         logbooks.forEach(logbook-> 
         {
-            try
-            {
-                model.addSelectedLogbook(logbook.getName());
-            } 
-            catch (Exception ex)
-            {
-                logger.log(Level.WARNING, "Selected logbook initialization failed.", ex);
-            }
+            model.addSelectedLogbook(logbook.getName());
         });  
         
         Collection<Tag> tags = template.getTags();
         tags.forEach(tag-> 
         {
-            try
-            {
-                model.addSelectedTag(tag.getName());
-            } 
-            catch (Exception ex)
-            {
-                logger.log(Level.WARNING, "Selected tag initialization failed.", ex);
-            }
+            model.addSelectedTag(tag.getName());
         });
         
         for (Attachment attachment : template.getAttachments())
@@ -168,7 +153,7 @@ public class LogEntryDialog extends Dialog<LogEntry>
                 } 
                 catch (FileNotFoundException ex)
                 {
-                    logger.log(Level.WARNING, "Log entry template attachment file not found: '" + file.getName() + '"', ex);
+                    logger.log(Level.WARNING, "Log entry template attachment file not found: '" + file.getName() + "'", ex);
                 }
                 
                 model.addImage(image);

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -59,13 +59,14 @@ public class LogEntryModel
     private final ObservableList<Image>  images;
     private final ObservableList<File>   files;
     
-    /** onSubmitAction runnable - runnable to executed after the submit action completes.*/
+    /** onSubmitAction runnable - runnable to be executed after the submit action completes. */
     private Runnable onSubmitAction;
     
     public LogEntryModel(final Node callingNode)
     {   
         logService = LogService.getInstance();
         logFactory = logService.getLogFactories().get("org.phoebus.sns.logbook");
+        
         tags     = FXCollections.observableArrayList();
         logbooks = FXCollections.observableArrayList();
  

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import javax.imageio.ImageIO;
 
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.logbook.AttachmentImpl;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
@@ -76,8 +77,23 @@ public class LogEntryModel
         files  = FXCollections.observableArrayList();
         
         node = callingNode;
+        
+        getDefaults();
     }
 
+    private void getDefaults()
+    {
+        PreferencesReader prefs = new PreferencesReader(LogEntryModel.class, "/log_ui_preferences.properties");
+        String defaults = prefs.get("default_logbooks");
+        // Split the comma separated list.
+        String[] default_logbooks = defaults.split("(\\s)*,(\\s)*");
+        // Get rid of leading and trailing whitespace and add the default to the selected list.
+        for (String logbook : default_logbooks)
+        {
+            addSelectedLogbook(logbook.trim());
+        }
+    }
+    
     /**
      * Gets the JavaFX Scene graph.
      * @return Scene
@@ -194,7 +210,9 @@ public class LogEntryModel
      */
     public boolean hasSelectedLogbook (final String logbook)
     {
-        return selectedLogbooks.contains(logbook);
+        boolean result = selectedLogbooks.contains(logbook);
+        System.out.println(logbook + " : " + result);
+        return result;
     }
     
     /**

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -200,9 +200,7 @@ public class LogEntryModel
      */
     public boolean hasSelectedLogbook (final String logbook)
     {
-        boolean result = selectedLogbooks.contains(logbook);
-        System.out.println(logbook + " : " + result);
-        return result;
+        return selectedLogbooks.contains(logbook);
     }
 
     /**

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogbooksTagsView.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogbooksTagsView.java
@@ -7,11 +7,13 @@
  *******************************************************************************/
 package org.phoebus.logbook.ui.write;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 import org.phoebus.ui.javafx.ImageCache;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -180,16 +182,25 @@ public class LogbooksTagsView extends VBox
     /** Initialize the drop down context menus by adding listeners to their content lists. */
     private void initializeSelectors()
     {
+        Comparator<MenuItem> comp = (a, b) -> 
+        {
+            CheckBox checkA = (CheckBox)((CustomMenuItem) a).getContent();
+            CheckBox checkB = (CheckBox)((CustomMenuItem) b).getContent();
+
+            return checkA.getText().compareTo(checkB.getText());
+        };
         model.addLogbookListener((ListChangeListener.Change<? extends String> c) -> 
         {
             if (c.next())
                 c.getAddedSubList().forEach(newLogbook -> addToLogbookDropDown(newLogbook));
+            FXCollections.sort(logbookDropDown.getItems(), comp);
         });
 
         model.addTagListener((ListChangeListener.Change<? extends String> c) -> 
         {
             if (c.next())
                 c.getAddedSubList().forEach(newTag -> addToTagDropDown(newTag));
+            FXCollections.sort(tagDropDown.getItems(), comp);
         });
         
         // Once the listeners are added ask the model to fetch the lists.
@@ -255,7 +266,7 @@ public class LogbooksTagsView extends VBox
                 }
             }
         });
-        tagDropDown.getItems().add(newTag);        
+        tagDropDown.getItems().add(newTag);   
     }
     
     /** Sets the field's text based on the selected items list. */

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogbooksTagsView.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogbooksTagsView.java
@@ -224,18 +224,24 @@ public class LogbooksTagsView extends VBox
             {
                 CheckBox source = (CheckBox) e.getSource();
                 String text = source.getText();
-                if (model.getSelectedLogbooks().contains(text))
+                if (source.isSelected())
                 {
-                    model.removeSelectedLogbook(text);
+                    if (! model.hasSelectedLogbook(text))
+                    {
+                        System.out.println("Adding selected log book : " + text);
+                        model.addSelectedLogbook(text);
+                    }
                     setFieldText(logbookDropDown, model.getSelectedLogbooks(), logbookField);
                 }
                 else
                 {
-                    model.addSelectedLogbook(text);
+                    model.removeSelectedLogbook(text);
                     setFieldText(logbookDropDown, model.getSelectedLogbooks(), logbookField);
-                } 
+                }
             }
         });
+        if (model.hasSelectedLogbook(item))
+            checkBox.fire();
         logbookDropDown.getItems().add(newLogbook);
     }
     
@@ -254,18 +260,23 @@ public class LogbooksTagsView extends VBox
             {
                 CheckBox source = (CheckBox) e.getSource();
                 String text = source.getText();
-                if (model.getSelectedTags().contains(text))
+                if (source.isSelected())
                 {
-                    model.removeSelectedTag(text);
+                    if (! model.hasSelectedTag(text))
+                    {
+                        model.addSelectedTag(text);
+                    }
                     setFieldText(tagDropDown, model.getSelectedTags(), tagField);
                 }
                 else
                 {
-                    model.addSelectedTag(text);
+                    model.removeSelectedTag(text);
                     setFieldText(tagDropDown, model.getSelectedTags(), tagField);
                 }
             }
         });
+        if (model.hasSelectedTag(item))
+            checkBox.fire();
         tagDropDown.getItems().add(newTag);   
     }
     
@@ -278,6 +289,7 @@ public class LogbooksTagsView extends VBox
             CustomMenuItem custom = (CustomMenuItem) menuItem;
             CheckBox check = (CheckBox) custom.getContent();
             // If the item is selected make sure it is checked.
+            
             if (selectedItems.contains(check.getText()))
             {
                 if (! check.isSelected()) 

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -1,0 +1,9 @@
+# ------------------------------
+# Package org.phoebus.logbook.ui
+# ------------------------------
+
+# Default log books for log entries
+default_logbooks=
+
+# Whether or not to save user credentials to file so they only have to be entered once when making log entries.
+save_credentials=false

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -2,7 +2,7 @@
 # Package org.phoebus.logbook.ui
 # ------------------------------
 
-# Default log books for log entries
+# Comma-separated list of default logbooks for new log entries.
 default_logbooks=Scratch Pad
 
 # Whether or not to save user credentials to file so they only have to be entered once when making log entries.

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -3,7 +3,7 @@
 # ------------------------------
 
 # Default log books for log entries
-default_logbooks=
+default_logbooks=Scratch Pad
 
 # Whether or not to save user credentials to file so they only have to be entered once when making log entries.
 save_credentials=false

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogFactory.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogFactory.java
@@ -11,8 +11,10 @@ public interface LogFactory {
 
     public String getId();
 
+    /** Retrieve a read only log client */
     public LogClient getLogClient();
 
+    /** Retrieve a log client with authentication token */
     public LogClient getLogClient(Object authToken);
 
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogService.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogService.java
@@ -61,28 +61,29 @@ public class LogService {
     }
 
     /**
-     * Create a log entry in all register LogFactory
+     * Create a log entry in all registered LogFactory
      * 
      * @param adaptedSelections
+     * @param authToken - Authentication Token
      */
-    public void createLogEntry(LogEntry logEntry) {
+    public void createLogEntry(LogEntry logEntry, Object authToken) {
         executor.submit(() -> {
             logFactories.values().stream().forEach(logFactory -> {
-                logFactory.getLogClient().set(logEntry);
+                logFactory.getLogClient(authToken).set(logEntry);
             });
         });
     }
-
+    
     /**
-     * Create a log entry in all register LogFactory TODO change to Log type
+     * Create a log entry in all registered LogFactory TODO change to Log type
      * 
      * @param adaptedSelections
      */
-    public void createLogEntry(List<LogEntry> logEntries) {
+    public void createLogEntry(List<LogEntry> logEntries,  Object authToken) {
         executor.submit(() -> {
             logFactories.values().stream().forEach(logFactory -> {
                 logEntries.forEach(logEntry -> {
-                    logFactory.getLogClient().set(logEntry);
+                    logFactory.getLogClient(authToken).set(logEntry);
                 });
             });
         });
@@ -94,9 +95,9 @@ public class LogService {
      * @param id
      * @param log
      */
-    public void createLogEntry(String id, LogEntry logEntry) {
+    public void createLogEntry(String id, LogEntry logEntry,  Object authToken) {
         executor.submit(() -> {
-            logFactories.get(id).getLogClient().set(logEntry);
+            logFactories.get(id).getLogClient(authToken).set(logEntry);
         });
     }
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/actions/contextMenuLogging.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/actions/contextMenuLogging.java
@@ -41,7 +41,7 @@ public class contextMenuLogging implements ContextMenuEntry {
                 });
             });
         });
-        LogService.getInstance().createLogEntry(adaptedSelections);
+        LogService.getInstance().createLogEntry(adaptedSelections, null);
         return null;
     }
 

--- a/core/types/src/main/java/org/phoebus/core/types/adapters/ProcessVariablesAdapterFactory.java
+++ b/core/types/src/main/java/org/phoebus/core/types/adapters/ProcessVariablesAdapterFactory.java
@@ -1,6 +1,6 @@
 package org.phoebus.core.types.adapters;
 
-import static org.phoebus.logbook.LogEntryImpl.LogEntryBuilder.*;
+import static org.phoebus.logbook.LogEntryImpl.LogEntryBuilder.log;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +29,7 @@ public class ProcessVariablesAdapterFactory implements AdapterFactory {
         if (adapterType.isAssignableFrom(LogEntry.class)) {
             ProcessVariable tpv = ((ProcessVariable) adaptableObject);
             LogEntry log = log().description("PV name : " + tpv.getName()).build();
-            LogService.getInstance().createLogEntry(log);
+            LogService.getInstance().createLogEntry(log, null);
             return Optional.of(log);
         } else if (adapterType.isAssignableFrom(String.class)) {
             ProcessVariable tpv = ((ProcessVariable) adaptableObject);

--- a/core/types/src/main/java/org/phoebus/core/types/adapters/TimeStampedProcessVariableAdapterFactory.java
+++ b/core/types/src/main/java/org/phoebus/core/types/adapters/TimeStampedProcessVariableAdapterFactory.java
@@ -28,7 +28,7 @@ public class TimeStampedProcessVariableAdapterFactory implements AdapterFactory 
         if (adapterType.isAssignableFrom(LogEntry.class)) {
             TimeStampedProcessVariable tpv = ((TimeStampedProcessVariable) adaptableObject);
             LogEntry log = log().description("PV name: " + tpv.getName() + " " + tpv.getTime()).build();
-            LogService.getInstance().createLogEntry(log);
+            LogService.getInstance().createLogEntry(log, null);
             return Optional.of(log);
         } else if (adapterType.isAssignableFrom(String.class)) {
             TimeStampedProcessVariable tpv = ((TimeStampedProcessVariable) adaptableObject);

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -2,6 +2,7 @@ package org.phoebus.ui.application;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.util.ArrayList;
@@ -196,13 +197,9 @@ public class PhoebusApplication extends Application {
 
         Locations.initialize();
 
-        // Check for site-specific settings.ini bundled into distribution
-        final File site_settings = new File(Locations.install(), "settings.ini");
-        if (site_settings.canRead())
-        {
-            logger.log(Level.CONFIG, "Loading settings from " + site_settings);
-            PropertyPreferenceLoader.load(new FileInputStream(site_settings));
-        }
+        // Handle site specific settings and any settings files passed on command line.
+        handleSettings(getParameters().getRaw());
+        
         // Locate registered applications and start them, allocating 30% to that
         startApplications(new SubJobMonitor(monitor, 30));
 
@@ -230,7 +227,46 @@ public class PhoebusApplication extends Application {
                 splash.close();
         });
     }
-
+    
+    /**
+     * Handle settings from preferences.
+     * <p>Site settings loaded first, command line settings take precedence and will over write site settings.
+     * @param params - List of raw application parameters
+     * @throws Exception 
+     * @throws FileNotFoundException 
+     */
+    private void handleSettings(List<String> params) throws Exception
+    {
+        // Check for site-specific settings.ini bundled into distribution
+        final File site_settings = new File(Locations.install(), "settings.ini");
+        if (site_settings.canRead())
+        {
+            logger.log(Level.CONFIG, "Loading settings from " + site_settings);
+            PropertyPreferenceLoader.load(new FileInputStream(site_settings));
+        }
+        
+        // Check for -settings parameter.
+        final Iterator<String> paramIterator = params.iterator();
+        
+        while (paramIterator.hasNext())
+        {
+            final String cmd = paramIterator.next();
+            if (cmd.equals("-settings"))
+            {
+                if (!paramIterator.hasNext())
+                    throw new Exception("Missing -settings settings file name");
+                final String settingsFileName = paramIterator.next();
+                
+                // Settings from "-settings ..." takes precedence over site-specific settings.
+                logger.info("Loading settings from " + settingsFileName);
+                if (settingsFileName.endsWith(".xml"))
+                    java.util.prefs.Preferences.importPreferences(new FileInputStream(settingsFileName));
+                else
+                    PropertyPreferenceLoader.load(new FileInputStream(settingsFileName));
+            }
+        }
+    }
+    
     private void startUI(final MementoTree memento, final JobMonitor monitor) throws Exception
     {
         monitor.beginTask("Start UI", 4);

--- a/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
+++ b/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
@@ -65,6 +65,7 @@ public class Launcher
                     iter.remove();
                     LogManager.getLogManager().readConfiguration(new FileInputStream(filename));
                 }
+                
                 else if (cmd.equals("-settings"))
                 {
                     if (! iter.hasNext())
@@ -79,6 +80,7 @@ public class Launcher
                     else
                         PropertyPreferenceLoader.load(new FileInputStream(filename));
                 }
+                
                 else if (cmd.equals("-export_settings"))
                 {
                     if (! iter.hasNext())

--- a/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
+++ b/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
@@ -33,16 +33,14 @@ public class Launcher
         LogManager.getLogManager().readConfiguration(Launcher.class.getResourceAsStream("/logging.properties"));
 
         Locations.initialize();
-        // Check for bundled product setting before potentially adding command-line settings
         // Check for site-specific settings.ini bundled into distribution
-
+        // before potentially adding command-line settings.
         final File site_settings = new File(Locations.install(), "settings.ini");
         if (site_settings.canRead())
         {
             logger.log(Level.CONFIG, "Loading settings from " + site_settings);
             PropertyPreferenceLoader.load(new FileInputStream(site_settings));
         }
-
 
         // Handle arguments, potentially not even starting the UI
         final List<String> args = new ArrayList<>(List.of(original_args));

--- a/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
+++ b/phoebus-product/src/main/java/org/phoebus/product/Launcher.java
@@ -11,7 +11,6 @@ import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
-import org.phoebus.framework.preferences.PropertyPreferenceLoader;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.framework.workbench.ApplicationService;
@@ -65,22 +64,6 @@ public class Launcher
                     iter.remove();
                     LogManager.getLogManager().readConfiguration(new FileInputStream(filename));
                 }
-                
-                else if (cmd.equals("-settings"))
-                {
-                    if (! iter.hasNext())
-                        throw new Exception("Missing -settings file name");
-                    iter.remove();
-                    final String filename = iter.next();
-                    iter.remove();
-
-                    logger.info("Loading settings from " + filename);
-                    if (filename.endsWith(".xml"))
-                        Preferences.importPreferences(new FileInputStream(filename));
-                    else
-                        PropertyPreferenceLoader.load(new FileInputStream(filename));
-                }
-                
                 else if (cmd.equals("-export_settings"))
                 {
                     if (! iter.hasNext())


### PR DESCRIPTION
The order of precedence for preferences from "Locations.install" and the "-settings" command line option have been reordered. The command line option now takes precedence over the default location.

Two new preferences have been added to org.phoebus.logbook.ui.write: default_logbooks and save_credentials

default_logbooks - lets the site define default logbooks for logbook entries. This has been implemented.

save_credentials - can be used to tell the UI to save entered credentials to file so that they only have to log in once. This has not yet been implemented.