### PR TITLE
Alarm config xml 275

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
-package org.phoebus.applications.alarm.server;
+package org.phoebus.applications.alarm;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -31,7 +31,7 @@ public class ResettableTimeout
 {
     private final long timeout_secs;
 
-	private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("Timer"));
+	private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
     private final CountDownLatch no_more_messages = new CountDownLatch(1);
     private final Runnable signal_no_more_messages = () -> no_more_messages.countDown();
     private final AtomicReference<ScheduledFuture<?>> timeout = new AtomicReference<>();
@@ -44,7 +44,7 @@ public class ResettableTimeout
 	}
 
 	/** Reset the timer. As long as this is called within the timeout, we keep running */
-    void reset()
+    public void reset()
     {
         final ScheduledFuture<?> previous = timeout.getAndSet(timer.schedule(signal_no_more_messages, timeout_secs, TimeUnit.SECONDS));
         if (previous != null)

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmConfigMonitor.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmConfigMonitor.java
@@ -30,7 +30,7 @@ import org.phoebus.applications.alarm.model.AlarmTreeItem;
  *  @author Evan Smith
  */
 @SuppressWarnings("nls")
-public class UpdateMonitor
+public class AlarmConfigMonitor
 {
     private final AlarmClient client;
     private final ResettableTimeout timer;
@@ -76,7 +76,7 @@ public class UpdateMonitor
     /** @param idle_secs Seconds after which we decide that there's a pause in configuration updates
      *  @param client AlarmClient to check for a pause in updates
      */
-    public UpdateMonitor(final long idle_secs, final AlarmClient client)
+    public AlarmConfigMonitor(final long idle_secs, final AlarmClient client)
     {
         this.client = client;
         timer = new ResettableTimeout(idle_secs);

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/UpdateMonitor.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/UpdateMonitor.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.alarm.client;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.phoebus.applications.alarm.ResettableTimeout;
+import org.phoebus.applications.alarm.model.AlarmTreeItem;
+
+/** Check for a pause in alarm client updates.
+ *
+ *  <p>When starting up, the alarm client reads all the past configuration
+ *  updates.
+ *  There is no perfect way to determine that we received "all" configuration
+ *  information, because further updates could happen at any time,
+ *  whenever a user decides to modify the alarm tree.
+ *
+ *  <p>The best approach is to check for a pause.
+ *  Not receiving any alarm client updates for a while
+ *  likely means that we have a stable configuration.
+ *
+ *  <p>This helper awaits such a pause in updates.
+ *
+ *  @author Kay Kasemir
+ *  @author Evan Smith
+ */
+@SuppressWarnings("nls")
+public class UpdateMonitor
+{
+    private final AlarmClient client;
+    private final ResettableTimeout timer;
+    private final AtomicInteger updates = new AtomicInteger();
+
+    private final AlarmClientListener updateListener = new AlarmClientListener()
+    {
+        @Override
+        public void serverStateChanged(final boolean alive)
+        {
+            //NOP
+        }
+
+        @Override
+        public void serverModeChanged(boolean maintenance_mode)
+        {
+            //NOP
+        }
+
+        @Override
+        public void itemAdded(final AlarmTreeItem<?> item)
+        {
+            // Reset the timer when receiving update
+            timer.reset();
+            updates.incrementAndGet();
+        }
+
+        @Override
+        public void itemRemoved(final AlarmTreeItem<?> item)
+        {
+            // Reset the timer when receiving update
+            timer.reset();
+            updates.incrementAndGet();
+        }
+
+        @Override
+        public void itemUpdated(final AlarmTreeItem<?> item)
+        {
+            //NOP
+        }
+    };
+
+    /** @param idle_secs Seconds after which we decide that there's a pause in configuration updates
+     *  @param client AlarmClient to check for a pause in updates
+     */
+    public UpdateMonitor(final long idle_secs, final AlarmClient client)
+    {
+        this.client = client;
+        timer = new ResettableTimeout(idle_secs);
+    }
+
+    /** Wait for a pause in configuration updates
+     *  @param timeout If there is no pause in configuration updates for this time, give up
+     *  @throws Exception on timeout, i.e. could not detect a pause in updates
+     */
+    public void waitForPauseInUpdates(final long timeout) throws Exception
+    {
+        client.addListener(updateListener);
+        if (! timer.awaitTimeout(timeout))
+             throw new Exception(timeout + " seconds have passed, I give up waiting for updates to subside.");
+        // Reset the counter to count any updates received after we decide to continue.
+        updates.set(0);
+    }
+
+    /** @return Updates that were received after <code>waitForPauseInUpdates</code> */
+    public int getCount()
+    {
+        return updates.get();
+    }
+
+    /** Call when no longer interested in checking updates */
+    public void dispose()
+    {
+        client.removeListener(updateListener);
+        timer.shutdown();
+    }
+}

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelSnapshotDemo.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelSnapshotDemo.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.alarm;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+import org.phoebus.applications.alarm.client.AlarmClient;
+import org.phoebus.applications.alarm.client.AlarmConfigMonitor;
+import org.phoebus.applications.alarm.model.xml.XmlModelWriter;
+
+/** Captures a snapshot of alarm config and writes as XML
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class AlarmModelSnapshotDemo
+{
+	@Test
+	public void testAlarmModelWriter() throws Exception
+	{
+	    // Get alarm configuration
+	    final AlarmClient client = new AlarmClient(AlarmDemoSettings.SERVERS, AlarmDemoSettings.ROOT);
+
+	    System.out.println("Wait for stable configuration, i.e. no changes for 4 seconds...");
+
+	    // Wait until we have a snapshot, i.e. no more changes for 4 seconds
+	    final AlarmConfigMonitor monitor = new AlarmConfigMonitor(4, client);
+	    monitor.waitForPauseInUpdates(30);
+
+	    System.out.println("Alarm configuration:");
+
+
+		final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+		final XmlModelWriter xmlWriter = new XmlModelWriter(buf);
+		xmlWriter.write(client.getRoot());
+		xmlWriter.close();
+        final String xml = buf.toString();
+        System.out.println(xml);
+
+        final int changes = monitor.getCount();
+        if (changes > 0)
+            System.out.println("Bummer, there were " + changes + " updates to the configuration, might have to try this again...");
+        monitor.dispose();
+        client.shutdown();
+	}
+}

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
@@ -5,7 +5,7 @@
  *  which accompanies this distribution, and is available at
  *  http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
-package org.phoebus.applications.alarm.server;
+package org.phoebus.applications.alarm;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -15,6 +15,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.phoebus.applications.alarm.ResettableTimeout;
 
 /** JUnit test of the {@link ResettableTimeout}
  *  @author Kay Kasemir

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
@@ -11,11 +11,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.phoebus.applications.alarm.client.AlarmClient;
-import org.phoebus.applications.alarm.client.AlarmClientListener;
 import org.phoebus.applications.alarm.client.AlarmClientNode;
+import org.phoebus.applications.alarm.client.UpdateMonitor;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreeLeaf;
 import org.phoebus.applications.alarm.model.xml.XmlModelReader;
@@ -32,67 +31,7 @@ public class AlarmConfigTool
     /** Time the model must be stable for. Unit is seconds. Default is 4 seconds. */
     private static final long STABILIZATION_SECS = 4;
 
-    private class UpdateMonitor
-	{
-		private final ResettableTimeout timer = new ResettableTimeout(STABILIZATION_SECS);
-        private final AtomicInteger updates = new AtomicInteger();
-
-	    private final AlarmClientListener updateListener = new AlarmClientListener()
-        {
-            @Override
-            public void serverStateChanged(final boolean alive)
-            {
-                //NOP
-            }
-
-            @Override
-            public void serverModeChanged(boolean maintenance_mode)
-            {
-                //NOP
-            }
-
-            @Override
-            public void itemAdded(final AlarmTreeItem<?> item)
-            {
-            	// Reset the timer when receiving update
-                timer.reset();
-        		updates.incrementAndGet();
-            }
-
-            @Override
-            public void itemRemoved(final AlarmTreeItem<?> item)
-            {
-            	// Reset the timer when receiving update
-                timer.reset();
-        		updates.incrementAndGet();
-            }
-
-            @Override
-            public void itemUpdated(final AlarmTreeItem<?> item)
-            {
-            	//NOP
-            }
-        };
-
-        public void listen(AlarmClient client) throws Exception
-        {
-            client.addListener(updateListener);
-            if (! timer.awaitTimeout(30))
-                 throw new Exception("30 seconds have passed, I give up waiting for updates to subside.");
-        	// Reset the counter to count any updates received after we decide to continue.
-        	updates.set(0);
-        }
-
-        public Integer getCount()
-        {
-        	return updates.get();
-        }
-	}
-
-    private AlarmClient client = null;
-    private UpdateMonitor updateMonitor = null;
-
-	// Export an alarm system model to an xml file.
+    	// Export an alarm system model to an xml file.
     public void exportModel(String filename, String server, String config) throws Exception
 	{
         final XmlModelWriter xmlWriter;
@@ -112,14 +51,14 @@ public class AlarmConfigTool
             xmlWriter = new XmlModelWriter(fos);
         }
 
-		client = new AlarmClient(server, config);
+        final AlarmClient client = new AlarmClient(server, config);
         client.start();
 
         System.out.printf("Writing file after model is stable for %d seconds:\n", STABILIZATION_SECS);
         System.out.println("Monitoring changes...");
 
-        updateMonitor = new UpdateMonitor();
-        updateMonitor.listen(client);
+        final UpdateMonitor updateMonitor = new UpdateMonitor(STABILIZATION_SECS, client);
+        updateMonitor.waitForPauseInUpdates(30);
 
         System.out.printf("Received no more updates for %d seconds, I think I have a stable configuration\n", STABILIZATION_SECS);
 
@@ -129,6 +68,8 @@ public class AlarmConfigTool
 
         System.out.println("\nModel written to file: " + filename);
         System.out.printf("%d updates were received while writing model to file.\n", updateMonitor.getCount());
+
+        updateMonitor.dispose();
 
         client.shutdown();
 	}
@@ -143,15 +84,14 @@ public class AlarmConfigTool
 		xmlModelReader.load(fileInputStream);
 
 		// Connect to the server.
-		client = new AlarmClient(server, config);
+		final AlarmClient client = new AlarmClient(server, config);
         client.start();
         try
         {
-            updateMonitor = new UpdateMonitor();
-
             System.out.println("Fetching server model. This could take some time ...");
-
-            updateMonitor.listen(client);
+            final UpdateMonitor updateMonitor = new UpdateMonitor(STABILIZATION_SECS, client);
+            updateMonitor.waitForPauseInUpdates(30);
+            updateMonitor.dispose();
 
             final AlarmClientNode new_root = xmlModelReader.getRoot();
             // Check that the configs match.
@@ -174,7 +114,7 @@ public class AlarmConfigTool
             // For every child of the new root, add them and their descendants to the old root.
             final List<AlarmTreeItem<?>> new_root_children = new_root.getChildren();
             for (final AlarmTreeItem<?> child : new_root_children)
-				addNodes(root, child);
+				addNodes(client, root, child);
             System.out.println("Done.");
         }
         finally
@@ -183,7 +123,7 @@ public class AlarmConfigTool
         }
 	}
 
-	private void addNodes(AlarmTreeItem<?> parent, AlarmTreeItem<?> tree_item) throws Exception
+	private void addNodes(final AlarmClient client, final AlarmTreeItem<?> parent, final AlarmTreeItem<?> tree_item) throws Exception
 	{
 		// Determine if the item is a node or a leaf and add to the model appropriately.
 		if (tree_item instanceof AlarmTreeLeaf)
@@ -197,6 +137,6 @@ public class AlarmConfigTool
 		// Recurse over children.
 		final List<AlarmTreeItem<?>> children = tree_item.getChildren();
 		for (final AlarmTreeItem<?> child : children)
-			addNodes(tree_item, child);
+			addNodes(client, tree_item, child);
 	}
 }

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.client.AlarmClientNode;
-import org.phoebus.applications.alarm.client.UpdateMonitor;
+import org.phoebus.applications.alarm.client.AlarmConfigMonitor;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreeLeaf;
 import org.phoebus.applications.alarm.model.xml.XmlModelReader;
@@ -57,7 +57,7 @@ public class AlarmConfigTool
         System.out.printf("Writing file after model is stable for %d seconds:\n", STABILIZATION_SECS);
         System.out.println("Monitoring changes...");
 
-        final UpdateMonitor updateMonitor = new UpdateMonitor(STABILIZATION_SECS, client);
+        final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(STABILIZATION_SECS, client);
         updateMonitor.waitForPauseInUpdates(30);
 
         System.out.printf("Received no more updates for %d seconds, I think I have a stable configuration\n", STABILIZATION_SECS);
@@ -89,7 +89,7 @@ public class AlarmConfigTool
         try
         {
             System.out.println("Fetching server model. This could take some time ...");
-            final UpdateMonitor updateMonitor = new UpdateMonitor(STABILIZATION_SECS, client);
+            final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(STABILIZATION_SECS, client);
             updateMonitor.waitForPauseInUpdates(30);
             updateMonitor.dispose();
 

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.phoebus.applications.alarm.AlarmSystem;
+import org.phoebus.applications.alarm.ResettableTimeout;
 import org.phoebus.applications.alarm.client.ClientState;
 import org.phoebus.applications.alarm.client.KafkaHelper;
 import org.phoebus.applications.alarm.model.SeverityLevel;


### PR DESCRIPTION
For #275..

@shroffk On one hand, this moves some code from the alarm server to the alarm model, a generally useful reorg. In addition, it adds an example.

With this, all the code for keeping an in-memory model of the alarm configuration, and formatting that as XML is in app-alarm-model.

`AlarmModelWriterTest`: Shows how to programmatically create an alarm tree with root, subnodes, leaf nodes in memory and then write that as XML. The in-memory model uses `AlarmClient*` classes, but it's not connected to an actual Kafka client, doesn't read from Kafka, doesn't write to Kafka.
So the same type of code could read from ElasticSearch to build an alarm tree, then export as XML.

`AlarmModelSnapshotDemo`: Uses the `AlarmClient` to fetch alarm configuration from Kafka, then dumps as XML. When the alarm client builds the model from the Kafka stream of config updates, there is the technical issue of knowing when we're "done". In principle, the alarm config stream never ends, a user could at any time change the configuration, creating another update. This code shows how to wait for a pause in updates, considering that as a stable configuration.
With ElasticSearch, that would not be necessary because it reads the configuration updates until reaching a certain time stamp, and then it's "done" and can export as XML.

