### PR TITLE
Probe readonly indicator

### DIFF
--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -143,18 +143,12 @@ public class ProbeController {
 
     private void update(final VType value)
     {
-        Platform.runLater(() ->
-        {
-            setValue(value);
-        });
+        Platform.runLater(() -> setValue(value));
     }
 
     private void updateWritable(final Boolean writable)
     {
-        Platform.runLater(() ->
-        {
-            txtValue.setEditable(false);
-        });
+        Platform.runLater(() ->  txtValue.setEditable(writable));
     }
 
     @FXML


### PR DESCRIPTION
The value, alarm info, .. can always be selected and copied out, but editing the value is only enabled when the PV has write access.

#331