### PR TITLE
Alarm logger readme

### DIFF
--- a/app/alarm/logging-ui/.classpath
+++ b/app/alarm/logging-ui/.classpath
@@ -7,8 +7,6 @@
   </classpathentry>
   <classpathentry kind="src" output="target/classes" path="src/main/java"/>
   <classpathentry kind="src" output="target/classes" path="src/main/resources"/>
-  <classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-  <classpathentry kind="src" output="target/test-classes" path="src/test/resources"/>
   <classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>
   <classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
   <classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>

--- a/services/alarm-config-logger/.classpath
+++ b/services/alarm-config-logger/.classpath
@@ -11,17 +11,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/services/alarm-logger/.classpath
+++ b/services/alarm-logger/.classpath
@@ -2,8 +2,6 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/dependencies"/>

--- a/services/alarm-logger/README.md
+++ b/services/alarm-logger/README.md
@@ -9,7 +9,9 @@ Logging alarm state and other messages to an elastic back end.
 
     bin/elasticsearch
 
-elasticsearch defaults to port 9200, however if elasticsearch is configured to use another port this can be set in the alarm\_logging\_preferences.properties file.
+elasticsearch defaults to port 9200, however if elasticsearch is configured to use another port this can be set in
+
+    /src/main/resources/alarm_logging_preferences.properties
 
 
 ### Create an elasticsearch index

--- a/services/alarm-logger/README.md
+++ b/services/alarm-logger/README.md
@@ -1,7 +1,35 @@
-# alarm logging
-logging alarm state and other messages to an elastic backend.
+# Alarm Logging
 
-### Dependencies ###
-1. elastic version 6+
-to Install elastic(https://www.elastic.co/products).
+Logging alarm state and other messages to an elastic back end.
 
+## Dependencies ##
+1. elastic version 6+ ([to install elastic](https://www.elastic.co/products)).
+
+### Start elasticsearch
+
+    bin/elasticsearch
+
+elasticsearch defaults to port 9200, however if elasticsearch is configured to use another port this can be set in the alarm\_logging\_preferences.properties file.
+
+
+### Create an elasticsearch index
+
+Once, elasticsearch is set up, run the create\_alarm\_index.sh script.
+
+The  argument to the start up script should be the root of the alarm tree where all letters are lower case.
+
+For example, with the alarm tree titled 'Accelerator', the script would be run like
+
+    sh create_alarm_index.sh accelerator
+    
+this would result in an elasticsearch index titled 'accelerator_alarms' to be created.
+
+### Run the alarm logging service
+
+Start the alarm logging service
+    
+    java AlarmService
+    
+    java -jar service-alarm-logger.jar
+    
+    ...

--- a/services/alarm-logger/src/main/resources/alarm_logging_service.properties
+++ b/services/alarm-logger/src/main/resources/alarm_logging_service.properties
@@ -1,5 +1,5 @@
 # location of elastic node/s
-es_host=130.199.219.152
+#es_host=
 es_port=9200
 
 # Kafka alarm topics


### PR DESCRIPTION
Tweaks to properites and classpath files.

The .classpath files contained references to non-existent "test" directories.
 
The alarm_logging_service.properties file had an IP address set in it. Commenting this out let the address default to localhost.

Updates to the readme to flesh out setup instructions.