### PR TITLE
Databrowser PV Drop

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -136,8 +136,8 @@ public class Controller
             // if channel was found at least once, we do not need to report anything
             if (!channelFoundAtLeastOnce)
             {
-                logger.log(Level.WARNING,
-                          "Channel " + job.getPVItem().getResolvedDisplayName() + " not found in any of the archived sources.");
+                logger.log(Level.INFO,
+                           "Channel " + job.getPVItem().getResolvedDisplayName() + " not found in any of the archived sources.");
             }
         }
     };

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/DroppedPVNameParser.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/DroppedPVNameParser.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.trends.databrowser3.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Parser for dropped PV names
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class DroppedPVNameParser
+{
+    /** Parse PV names from text
+     *
+     *  <p>Text may contain
+     *  <ul>
+     *  <li>Just one PV name, which may be "sim://sine(1, 10, 0.1)"
+     *  <li>List of PV names separated by newlines
+     *  <li>.. separated by space, comma, semicolon
+     *  </ul>
+     *
+     *  @param text Text that may contain PV names
+     *  @return List of PV names
+     *  @throws Exception on error
+     */
+    public static List<String> parseDroppedPVs(String text) throws Exception
+    {
+        text = text.trim();
+        // Remove optional 'array' wrapper
+        if (text.startsWith("[")  &&  text.endsWith("]"))
+            text = text.substring(1, text.length()-2);
+
+        final List<String> names = new ArrayList<>();
+
+        // Need to look for a separator, but skipping them inside quoted text and brackets
+        final int len = text.length();
+        int start = 0, pos = 0;
+
+        while (pos < len)
+        {
+            final char c = text.charAt(pos);
+            if (c == '"')
+                pos = locateClosingQuote(text, pos+1);
+            else if (c == '(')
+                pos = locateClosingBrace(text, pos+1);
+            else if ("\r\n\t,; ".indexOf(c) >= 0)
+            {   // Found one of the separators
+                final String name = text.substring(start, pos).trim();
+                if (! name.isEmpty())
+                    names.add(name);
+                start = ++pos;
+            }
+            else
+                ++pos;
+        }
+        // Was there a last name?
+        if (pos > start)
+        {
+            final String name = text.substring(start, pos).trim();
+            if (! name.isEmpty())
+                names.add(name);
+        }
+        return names;
+    }
+
+    /** Locate closing, non-escaped quote
+     *  @param text Text to search
+     *  @param pos Position after opening quote
+     *  @return Position after the closing quote, or -1
+     *  @throws Exception if there is no closing quote
+     */
+    private static int locateClosingQuote(final String text, int pos) throws Exception
+    {
+        int end = text.indexOf('"', pos);
+        while (end > pos && text.charAt(end-1) == '\\')
+            end = text.indexOf('"', end+1);
+        if (end < 0)
+            throw new Exception("Missing closing quote");
+        return end + 1;
+    }
+
+    /** Locate closing brace, ignoring those inside quotes
+     *  @param text Text to search
+     *  @param pos Position after opening quote
+     *  @return Position after the closing quote, or -1
+     *  @throws Exception if there is no closing quote
+     */
+    private static int locateClosingBrace(final String text, int pos) throws Exception
+    {
+        final int end = text.length();
+        while (pos < end)
+        {
+            final char c = text.charAt(pos);
+            if (c == '"')
+                pos = locateClosingQuote(text, pos+1);
+            else if (c == ')')
+                return pos;
+            else
+                ++pos;
+        }
+        throw new Exception("Missing closing brace");
+    }
+}

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser3.ui;
 
+import static org.csstudio.trends.databrowser3.Activator.logger;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,7 +108,7 @@ public class Perspective extends SplitPane
         }
         catch (Exception ex)
         {
-            Activator.logger.log(Level.SEVERE, "Cannot start data browser", ex);
+            logger.log(Level.SEVERE, "Cannot start data browser", ex);
         }
 
         // As pane is resized, assert that the minimzed left or bottom region stays minimized
@@ -261,22 +263,17 @@ public class Perspective extends SplitPane
             }
             else if (db.hasString())
             {
-                final List<String> pvs = new ArrayList<>();
-                // Allow passing in many names, assuming that white space separates them
-                final String[] names = db.getString().split("[\\r\\n\\t ]+");
-                for (String one_name : names)
-                {   // Might also have received "[pv1, pv2, pv2]", turn that into "pv1", "pv2", "pv3"
-                    String suggestion = one_name;
-                    if (suggestion.startsWith("["))
-                        suggestion = suggestion.substring(1);
-                    if (suggestion.endsWith("]")  &&  !suggestion.contains("["))
-                        suggestion = suggestion.substring(0, suggestion.length()-1);
-                    if (suggestion.endsWith(","))
-                        suggestion = suggestion.substring(0, suggestion.length()-1);
-                    pvs.add(suggestion);
+                final String dropped = db.getString();
+                try
+                {
+                    final List<String> pvs = DroppedPVNameParser.parseDroppedPVs(dropped);
+                    if (pvs.size() > 0)
+                        Platform.runLater(() -> lst.droppedNames(pvs));
                 }
-                if (pvs.size() > 0)
-                    Platform.runLater(() -> lst.droppedNames(pvs));
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING, "Cannot parse PV names from dropped text " + dropped, ex);
+                }
             }
             else if (db.hasFiles())
             {

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/DroppedPVNameParserTest.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/DroppedPVNameParserTest.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.trends.databrowser3.ui;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/** Unit test of {@link DroppedPVNameParser}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class DroppedPVNameParserTest
+{
+    @Test
+    public void testSingle() throws Exception
+    {
+        // Just one PV name seems to be the easiest case..
+        List<String> names = DroppedPVNameParser.parseDroppedPVs("SomePVName");
+        assertThat(names, equalTo(List.of("SomePVName")));
+
+        // .. but it depends on all the other cases being handled,
+        // since the PV may contain commas or spaces
+        // that need to be ignored when inside quoted text or argument lists
+        names = DroppedPVNameParser.parseDroppedPVs("loc://array(1, 2, 3)");
+        assertThat(names, equalTo(List.of("loc://array(1, 2, 3)")));
+
+        // loc://info("Text (with comma, spaces; and semicolon)")
+        names = DroppedPVNameParser.parseDroppedPVs("loc://info(\"Text (with comma, spaces; and semicolon)\")");
+        assertThat(names, equalTo(List.of("loc://info(\"Text (with comma, spaces; and semicolon)\")")));
+
+        // loc://options<VEnum>(2, "A", "B (2)", "C")
+        names = DroppedPVNameParser.parseDroppedPVs("loc://options<VEnum>(2, \"A\", \"B (2)\", \"C\")");
+        assertThat(names, equalTo(List.of("loc://options<VEnum>(2, \"A\", \"B (2)\", \"C\")")));
+   }
+
+    @Test
+    public void testNewline() throws Exception
+    {
+        // Plain newline
+        List<String> names = DroppedPVNameParser.parseDroppedPVs("pv1\npv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        // Windows line ending
+        names = DroppedPVNameParser.parseDroppedPVs("pv1\r\npv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        // Old Mac
+        names = DroppedPVNameParser.parseDroppedPVs("pv1\rpv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        // Wrapped into 'array' brackets..
+        names = DroppedPVNameParser.parseDroppedPVs("[ pv1\npv2 ] ");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+    }
+
+    @Test
+    public void testTab() throws Exception
+    {
+        List<String> names = DroppedPVNameParser.parseDroppedPVs("pv1\tpv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1 \t  pv2 \t pv3");
+        assertThat(names, equalTo(List.of("pv1", "pv2", "pv3")));
+    }
+
+    @Test
+    public void testComma() throws Exception
+    {
+        List<String> names = DroppedPVNameParser.parseDroppedPVs("pv1,pv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1,   pv2 , pv3");
+        assertThat(names, equalTo(List.of("pv1", "pv2", "pv3")));
+
+        // Ignore commata inside quoted text
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1,   loc://txt(\"a, b, c\") , pv3");
+        assertThat(names, equalTo(List.of("pv1", "loc://txt(\"a, b, c\")", "pv3")));
+
+        // Ignore commata inside round brackets
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1,   sim://sine(1, 2, 3) , pv3");
+        assertThat(names, equalTo(List.of("pv1", "sim://sine(1, 2, 3)", "pv3")));
+
+        // Ignore closing brace inside quotes
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1,   loc://names(\"Fred\", \"Ed (3rd)\") , pv3");
+        assertThat(names, equalTo(List.of("pv1", "loc://names(\"Fred\", \"Ed (3rd)\")", "pv3")));
+
+        // Also allow semicolons
+        names = DroppedPVNameParser.parseDroppedPVs(" pv1;   pv2 ; pv3");
+        assertThat(names, equalTo(List.of("pv1", "pv2", "pv3")));
+    }
+
+    @Test
+    public void testSpace() throws Exception
+    {
+        List<String> names = DroppedPVNameParser.parseDroppedPVs("pv1   pv2");
+        assertThat(names, equalTo(List.of("pv1", "pv2")));
+
+        // Ignore spaces in brackets
+        names = DroppedPVNameParser.parseDroppedPVs("pv1   sim://sine(1, 2, 3)");
+        assertThat(names, equalTo(List.of("pv1", "sim://sine(1, 2, 3)")));
+
+        // Ignore spaces in quotes
+        names = DroppedPVNameParser.parseDroppedPVs("  pv1   loc://tag(\"You're it!\")    ");
+        assertThat(names, equalTo(List.of("pv1", "loc://tag(\"You're it!\")")));
+    }
+}

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/ProposalProvider.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/ProposalProvider.java
@@ -20,6 +20,13 @@ public interface ProposalProvider
 
     /** Get proposals
      *
+     *  <p>Implementation should handle interruption.
+     *
+     *  <p>If the user enters another text while
+     *  a previously submitted lookup is still executing,
+     *  the PropsalService will interrupt the ongoing lookup
+     *  and start a new lookup for the user's most recent text.
+     *
      *  @param text Text entered by user
      *  @return {@link Proposal}s that could be applied to the text
      */


### PR DESCRIPTION
Fixes #289, allowing to drop for example any of these:

`pv1,pv2,pv3`

`sim://sine(1, 2, 0.5)     sim://ramp(1, 5, 0.2)`

`sim://sine(1, 2, 0.5);sim://ramp(1, 5, 0.2)`

```
sim://sine(1, 2, 0.5)
sim://ramp(1, 5, 0.2)`
```
