### PR TITLE
Context menu additions

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -23,8 +23,10 @@ import org.phoebus.applications.email.actions.SendEmailAction;
 import org.phoebus.framework.persistence.Memento;
 import org.phoebus.logbook.ui.menu.SendLogbookAction;
 import org.phoebus.ui.application.SaveSnapshotAction;
+import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ClearingTextField;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
 import org.phoebus.ui.text.RegExHelper;
@@ -343,8 +345,11 @@ public class AlarmTableUI extends BorderPane
                 menu_items.add(new SeparatorMenuItem());
 
             if (AlarmUI.mayConfigure()  &&   selection.size() == 1)
+            {
                 menu_items.add(new ConfigureComponentAction(table, client, selection.get(0)));
-
+                menu_items.add(new SeparatorMenuItem());
+            }
+            menu_items.add(new PrintAction(DockPane.getActiveDockPane()));
             menu_items.add(new SaveSnapshotAction(table));
             menu_items.add(new SendEmailAction(table, "Alarm Snapshot", this::list_alarms, () -> Screenshot.imageFromNode(this)));
             menu_items.add(new SendLogbookAction(table, "Alarm Snapshot", this::list_alarms, () -> Screenshot.imageFromNode(this)));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -23,7 +23,6 @@ import org.phoebus.applications.email.actions.SendEmailAction;
 import org.phoebus.framework.persistence.Memento;
 import org.phoebus.logbook.ui.menu.SendLogbookAction;
 import org.phoebus.ui.application.SaveSnapshotAction;
-import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ClearingTextField;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.PrintAction;
@@ -349,7 +348,7 @@ public class AlarmTableUI extends BorderPane
                 menu_items.add(new ConfigureComponentAction(table, client, selection.get(0)));
                 menu_items.add(new SeparatorMenuItem());
             }
-            menu_items.add(new PrintAction(DockPane.getActiveDockPane()));
+            menu_items.add(new PrintAction(this));
             menu_items.add(new SaveSnapshotAction(table));
             menu_items.add(new SendEmailAction(table, "Alarm Snapshot", this::list_alarms, () -> Screenshot.imageFromNode(this)));
             menu_items.add(new SendLogbookAction(table, "Alarm Snapshot", this::list_alarms, () -> Screenshot.imageFromNode(this)));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -368,7 +368,8 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
                     menu_items.add(new RemoveComponentAction(tree_view, model, selection));
                 }
             }
-
+            
+            menu_items.add(new SeparatorMenuItem());
             menu_items.add(new SaveSnapshotAction(DockPane.getActiveDockPane()));
             menu_items.add(new SendEmailAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));
             menu_items.add(new SendLogbookAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -371,7 +371,7 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
             }
             
             menu_items.add(new SeparatorMenuItem());
-            menu_items.add(new PrintAction(DockPane.getActiveDockPane()));
+            menu_items.add(new PrintAction(tree_view));
             menu_items.add(new SaveSnapshotAction(DockPane.getActiveDockPane()));
             menu_items.add(new SendEmailAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));
             menu_items.add(new SendLogbookAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -33,6 +33,7 @@ import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
 import org.phoebus.ui.javafx.TreeHelper;
@@ -370,6 +371,7 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
             }
             
             menu_items.add(new SeparatorMenuItem());
+            menu_items.add(new PrintAction(DockPane.getActiveDockPane()));
             menu_items.add(new SaveSnapshotAction(DockPane.getActiveDockPane()));
             menu_items.add(new SendEmailAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));
             menu_items.add(new SendLogbookAction(tree_view, "Alarm Screenshot", "See alarm tree screenshot", () -> Screenshot.imageFromNode(tree_view)));

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/Messages.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/Messages.java
@@ -34,6 +34,7 @@ public class Messages
                          Remove,
                          Remove_Tooltip,
                          Search,
+                         SearchAvailableItems,
                          Selected,
                          SelectLevelTooltip,
                          Submit,

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
@@ -86,6 +86,7 @@ public class SendLogbookAction extends MenuItem
             logEntryBuilder.appendDescription(body);
 
         if (image_file != null)
+        {
             try
             {
                 final Attachment attachment = AttachmentImpl.of(image_file, "image", false);
@@ -95,7 +96,8 @@ public class SendLogbookAction extends MenuItem
             {
                 logger.log(Level.WARNING, "Cannot attach " + image_file, ex);
             }
-
+        }
+        
         final LogEntry template = logEntryBuilder.createdDate(Instant.now()).build();
 
         final LogEntryDialog logEntryDialog = new LogEntryDialog(parent, template);

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/AttachmentsView.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/AttachmentsView.java
@@ -27,7 +27,7 @@ import javafx.scene.image.Image;
  */
 public class AttachmentsView extends Accordion
 {
-    private final TabPane          tabPane;
+    private final TabPane       tabPane;
     private final ImagesTab     images;
     private final FilesTab      files;
     private final PropertiesTab properties;
@@ -40,7 +40,10 @@ public class AttachmentsView extends Accordion
         images.setSnapshotNode(parent.getScene().getRoot());
         files      = new FilesTab();
         properties = new PropertiesTab();
-
+        
+        images.setImages(model.getImages());
+        files.setFiles(model.getFiles());
+        
         tabPane.getTabs().addAll(images, files, properties);
 
         TitledPane tPane = new TitledPane(Messages.Attachments, tabPane);
@@ -53,20 +56,8 @@ public class AttachmentsView extends Accordion
         return images.getImages();
     }
 
-    public void setImages(final List<Image> images)
-    {
-        this.images.setImages(images);
-    }
-
     public List<File> getFiles()
     {
         return files.getFiles();
     }
-
-    public void setFiles(final List<File> files)
-    {
-        this.files.setFiles(files);
-    }
-
-
 }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/ListSelectionDialog.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/ListSelectionDialog.java
@@ -207,6 +207,7 @@ public class ListSelectionDialog extends Dialog<Boolean>
         
         final ClearingTextField searchField = new ClearingTextField();
         searchField.setId(SEARCH_ID);
+        searchField.setTooltip(new Tooltip(Messages.SearchAvailableItems));
         searchField.textProperty().addListener((changeListener, oldVal, newVal) -> 
         {
             searchAvailableItemsForSubstring(newVal);

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryDialog.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryDialog.java
@@ -70,7 +70,11 @@ public class LogEntryDialog extends Dialog<LogEntry>
     
     public LogEntryDialog(final Node parent, LogEntry template)
     {
+        
         model = new LogEntryModel(parent);
+
+        if (null != template)
+            setModelTemplate(template);
 
         content = new VBox();
 
@@ -79,9 +83,6 @@ public class LogEntryDialog extends Dialog<LogEntry>
 
         // Images, Files, Properties
         attachmentsView = new AttachmentsView(parent, model);
-
-        if (null != template)
-            setModelTemplate(template);
 
         // Let the Text Area grow to the bottom.
         VBox.setVgrow(logEntryFields,  Priority.ALWAYS);
@@ -148,7 +149,7 @@ public class LogEntryDialog extends Dialog<LogEntry>
      */
     private void setModelTemplate(LogEntry template)
     {
-        // model.setTitle(template.getTitle());
+        model.setTitle(template.getTitle());
         model.setText(template.getDescription());
         Collection<Logbook> logbooks = template.getLogbooks();
         logbooks.forEach(logbook->
@@ -184,9 +185,8 @@ public class LogEntryDialog extends Dialog<LogEntry>
             else if (attachment.getContentType().equals(Attachment.CONTENT_FILE))
                 files.add(file);
         }
-
-        attachmentsView.setImages(images);
-        attachmentsView.setFiles(files);
+        model.setImages(images);
+        model.setFiles(files);
     }
 
     /** Set a runnable to be executed <b>after</b> the log entry submission occurs. */

--- a/app/logbook/ui/src/main/resources/org/phoebus/logbook/ui/messages.properties
+++ b/app/logbook/ui/src/main/resources/org/phoebus/logbook/ui/messages.properties
@@ -21,6 +21,7 @@ Properties=Properties
 Remove=Remove
 Remove_Tooltip=Remove the selected items.
 Search=Search available:
+SearchAvailableItems=Search the list of available items.
 Selected=Selected
 SelectLevelTooltip=Select the log entry level.
 Submit=Submit

--- a/app/pvtable/.classpath
+++ b/app/pvtable/.classpath
@@ -9,5 +9,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
 	<classpathentry kind="src" path="/core-security"/>
+	<classpathentry kind="src" path="/app-email"/>
+	<classpathentry kind="src" path="/app-logbook-ui"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/app/pvtable/build.xml
+++ b/app/pvtable/build.xml
@@ -1,7 +1,17 @@
 <project default="app-pvtable">
   <import file="../../dependencies/ant_settings.xml"/>
 
-  <target name="app-pvtable" depends="compile-app">
+  <target name="app-pvtable">
+    <mkdir dir="${classes}"/>
+  	  <javac destdir="${classes}">
+  	    <src path="${src}"/>
+  	    <src path="${test}"/>
+  	    <classpath>
+  	      <path refid="app-classpath"/>
+  	      <pathelement path="../logbook/ui/${build}/app-logbook-ui-${version}.jar"/>
+  	      <pathelement path="../email/${build}/app-email-${version}.jar"/>
+  	      </classpath>
+  	  </javac>
     <jar destfile="${build}/app-pvtable-${version}.jar">
       <fileset dir="${classes}"/>
       <fileset dir="${resources}"/>

--- a/app/pvtable/build.xml
+++ b/app/pvtable/build.xml
@@ -5,7 +5,6 @@
     <mkdir dir="${classes}"/>
   	  <javac destdir="${classes}">
   	    <src path="${src}"/>
-  	    <src path="${test}"/>
   	    <classpath>
   	      <path refid="app-classpath"/>
   	      <pathelement path="../logbook/ui/${build}/app-logbook-ui-${version}.jar"/>

--- a/app/pvtable/pom.xml
+++ b/app/pvtable/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
-      <artifactId>app-logbook</artifactId>
+      <artifactId>app-logbook-ui</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
   </dependencies>

--- a/app/pvtable/pom.xml
+++ b/app/pvtable/pom.xml
@@ -45,5 +45,15 @@
       <artifactId>core-security</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+        <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-email</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-logbook</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -30,7 +30,6 @@ import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.autocomplete.PVAutocompleteMenu;
 import org.phoebus.ui.dialog.NumericInputDialog;
 import org.phoebus.ui.dnd.DataFormats;
-import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
@@ -641,7 +640,7 @@ public class PVTable extends VBox
             if (ContextMenuHelper.addSupportedEntries(table, menu))
                 menu.getItems().add(new SeparatorMenuItem());
             
-            menu.getItems().add(new PrintAction(DockPane.getActiveDockPane()));
+            menu.getItems().add(new PrintAction(this));
             menu.getItems().add(new SaveSnapshotAction(table));
             menu.getItems().add(new SendEmailAction(table, "PV Snapshot", () -> "See attached screenshot.", () -> Screenshot.imageFromNode(this)));
             menu.getItems().add(new SendLogbookAction(table, "PV Snapshot", () -> "See attached screenshot.", () -> Screenshot.imageFromNode(this)));

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.phoebus.applications.email.actions.SendEmailAction;
 import org.phoebus.applications.pvtable.PVTableApplication;
 import org.phoebus.applications.pvtable.Settings;
 import org.phoebus.applications.pvtable.model.PVTableItem;
@@ -22,11 +23,16 @@ import org.phoebus.applications.pvtable.model.PVTableModelListener;
 import org.phoebus.applications.pvtable.model.VTypeHelper;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.SelectionService;
+import org.phoebus.logbook.ui.menu.SendLogbookAction;
 import org.phoebus.security.authorization.AuthorizationService;
 import org.phoebus.ui.application.ContextMenuHelper;
+import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.autocomplete.PVAutocompleteMenu;
 import org.phoebus.ui.dialog.NumericInputDialog;
 import org.phoebus.ui.dnd.DataFormats;
+import org.phoebus.ui.docking.DockPane;
+import org.phoebus.ui.javafx.PrintAction;
+import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
 import org.phoebus.ui.pv.SeverityColors;
 import org.phoebus.vtype.VEnum;
@@ -628,16 +634,22 @@ public class PVTable extends VBox
                         disableSaveRestore();
                     }
                 });
-                menu.getItems().addAll(new SeparatorMenuItem(), disableSaveRestore);
+                menu.getItems().addAll(disableSaveRestore, new SeparatorMenuItem());
             }
 
             // Add PV entries
-            ContextMenuHelper.addSupportedEntries(table, menu);
+            if (ContextMenuHelper.addSupportedEntries(table, menu))
+                menu.getItems().add(new SeparatorMenuItem());
+            
+            menu.getItems().add(new PrintAction(DockPane.getActiveDockPane()));
+            menu.getItems().add(new SaveSnapshotAction(table));
+            menu.getItems().add(new SendEmailAction(table, "PV Snapshot", () -> "See attached screenshot.", () -> Screenshot.imageFromNode(this)));
+            menu.getItems().add(new SendLogbookAction(table, "PV Snapshot", () -> "See attached screenshot.", () -> Screenshot.imageFromNode(this)));
         });
         
         table.setContextMenu(menu);
     }
-
+    
     private boolean maySetToSaveRestore()
     {
         return AuthorizationService.hasAuthorization("disable_save_restore");

--- a/app/pvtree/.classpath
+++ b/app/pvtree/.classpath
@@ -9,5 +9,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-types"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
+	<classpathentry kind="src" path="/app-email"/>
+	<classpathentry kind="src" path="/app-logbook-ui"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/app/pvtree/build.xml
+++ b/app/pvtree/build.xml
@@ -1,8 +1,19 @@
 <project default="app-pvtree">
   <import file="../../dependencies/ant_settings.xml"/>
-
-  <target name="app-pvtree" depends="compile-app">
-    <jar destfile="${build}/app-pvtree-${version}.jar">
+  
+  <target name="app-pvtree">
+    <mkdir dir="${classes}"/>
+    <javac destdir="${classes}">
+      <src path="${src}"/>
+      <src path="${test}"/>
+      <classpath>
+        <path refid="app-classpath"/>
+        <pathelement path="../logbook/ui/${build}/app-logbook-ui-${version}.jar"/>
+        <pathelement path="../email/${build}/app-email-${version}.jar"/>
+      </classpath>
+    </javac>
+ 
+  	<jar destfile="${build}/app-pvtree-${version}.jar">
       <fileset dir="${classes}"/>
       <fileset dir="${resources}"/>
     </jar>

--- a/app/pvtree/pom.xml
+++ b/app/pvtree/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
-      <artifactId>app-logbook</artifactId>
+      <artifactId>app-logbook-ui</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
   </dependencies>

--- a/app/pvtree/pom.xml
+++ b/app/pvtree/pom.xml
@@ -40,5 +40,15 @@
       <artifactId>core-types</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+        <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-email</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-logbook</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -35,5 +35,15 @@
       <artifactId>core-pv</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-email</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-logbook</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -35,15 +35,5 @@
       <artifactId>core-pv</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>org.phoebus</groupId>
-      <artifactId>app-email</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.phoebus</groupId>
-      <artifactId>app-logbook</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 </project>

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -37,14 +37,15 @@ public class ContextMenuHelper
      *
      *  @param parent_node Parent node, usually owner of the context menu
      *  @param menu Menu where selection-based entries will be added
+     *  @return <code>true</code> if a supported entry was added.
      */
-    public static void addSupportedEntries(final Node parent_node, final ContextMenu menu)
+    public static boolean addSupportedEntries(final Node parent_node, final ContextMenu menu)
     {
         final Window window = parent_node.getScene().getWindow();
         if (! (window instanceof Stage))
         {
             logger.log(Level.WARNING, "Expected 'Stage' for context menu, got " + window);
-            return;
+            return false;
         }
         final Stage stage = (Stage) window;
         // Assert that this window's dock pane is the active one.
@@ -52,6 +53,9 @@ public class ContextMenuHelper
         //  always activate the stage)
         DockStage.setActiveDockStage(stage);
 
+        if (ContextMenuService.getInstance().listSupportedContextMenuEntries().isEmpty())
+            return false;
+        
         for (ContextMenuEntry<?> entry : ContextMenuService.getInstance().listSupportedContextMenuEntries())
         {
             final MenuItem item = new MenuItem(entry.getName());
@@ -72,5 +76,7 @@ public class ContextMenuHelper
             });
             menu.getItems().add(item);
         }
+        
+        return true;
     }
 }


### PR DESCRIPTION
Added PrintAction to the AlarmTree and AlarmTable context menus.

Added PrintAction, SendEmailAction, SendLogbookAction, and SnapshotAction to the PVTree and PVTable context menus.

PrintAction takes the current JavaFX node, not the active DockPane.

Logbook enties and emails are initialized with titles, text, and screenshots when appropriate.