### PR TITLE
Table edit

### DIFF
--- a/app/alarm/Readme.md
+++ b/app/alarm/Readme.md
@@ -26,12 +26,21 @@ Download Kafka as described on https://kafka.apache.org/quickstart
     tar -vzxf kafka_2.11-1.1.0.tgz
     ln -s kafka_2.11-1.1.0 kafka
     
-Check `config/server.properties`. By default it contains this, which "works",
-but risks that Linux will delete the data:
+Check `config/zookeeper.properties` and `config/server.properties`.
+By default these contain settings for keeping data in `/tmp/`, which works for initial tests,
+but risks that Linux will delete the data.
+For a production setup, change `zookeeper.properties`:
 
+    # Suggest to change this to a location outside of /tmp,
+    # for example /var/zookeeper-logs or /home/controls/zookeeper-logs
+    dataDir=/tmp/zookeeper
+  
+Similarly, change the directory setting in `server.properties`
+    
     # Suggest to change this to a location outside of /tmp,
     # for example /var/kafka-logs or /home/controls/kafka-logs
     log.dirs=/tmp/kafka-logs
+
 
 Kafka depends on Zookeeper. By default, Kafka will quit if it cannot connect to Zookeeper within 6 seconds.
 When the Linux host boots up, this may not be long enough to allow Zookeeper to start.

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
@@ -25,12 +25,10 @@ class AcknowledgeAction extends MenuItem
     public AcknowledgeAction(final AlarmClient model, final List<AlarmTreeItem<?>> active)
     {
         super("Acknowledge", ImageCache.getImageView(AlarmUI.class, "/icons/acknowledge.png"));
-        setOnAction(event -> 
+        setOnAction(event ->
         {
             JobManager.schedule(getText(), monitor ->
-            {
-                active.forEach(item -> model.acknowledge(item, true));
-            });
+                active.forEach(item -> model.acknowledge(item, true)));
         });
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -20,6 +20,7 @@ import org.phoebus.applications.alarm.ui.AlarmContextMenuHelper;
 import org.phoebus.applications.alarm.ui.AlarmUI;
 import org.phoebus.applications.alarm.ui.tree.ConfigureComponentAction;
 import org.phoebus.applications.email.actions.SendEmailAction;
+import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.persistence.Memento;
 import org.phoebus.logbook.ui.menu.SendLogbookAction;
 import org.phoebus.ui.application.SaveSnapshotAction;
@@ -194,7 +195,7 @@ public class AlarmTableUI extends BorderPane
         acknowledge.setOnAction(event ->
         {
             for (AlarmInfoRow row : active.getSelectionModel().getSelectedItems())
-                client.acknowledge(row.item, true);
+                JobManager.schedule("ack", monitor -> client.acknowledge(row.item, true));
         });
 
         final Button unacknowledge = new Button("", ImageCache.getImageView(AlarmUI.class, "/icons/unacknowledge.png"));
@@ -202,7 +203,7 @@ public class AlarmTableUI extends BorderPane
         unacknowledge.setOnAction(event ->
         {
             for (AlarmInfoRow row : acknowledged.getSelectionModel().getSelectedItems())
-                client.acknowledge(row.item, false);
+                JobManager.schedule("unack", monitor -> client.acknowledge(row.item, false));
         });
 
         search.setTooltip(new Tooltip("Enter pattern ('vac', 'amp*trip')\nfor PV Name or Description,\npress RETURN to select"));
@@ -318,7 +319,7 @@ public class AlarmTableUI extends BorderPane
             row.setOnMouseClicked(event ->
             {
                 if (event.getClickCount() == 2  &&  !row.isEmpty())
-                    client.acknowledge(row.getItem().item, active);
+                    JobManager.schedule("ack", monitor ->  client.acknowledge(row.getItem().item, active));
             });
             return row;
         });

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
@@ -40,21 +40,25 @@ public class StringTableDemo extends Application
     public void start(final Stage stage)
     {
         // Example data
-        final List<String> headers = Arrays.asList("Left", "Middle", "Right");
+        final List<String> headers = Arrays.asList("Left", "Options", "Bool", "Right");
         // Data lacks one element to demonstrate log message.
         // Table still "works"
         final List<List<String>> data = Arrays.asList(
-                Arrays.asList("One", "Two" /*, "missing" */),
-                Arrays.asList("Uno", "Due", "Tres"));
+                Arrays.asList("One", "Two", "true"/*, "missing" */),
+                Arrays.asList("Uno", "Due", "false", "Tres"));
 
         // Table
         final StringTable table = new StringTable(true);
         table.setHeaders(headers);
         table.setColumnOptions(1, Arrays.asList("Two", "Due", "Zwo", "1+2-1"));
+        table.setColumnOptions(2, StringTable.BOOLEAN_OPTIONS);
         table.setData(data);
         table.setBackgroundColor(Color.PINK);
         table.setTextColor(Color.GREEN);
         table.setFont(Font.font("Liberation Serif", 12.0));
+
+        // Table looks OK by default, but combo box will need more space
+        table.setColumnWidth(1, 100);
 
         table.setListener(new StringTableListener()
         {

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
@@ -14,6 +14,7 @@ import org.phoebus.ui.javafx.StringTable;
 import org.phoebus.ui.javafx.StringTableListener;
 
 import javafx.application.Application;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -118,6 +119,8 @@ public class StringTableDemo extends Application
         layout.setTop(label);
         layout.setCenter(table);
         layout.setRight(new VBox(10, new_headers, new_data, set_color, sel_row));
+
+        BorderPane.setMargin(layout.getRight(), new Insets(10));
 
         final Scene scene = new Scene(layout, 800, 700);
         stage.setScene(scene);

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
@@ -661,7 +661,7 @@ public class StringTable extends BorderPane
                 table.getSelectionModel().clearAndSelect(row, table_column);
                 table.edit(row, table_column);
             }),
-            200, TimeUnit.MILLISECONDS);
+            100, TimeUnit.MILLISECONDS);
     }
 
     /** @return Header labels */

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
@@ -240,7 +240,7 @@ public class StringTable extends BorderPane
             }
             else if (event.getCode() == KeyCode.ENTER)
             {
-                // Consume 'enter' and move to next column. Space can be used to toggle (or mouse click)
+                // Consume 'enter' and move to next row. Space can be used to toggle (or mouse click)
                 event.consume();
                 editCell(getIndex() + 1, getTableColumn());
             }

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
@@ -8,12 +8,14 @@
 package org.phoebus.ui.javafx;
 
 import static org.phoebus.ui.javafx.JFXUtil.logger;
+import static org.phoebus.ui.javafx.UpdateThrottle.TIMER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -524,6 +526,9 @@ public class StringTable extends BorderPane
             }
             row.set(col, event.getNewValue());
             fireDataChanged();
+
+            // Automatically edit the next row, same column
+            editCell(event.getTablePosition().getRow() + 1, table_column);
         });
         table_column.setOnEditCancel(event -> editing = false);
         table_column.setSortable(false);
@@ -532,6 +537,21 @@ public class StringTable extends BorderPane
             table.getColumns().add(index, table_column);
         else
             table.getColumns().add(table_column);
+    }
+
+    /** Start 'edit' mode for a cell
+     *  @param row
+     *  @param table_column
+     */
+    private void editCell(final int row, final TableColumn<List<String>, String> table_column)
+    {
+        TIMER.schedule(() ->
+            Platform.runLater(() ->
+            {
+                table.getSelectionModel().clearAndSelect(row, table_column);
+                table.edit(row, table_column);
+            }),
+            200, TimeUnit.MILLISECONDS);
     }
 
     /** @return Header labels */


### PR DESCRIPTION
Fixes #271:

In table widget  or other users of StringTable
 * Simply typing a character starts editing the active cell
 * RETURN submits and starts editing the cell below
 * TAB submits and starts editing the cell to the right (wrapping to first column at right edge)
 * SHIFT-TAB .. left ..