### PR TITLE
Make dockpane tab name more readable

### DIFF
--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
@@ -16,8 +16,8 @@ public class LogEntryCalenderApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryCalenderApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryCalenderApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "logEntryCalender";
-    public static final String DISPLAYNAME = "LogEntryCalender";
+    public static final String NAME = "Log Entry Calender";
+    public static final String DISPLAYNAME = "Log Entry Calender";
 
     private static final String SUPPORTED_SCHEMA = "logCalender";
     private LogFactory logFactory;

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
@@ -27,8 +27,7 @@ public class LogEntryCalenderApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
-    public String getDisplayName()
-    {
+    public String getDisplayName() {
         return DISPLAYNAME;
     }
     

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
@@ -16,7 +16,7 @@ public class LogEntryCalenderApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryCalenderApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryCalenderApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "Log Entry Calender";
+    public static final String NAME = "logEntryCalender";
     public static final String DISPLAYNAME = "Log Entry Calender";
 
     private static final String SUPPORTED_SCHEMA = "logCalender";
@@ -27,6 +27,11 @@ public class LogEntryCalenderApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    public String getDisplayName()
+    {
+        return DISPLAYNAME;
+    }
+    
     @Override
     public String getName() {
         return NAME;

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderApp.java
@@ -27,6 +27,7 @@ public class LogEntryCalenderApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    @Override
     public String getDisplayName() {
         return DISPLAYNAME;
     }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
@@ -16,7 +16,7 @@ public class LogEntryListApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryListApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryListApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "logEntryList";
+    public static final String NAME = "Log Entry List";
     public static final String DISPLAYNAME = "Log Entry List";
 
     private static final String SUPPORTED_SCHEMA = "logbook";

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
@@ -27,8 +27,7 @@ public class LogEntryListApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
-    public String getDisplayName()
-    {
+    public String getDisplayName() {
         return DISPLAYNAME;
     }
     

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
@@ -16,7 +16,7 @@ public class LogEntryListApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryListApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryListApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "Log Entry List";
+    public static final String NAME = "logEntryList";
     public static final String DISPLAYNAME = "Log Entry List";
 
     private static final String SUPPORTED_SCHEMA = "logbook";
@@ -27,6 +27,11 @@ public class LogEntryListApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    public String getDisplayName()
+    {
+        return DISPLAYNAME;
+    }
+    
     @Override
     public String getName() {
         return NAME;

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryListApp.java
@@ -27,6 +27,7 @@ public class LogEntryListApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    @Override
     public String getDisplayName() {
         return DISPLAYNAME;
     }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
@@ -16,7 +16,7 @@ public class LogEntryTableApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryTableApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryTableApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "Log Entry Table";
+    public static final String NAME = "logEntryTable";
     public static final String DISPLAYNAME = "Log Entry Table";
 
     private static final String SUPPORTED_SCHEMA = "logbook";
@@ -27,6 +27,11 @@ public class LogEntryTableApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    public String getDisplayName()
+    {
+        return DISPLAYNAME;
+    }
+    
     @Override
     public String getName() {
         return NAME;

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
@@ -27,8 +27,7 @@ public class LogEntryTableApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
-    public String getDisplayName()
-    {
+    public String getDisplayName() {
         return DISPLAYNAME;
     }
     

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
@@ -16,7 +16,7 @@ public class LogEntryTableApp implements AppResourceDescriptor {
 
     public static final Logger logger = Logger.getLogger(LogEntryTableApp.class.getName());
     static final Image icon = ImageCache.getImage(LogEntryTableApp.class, "/icons/logbook-16.png");
-    public static final String NAME = "logEntryTable";
+    public static final String NAME = "Log Entry Table";
     public static final String DISPLAYNAME = "Log Entry Table";
 
     private static final String SUPPORTED_SCHEMA = "logbook";

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryTableApp.java
@@ -27,6 +27,7 @@ public class LogEntryTableApp implements AppResourceDescriptor {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookUiPreferences.logbook_factory);
     }
 
+    @Override
     public String getDisplayName() {
         return DISPLAYNAME;
     }


### PR DESCRIPTION
The dockpane tab names were harder to read as "applicationName" than "Application Name".