### PR TITLE
Fixes

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetTransfer.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetTransfer.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.util;
 
+import static javafx.scene.paint.Color.GRAY;
+import static org.csstudio.display.builder.editor.Plugin.logger;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Stroke;
@@ -24,6 +27,34 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import javax.imageio.ImageIO;
+import javax.swing.text.Document;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.rtf.RTFEditorKit;
+
+import org.csstudio.display.builder.editor.DisplayEditor;
+import org.csstudio.display.builder.editor.EditorUtil;
+import org.csstudio.display.builder.editor.Messages;
+import org.csstudio.display.builder.editor.palette.Palette;
+import org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker;
+import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.WidgetDescriptor;
+import org.csstudio.display.builder.model.WidgetFactory;
+import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.ModelWriter;
+import org.csstudio.display.builder.model.persist.WidgetClassesService;
+import org.csstudio.display.builder.model.util.ModelResourceUtil;
+import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
+import org.csstudio.display.builder.model.widgets.LabelWidget;
+import org.csstudio.display.builder.model.widgets.PVWidget;
+import org.csstudio.display.builder.model.widgets.PictureWidget;
+import org.csstudio.display.builder.model.widgets.SymbolWidget;
+import org.csstudio.display.builder.model.widgets.WebBrowserWidget;
+import org.csstudio.display.builder.representation.ToolkitRepresentation;
+import org.csstudio.display.builder.representation.javafx.widgets.SymbolRepresentation;
+
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Dimension2D;
 import javafx.geometry.Point2D;
@@ -38,36 +69,6 @@ import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
-import javax.imageio.ImageIO;
-import javax.swing.text.Document;
-import javax.swing.text.html.HTMLEditorKit;
-import javax.swing.text.rtf.RTFEditorKit;
-import org.csstudio.display.builder.editor.DisplayEditor;
-import org.csstudio.display.builder.editor.EditorUtil;
-import org.csstudio.display.builder.editor.Messages;
-import org.csstudio.display.builder.editor.palette.Palette;
-import org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker;
-import org.csstudio.display.builder.model.ArrayWidgetProperty;
-import org.csstudio.display.builder.model.DisplayModel;
-import org.csstudio.display.builder.model.Widget;
-import org.csstudio.display.builder.model.WidgetDescriptor;
-import org.csstudio.display.builder.model.WidgetFactory;
-import org.csstudio.display.builder.model.WidgetProperty;
-import org.csstudio.display.builder.model.persist.ModelReader;
-import org.csstudio.display.builder.model.persist.ModelWriter;
-import org.csstudio.display.builder.model.persist.WidgetClassesService;
-import org.csstudio.display.builder.model.util.ModelResourceUtil;
-import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
-import org.csstudio.display.builder.model.widgets.LabelWidget;
-import org.csstudio.display.builder.model.widgets.PVWidget;
-import org.csstudio.display.builder.model.widgets.PictureWidget;
-import org.csstudio.display.builder.model.widgets.SymbolWidget;
-import org.csstudio.display.builder.model.widgets.WebBrowserWidget;
-import org.csstudio.display.builder.representation.ToolkitRepresentation;
-import org.csstudio.display.builder.representation.javafx.widgets.SymbolRepresentation;
-
-import static javafx.scene.paint.Color.GRAY;
-import static org.csstudio.display.builder.editor.Plugin.logger;
 
 /** Helper for widget drag/drop
  *
@@ -493,14 +494,9 @@ public class WidgetTransfer {
 
         final DisplayModel model = selection_tracker.getModel();
         final SymbolWidget widget = (SymbolWidget) SymbolWidget.WIDGET_DESCRIPTOR.createWidget();
-        ArrayWidgetProperty<WidgetProperty<String>> propSymbols = widget.propSymbols();
 
         for ( int i = 0; i < fileNames.size(); i++ ) {
-            if ( i < propSymbols.size() ) {
-                propSymbols.getElement(i).setValue(fileNames.get(i));
-            } else {
-                widget.addSymbol(fileNames.get(i));
-            }
+            widget.addOrReplaceSymbol(i, fileNames.get(i));
         }
 
         final int index = widgets.size();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -422,7 +422,10 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         model_widget.propPVName().addPropertyListener(this::contentChanged);
 
         model_widget.propSymbols().addPropertyListener(this::imagesChanged);
-        model_widget.propSymbols().getValue().stream().forEach(p -> p.addPropertyListener(imagePropertyListener));
+        model_widget.propSymbols().getValue().stream().forEach(p -> {
+            p.removePropertyListener(imagePropertyListener);
+            p.addPropertyListener(imagePropertyListener);
+        });
 
         model_widget.propInitialIndex().addPropertyListener(this::initialIndexChanged);
 
@@ -622,11 +625,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
 
             for ( int i = 0; i < fileNames.size(); i++ ) {
-                if ( i < propSymbols.size() ) {
-                    propSymbols.getElement(i).setValue(fileNames.get(i));
-                } else {
-                    model_widget.addSymbol(fileNames.get(i));
-                }
+                model_widget.addOrReplaceSymbol(i, fileNames.get(i));
             }
 
         } finally {
@@ -647,7 +646,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
             }
 
             if ( fileNames == null ) {
-                logger.log(Level.WARNING, "Empty list of file names.");
+                logger.log(Level.WARNING, "Empty list of file names for " + model_widget);
             } else {
 
                 imagesList.clear();
@@ -677,6 +676,9 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
                 toBeRemoved.stream().forEach(f -> imagesMap.remove(f));
 
+                // Trigger update of displayed image by selecting default image and then
+                // again the proper one
+                setImageIndex(-1);
                 setImageIndex(Math.min(Math.max(getImageIndex(), 0), imagesList.size() - 1));
                 maxSize = computeMaximumSize(model_widget);
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -59,12 +59,6 @@ class ContextMenuSupport
         this.instance = instance;
         menu.setAutoHide(true);
 
-        // Menu inherits styling of widget's node.
-        // Some widgets update the background color
-        // (TextEntryRepresentation).
-        // No way to prevent inheritance, so reset to the modena.css default:
-        menu.setStyle("-fx-control-inner-background: derive(-fx-base,80%);");
-
         final ToolkitListener tkl = new ToolkitListener()
         {
             @Override
@@ -72,7 +66,13 @@ class ContextMenuSupport
             {
                 final Node node = JFXBaseRepresentation.getJFXNode(widget);
                 fillMenu(node, widget);
-                menu.show(node, screen_x, screen_y);
+                // Use window, not node, to show menu for two reasons:
+                // 1) menu.show(node, ..) means menu is attached to node,
+                //    inheriting styles of nodes. For widgets that change background color
+                //    via style, those colors would then apply to the menu items as well.
+                // 2) Clicking outside the menu will close the menu, while it would remain
+                //    open when attached to the node.
+                menu.show(node.getScene().getWindow(), screen_x, screen_y);
             }
         };
 

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/DataPlot.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/DataPlot.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import java.util.logging.Level;
 
 import org.csstudio.javafx.rtplot.PointType;
@@ -67,6 +68,8 @@ public class DataPlot extends VBox
     /** Scan Client */
     private final ScanClient scan_client = new ScanClient(Preferences.host, Preferences.port);
 
+    private final LongConsumer scan_id_listener;
+
     /** Information about all scans */
     private ScanInfoModel scan_info_model;
 
@@ -91,9 +94,12 @@ public class DataPlot extends VBox
     /** Data for the plot, one entry for each (x_device, y_device) based on y_devices */
     private volatile List<ScanPlotDataProvider> plot_data = Collections.emptyList();
 
-    /** Constructor */
-    public DataPlot()
+    /** Constructor
+     *  @param scan_id_listener Will be invoked when user selects different scan
+     */
+    public DataPlot(final LongConsumer scan_id_listener)
     {
+        this.scan_id_listener = scan_id_listener;
         scan_selector.setTooltip(new Tooltip("Select a Scan"));
         x_device_selector.setTooltip(new Tooltip("Select device for horizontal axis"));
         add_y_device.setTooltip(new Tooltip("Add trace for another device to plot"));
@@ -234,6 +240,7 @@ public class DataPlot extends VBox
         last_scan_data = null;
         plot.setTitle(title);
         reader.setScanId(scan_id);
+        scan_id_listener.accept(scan_id);
     }
 
     /** @param device Device to use for X axis */

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/ScanDataPlotInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/ScanDataPlotInstance.java
@@ -18,6 +18,8 @@ import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 
+import javafx.application.Platform;
+
 /** Application instance for Scan Data Plot
  *  @author Kay Kasemir
  */
@@ -36,7 +38,7 @@ public class ScanDataPlotInstance implements AppInstance
         data_plot = create(scan_id);
         final URI input = ScanURI.createURI(scan_id);
         tab = new DockItemWithInput(this, data_plot, input, null, null);
-        tab.setLabel("Scan Plot #" + scan_id);
+        Platform.runLater(() -> tab.setLabel("Scan Plot #" + scan_id));
         tab.addCloseCheck(() ->
         {
             data_plot.stop();
@@ -47,9 +49,21 @@ public class ScanDataPlotInstance implements AppInstance
 
     private DataPlot create(final long scan_id)
     {
-        final DataPlot plot = new DataPlot();
+        final DataPlot plot = new DataPlot(this::updateScanId);
         plot.selectScan(scan_id);
         return plot;
+    }
+
+    /** @param scan_id New scan selected by user in DataPlot */
+    private void updateScanId(final long scan_id)
+    {
+        // Skip the initial call from
+        // Constructor -> create -> selectScan
+        if (tab == null)
+            return;
+        final URI input = ScanURI.createURI(scan_id);
+        tab.setInput(input);
+        Platform.runLater(() -> tab.setLabel("Scan Plot #" + scan_id));
     }
 
     @Override

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/datatable/ScanDataTableInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/datatable/ScanDataTableInstance.java
@@ -17,6 +17,8 @@ import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 
+import javafx.application.Platform;
+
 /** Application instance for Scan Data Table
  *  @author Kay Kasemir
  */
@@ -33,7 +35,7 @@ public class ScanDataTableInstance implements AppInstance
         final DataTable data_table = create(scan_id);
         final URI input = ScanURI.createURI(scan_id);
         tab = new DockItemWithInput(this, data_table, input, null, null);
-        tab.setLabel("Scan Data #" + scan_id);
+        Platform.runLater(() -> tab.setLabel("Scan Data #" + scan_id));
         tab.addCloseCheck(() ->
         {
             data_table.dispose();

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/ScanEditorInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/ScanEditorInstance.java
@@ -30,6 +30,7 @@ import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 
+import javafx.application.Platform;
 import javafx.stage.FileChooser.ExtensionFilter;
 
 /** Application instance for Scan Editor
@@ -104,6 +105,7 @@ public class ScanEditorInstance  implements AppInstance
         // resource will find this instance and not start
         // another instance
         tab.setInput(ScanURI.createURI(id));
+        Platform.runLater(() -> tab.setLabel("Scan Editor #" + id));
 
         JobManager.schedule("Read Scan", monitor ->
         {

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
@@ -252,21 +252,30 @@ public class ScansTable extends VBox
         scan_table.setOnContextMenuRequested(event ->
         {
             // Update menu based on selected scan and states of scans in the table
+            // Start with benign, "read only" commands, then end with commands that
+            // do something like re-submit, abort, remove
             menu.getItems().setAll(server_info, new SeparatorMenuItem());
 
             final List<ScanInfo> selection = scan_table.getSelectionModel().getSelectedItems().stream().map(proxy -> proxy.info).collect(Collectors.toList());
             if (selection.size() == 1)
             {
+                // View data, plot, possibly commands
                 menu.getItems().add(new OpenScanDataTableAction(selection.get(0).getId()));
                 menu.getItems().add(new OpenScanDataPlotAction(selection.get(0).getId()));
-                menu.getItems().add(new SeparatorMenuItem());
 
                 final boolean have_commands = selection.get(0).getState() != ScanState.Logged;
                 if (have_commands)
                 {
-                    menu.getItems().add(new ReSubmitScanAction(scan_client, selection.get(0)));
-                    menu.getItems().add(new SaveScanAction(this, scan_client, selection.get(0)));
                     menu.getItems().add(new OpenScanEditorAction(selection.get(0).getId()));
+                    menu.getItems().add(new SaveScanAction(this, scan_client, selection.get(0)));
+                }
+
+                menu.getItems().add(new SeparatorMenuItem());
+
+                // Resubmit
+                if (have_commands)
+                {
+                    menu.getItems().add(new ReSubmitScanAction(scan_client, selection.get(0)));
                     menu.getItems().add(new SeparatorMenuItem());
                 }
             }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/dataplot/DataPlotDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/dataplot/DataPlotDemo.java
@@ -20,7 +20,7 @@ public class DataPlotDemo extends Application
     @Override
     public void start(final Stage stage) throws Exception
     {
-        final DataPlot plot = new DataPlot();
+        final DataPlot plot = new DataPlot(id -> System.err.println("Selected scan #" + id));
         final Scene scene = new Scene(plot, 800, 600);
         stage.setScene(scene);
         stage.show();

--- a/core/framework/src/main/java/org/phoebus/framework/workbench/Locations.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/Locations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,8 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class Locations
 {
-    private static final String PHOEBUS_INSTALL = "phoebus.install";
-    private static final String PHOEBUS_USER = "phoebus.user";
+    public static final String PHOEBUS_INSTALL = "phoebus.install";
+    public static final String PHOEBUS_USER = "phoebus.user";
 
     /** Initialize locations */
     public static void initialize()

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -146,6 +146,7 @@ public class DockItemWithInput extends DockItem
      *  The tab tooltip indicates complete input,
      *  while tab label will be set to basic name (sans path and extension).
      *  For custom name, call <code>setLabel</code> after updating input
+     *  in <code>Platform.runLater()</code>
      *
      *  @param input Input
      *  @see DockItemWithInput#setLabel(String)

--- a/phoebus-product/src/main/resources/logging.properties
+++ b/phoebus-product/src/main/resources/logging.properties
@@ -49,11 +49,12 @@ org.phoebus.applications.pvtree.level = WARNING
 org.phoebus.archive.reader.level = WARNING
 org.phoebus.security.level = WARNING
 org.csstudio.trends.databrowser3.level = WARNING
-org.csstudio.display.builder.level = CONFIG
-org.csstudio.display.builder.runtime.level = CONFIG
+org.csstudio.display.builder.level = WARNING
+org.csstudio.display.builder.model.level = WARNING
+org.csstudio.display.builder.runtime.level = WARNING
 org.csstudio.javafx.rtplot.level = CONFIG
 org.phoebus.applications.alarm.level = INFO
 org.phoebus.applications.email.level = WARNING
-
+org.csstudio.scan.level = WARNING
 
 


### PR DESCRIPTION
Scan UI fixes.

Setting `-Dphoebus.user=/some/dir` would move the user location used for mementos from the default `$HOME/.phoebus` to the desired location, but the preferences stayed in `$HOME/.phoebus`. Now the preferences use `phoebus.user` as well, so mementos and preference tree stay together.