### PR TITLE
Layout save/restore: Close all panes, including extra empty panes, before restore

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -104,7 +104,7 @@
     <ant target="product" dir="phoebus-product"/>
   </target>
 
-  <target name="services" depends="app" description="Assemble services">
+  <target name="services" depends="product" description="Assemble services">
     <ant target="service-scan-server" dir="services/scan-server"/>
     <ant target="service-alarm-server" dir="services/alarm-server"/>
     <ant target="service-alarm-logger" dir="services/alarm-logger"/>

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -808,7 +808,7 @@ public class PhoebusApplication extends Application {
             return;
 
         // Allow handlers for tab changes etc. to run as everything closed.
-        
+
         // On next UI tick, load content from memento file.
         Platform.runLater(() -> restoreState(memento));
     }
@@ -859,12 +859,20 @@ public class PhoebusApplication extends Application {
         if (memento == null)
             return any;
 
-        
-        System.out.println("\nRestore:");
-        
-        for (Stage stage : DockStage.getDockStages())
-            DockStage.dump(stage);
-        
+        // There should be just one, empty stage
+        final List<Stage> stages = DockStage.getDockStages();
+        if (stages.size() > 1  ||
+            stages.stream().map(DockStage::getDockPanes).count() > 1)
+        {
+            // More than one stage, or a stage with more than one pane
+            logger.log(Level.WARNING, "Expected single, empty stage for restoring state");
+            final StringBuilder buf = new StringBuilder();
+            buf.append("Found:\n");
+            for (Stage stage : stages)
+                DockStage.dump(buf, stage);
+            logger.log(Level.WARNING, buf.toString());
+        }
+
         try
         {
             // Global settings

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -214,7 +214,6 @@ public class DockPane extends TabPane
         // If this pane is empty, offer 'close' entry in context menu to close (merge) it.
         if (getTabs().isEmpty() &&  dock_parent instanceof SplitDock)
         {
-            System.out.println("Open context menu on pane?");
             final MenuItem close = new MenuItem("Close", new ImageView(close_icon));
             close.setOnAction(evt -> mergeEmptyAnonymousSplit());
             final ContextMenu menu = new ContextMenu(close);

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -502,7 +502,7 @@ public class DockPane extends TabPane
         else if (dock_parent instanceof SplitDock)
         {
             final SplitDock parent = (SplitDock) dock_parent;
-            // Remove this dock pane from BorderPane
+            // Remove this dock pane from parent
             final boolean first = parent.removeItem(this);
             // Place in split alongside a new dock pane
             final DockPane new_pane = new DockPane();

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -283,30 +283,30 @@ public class DockStage
     }
 
     /** @param stage Stage for which to dump basic panel hierarchy */
-    public static void dump(final Stage stage)
+    public static void dump(final StringBuilder buf, final Stage stage)
     {
         final Node node = getPaneOrSplit(stage);
-        System.out.println("Stage " + stage.getTitle());
-        dump(node, 0);
+        buf.append("Stage ").append(stage.getTitle()).append("\n");
+        dump(buf, node, 0);
     }
 
-    private static void dump(final Node node, final int level)
+    private static void dump(final StringBuilder buf, final Node node, final int level)
     {
         for (int i=0; i<level; ++i)
-            System.out.print("  ");
+            buf.append("  ");
         if (node instanceof DockPane)
         {
             final DockPane pane = (DockPane) node;
-            System.out.println(pane);
+            buf.append(pane).append("\n");
         }
         else if (node instanceof SplitDock)
         {
             final SplitDock split = (SplitDock) node;
-            System.out.println("Split");
-            dump(split.getItems().get(0), level + 1);
-            dump(split.getItems().get(1), level + 1);
+            buf.append("Split").append("\n");
+            dump(buf, split.getItems().get(0), level + 1);
+            dump(buf, split.getItems().get(1), level + 1);
         }
         else
-            System.out.println(node);
+            buf.append(node).append("\n");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/SplitDock.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/SplitDock.java
@@ -106,7 +106,7 @@ public class SplitDock extends SplitPane
      *  being an empty DockPane,
      *  replace ourself in the parent with that one non-empty item.
      */
-    void merge()
+    public void merge()
     {
         final DockPane empty_dock = findEmptyDock();
         if (empty_dock == null)

--- a/core/ui/src/main/java/org/phoebus/ui/docking/SplitDock.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/SplitDock.java
@@ -9,6 +9,7 @@ package org.phoebus.ui.docking;
 
 import static org.phoebus.ui.docking.DockPane.logger;
 
+import java.util.ArrayList;
 import java.util.logging.Level;
 
 import javafx.collections.ObservableList;
@@ -105,9 +106,18 @@ public class SplitDock extends SplitPane
     /** If this split holds only one useful item, the other one
      *  being an empty DockPane,
      *  replace ourself in the parent with that one non-empty item.
+     *
+     *  <p>Merges 'deep', i.e. first checks if any of the child
+     *  items can itself be merged, then merges this one.
      */
     public void merge()
     {
+        // First recurse to merge child splits.
+        // Use copy to avoid comodification
+        for (Node child : new ArrayList<>(getItems()))
+            if (child instanceof SplitDock)
+                ((SplitDock) child).merge();
+
         final DockPane empty_dock = findEmptyDock();
         if (empty_dock == null)
         {
@@ -118,10 +128,10 @@ public class SplitDock extends SplitPane
         // Remove the empty dock from this split
         getItems().remove(empty_dock);
 
-        // Should be left with just one child (dock or nested split)
+        // Usually left with just one child (dock or nested split)
         if (getItems().isEmpty())
         {
-            logger.log(Level.WARNING, "Cannot merge completely empty SplitPane " + this);
+            logger.log(Level.FINE, "Cannot merge completely empty SplitPane " + this);
             return;
         }
 

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import org.phoebus.framework.persistence.MementoTree;
@@ -28,6 +29,7 @@ import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.docking.DockStage;
 import org.phoebus.ui.docking.SplitDock;
+import org.phoebus.ui.javafx.UpdateThrottle;
 
 import javafx.application.Platform;
 import javafx.scene.Node;
@@ -225,7 +227,11 @@ public class MementoHelper
             // The divider position needs to be set at the end, after the complete scene has been restored.
             // Otherwise the SplitPane self-adjusts the position when the sub-elements are rendered,
             // replacing a position set now.
-            content.getNumber(POS).ifPresent(num -> Platform.runLater(() -> split.setDividerPosition(num.doubleValue())));
+            content.getNumber(POS).ifPresent(num ->
+            {
+                UpdateThrottle.TIMER.schedule(() -> Platform.runLater(() -> split.setDividerPosition(num.doubleValue())),
+                                              300, TimeUnit.MILLISECONDS);
+            });
         }
         else
             logger.log(Level.WARNING, "Expect <pane> or <split>, got " + content);

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -358,12 +358,8 @@ public class MementoHelper
             // All items have been closed, which triggers auto-merge.
             // But there could have been empty panes that are not closed
             // and thus not triggering a merge..
-            // TODO Merge
             if (split.getItems().size() > 0)
-            {
-                System.out.println("SplitDock still has items: " + split + ", forcing merge");
                 split.merge();
-            }
         }
         else
         {

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -265,8 +265,11 @@ public class MementoHelper
 
         // If dock item was restored within a SplitDock,
         // its Scene is only set on a later UI tick when the SplitPane is rendered.
-        // Defer restoring the application so that DockPane.autoHideTabs can locate the tab header
-        Platform.runLater(() -> restoreApplication(item_memento, pane, app));
+        // Defer restoring the application so that DockPane.autoHideTabs can locate the tab header,
+        // and for DockPane.setActiveDockPane(pane) to actually return the pane
+        // that we're about to set via DockPane.setActiveDockPane(), which it won't do
+        // for a pane without a Scene.
+        pane.deferUntilInScene(scene -> restoreApplication(item_memento, pane, app));
 
         return true;
     }

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -348,6 +348,16 @@ public class MementoHelper
             for (Node item : items)
                 if (! closePaneOrSplit(item))
                     return false;
+
+            // All items have been closed, which triggers auto-merge.
+            // But there could have been empty panes that are not closed
+            // and thus not triggering a merge..
+            // TODO Merge
+            if (split.getItems().size() > 0)
+            {
+                System.out.println("SplitDock still has items: " + split + ", forcing merge");
+                split.merge();
+            }
         }
         else
         {

--- a/phoebus-product/src/main/resources/logging.properties
+++ b/phoebus-product/src/main/resources/logging.properties
@@ -40,6 +40,7 @@ com.sun.speech.freetts.relp.AudioOutput.level = WARNING
 com.cosylab.epics.caj.level = WARNING
 org.phoebus.framework.workbench.level = WARNING
 org.phoebus.ui.javafx.BufferUtil.level = WARNING
+org.phoebus.ui.docking.level = WARNING
 org.phoebus.ui.application.PhoebusApplication.level = WARNING
 org.phoebus.ui.application.ApplicationLauncherService.level = WARNING
 org.phoebus.framework.rdb.level = WARNING


### PR DESCRIPTION
When closing the previously open tabs, that would merge split panes, but only those that host the closed tabs. Extra, empty panes would remain, and when then loading the new content there are many empty panes.

Now the 'merge' is more aggressive to close all panes.


Restoring the split pane divider position is delayed to have an effect, since setting it right away is soon replaced with the auto-layout as content is added to the split pane.