### PR TITLE
Alarm state logger fixes

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
@@ -19,6 +19,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.phoebus.applications.alarm.messages.AlarmStateMessage;
 import org.phoebus.applications.alarm.messages.MessageParser;
+import org.phoebus.applications.alarm.model.AlarmTreePath;
 
 public class AlarmStateLogger implements Runnable {
 
@@ -64,7 +65,8 @@ public class AlarmStateLogger implements Runnable {
                         Matcher matcher = pattern.matcher(key);
                         value.setConfig(key);
                         matcher.find();
-                        value.setPv(matcher.group());
+                        String[] tokens = AlarmTreePath.splitPath(key);
+                        value.setPv(tokens[tokens.length - 1]);
                         return new KeyValue<String, AlarmStateMessage>(key, value);
                     }
                 });

--- a/services/alarm-logger/startup/create_alarm_index.sh
+++ b/services/alarm-logger/startup/create_alarm_index.sh
@@ -20,14 +20,14 @@ curl -H 'Content-Type: application/json' -XPUT http://${es_host}:${es_port}/${1}
             "type" : "text"
           },
           "config" : {
-            "type" : "text"
+            "type" : "keyword"
           },
           "pv" : {
             "type" : "text",
             "analyzer" : "keyword"
           },
           "severity" : {
-            "type" : "text"
+            "type" : "keyword"
           },
           "message" : {
             "type" : "text"
@@ -40,7 +40,7 @@ curl -H 'Content-Type: application/json' -XPUT http://${es_host}:${es_port}/${1}
             "format" : "yyyy-MM-dd HH:mm:ss.SSS"
           },
           "current_severity" : {
-            "type" : "text"
+            "type" : "keyword"
           },
           "current_message" : {
             "type" : "text"


### PR DESCRIPTION
-  AlarmStateLogger: Extract PV using AlarmTreePath.splitPath()

   Using the regex method resulted in a config of
   "/Accelerator/sim://sine(0, 10, 1)" having a PV field of
   "sim://sine(0,".

   Using splitPath, the PV field is now "sine(0, 10, 1)".


- Make config, severity, current_severity keyword.

   This allows searches and aggregations to be performed upon these fields.