### PR TITLE
Running product project  from NetBeans

### DIFF
--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -126,6 +126,11 @@
       <artifactId>app-channel-channelfinder</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>dependencies</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Added a single dependency that will allow the product project to be built independently and run from NetBeans.

I would like to emphasise how the added dependency is written (automatically done by NetBeans):

- `<groupId>${project.groupId}</groupId>`: the groupId is written using a property,
- `<version>${project.version}</version>': version is also written using a property. 

Maybe we can update our pom files to use this kind of properties. Moreover I've noticed that some pom file have missing version in plugins and other parts. If you agree, this week I can look at them all and make them uniform.