### PR TITLE
PV Name patches: Allow '=' inside PV name

### DIFF
--- a/app/display/runtime/src/main/resources/display_runtime_preferences.properties
+++ b/app/display/runtime/src/main/resources/display_runtime_preferences.properties
@@ -34,7 +34,7 @@ python_path=
 # Remove PVManager's longString modifier,             'some_pv {"longString":true}' -> 'some_pv'
 # turn constant formula into constant local variable, '=42'                         -> 'loc://const42(42)'
 # as well as constant name into constant local var,   '="Fred"'                     -> 'loc://strFred("Fred")'
-pv_name_patches=\\{"longString":true\\}"@@=([0-9]+)@loc://const$1($1)@="([a-zA-Z]+)"@loc://str$1("$1")
+pv_name_patches=\\{"longString":true\\}"@@^=([0-9]+)@loc://const$1($1)@^="([a-zA-Z]+)"@loc://str$1("$1")
 
 # PV update throttle in millisecs
 # 250ms = 4 Hz

--- a/app/display/runtime/src/test/java/org/csstudio/display/builder/runtime/test/TextPatchTest.java
+++ b/app/display/runtime/src/test/java/org/csstudio/display/builder/runtime/test/TextPatchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ public class TextPatchTest
     @Test
     public void testConstantNumber() throws Exception
     {
-        final TextPatch pvm_string = new TextPatch("=([0-9]+)", "loc://const$1($1)");
+        final TextPatch pvm_string = new TextPatch("^=([0-9]+)", "loc://const$1($1)");
 
         String name = "=1";
         String patched = pvm_string.patch(name);
@@ -44,16 +44,29 @@ public class TextPatchTest
         patched = pvm_string.patch(name);
         System.out.println(name + " -> " + patched);
         assertThat(patched, equalTo("loc://const42(42)"));
+
+        // Can a PV name really contain '='?!
+        // Evidently, yes..
+        name = "test=0";
+        patched = pvm_string.patch(name);
+        System.out.println(name + " -> " + patched);
+        assertThat(patched, equalTo("test=0"));
     }
 
     @Test
     public void testConstantText() throws Exception
     {
-        final TextPatch pvm_string = new TextPatch("=\"([a-zA-Z]+)\"", "loc://str$1(\"$1\")");
+        final TextPatch pvm_string = new TextPatch("^=\"([a-zA-Z]+)\"", "loc://str$1(\"$1\")");
 
         String name = "=\"Fred\"";
         String patched = pvm_string.patch(name);
         System.out.println(name + " -> " + patched);
         assertThat(patched, equalTo("loc://strFred(\"Fred\")"));
+
+        // PV with '=' in the name?!
+        name = "test=egon";
+        patched = pvm_string.patch(name);
+        System.out.println(name + " -> " + patched);
+        assertThat(patched, equalTo("test=egon"));
     }
 }


### PR DESCRIPTION

Update display builder reg. ex. for patching PV names to be compatible with legacy displays