### PR TITLE
FileBrowser: Support selection via keyboard

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorApplication.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorApplication.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.csstudio.display.builder.editor.Messages;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.WidgetClassSupport;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.representation.javafx.FilenameSupport;
 import org.phoebus.framework.jobs.JobManager;
@@ -41,6 +42,7 @@ import javafx.stage.Window;
 @SuppressWarnings("nls")
 public class DisplayEditorApplication implements AppResourceDescriptor
 {
+    private static final List<String> FILE_EXTENSIONS = List.of(DisplayModel.FILE_EXTENSION, DisplayModel.LEGACY_FILE_EXTENSION, WidgetClassSupport.FILE_EXTENSION);
     public static final String NAME = "display_editor";
     public static final String DISPLAY_NAME = "Display Editor";
 
@@ -70,7 +72,7 @@ public class DisplayEditorApplication implements AppResourceDescriptor
     @Override
     public List<String> supportedFileExtentions()
     {
-        return DisplayModel.FILE_EXTENSIONS;
+        return FILE_EXTENSIONS;
     }
 
     @Override

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
@@ -33,6 +33,7 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.ContextMenuEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.DirectoryChooser;
@@ -242,8 +243,39 @@ public class FileBrowserController {
             }
             break;
         }
+        case ESCAPE: // De-select
+            treeView.selectionModelProperty().get().clearSelection();
+            break;
         default:
-            // Ignore
+            if ((event.getCode().compareTo(KeyCode.A) >= 0  &&  event.getCode().compareTo(KeyCode.Z) <= 0) ||
+                (event.getCode().compareTo(KeyCode.DIGIT0) >= 0  &&  event.getCode().compareTo(KeyCode.DIGIT9) <= 0))
+            {
+                // Move selection to first/next file that starts with that character
+                final String ch = event.getCode().getChar().toLowerCase();
+
+                final TreeItem<File> selected = treeView.selectionModelProperty().getValue().getSelectedItem();
+                final ObservableList<TreeItem<File>> siblings;
+                int index;
+                if (selected != null)
+                {   // Start after the selected item
+                    siblings = selected.getParent().getChildren();
+                    index = siblings.indexOf(selected);
+                }
+                else if (!treeView.getRoot().getChildren().isEmpty())
+                {   // Start at the root
+                    siblings = treeView.getRoot().getChildren();
+                    index = -1;
+                }
+                else
+                    break;
+                for (++index;  index < siblings.size();  ++index)
+                    if (siblings.get(index).getValue().getName().toLowerCase().startsWith(ch))
+                    {
+                        treeView.selectionModelProperty().get().clearSelection();
+                        treeView.selectionModelProperty().get().select(siblings.get(index));
+                        break;
+                    }
+            }
         }
     }
 


### PR DESCRIPTION
Pressing a character or number key selects the first item that starts
with that char or number. If item is already selected, move selection to
the next matching file or directory.
Searches the siblings of the root or current selection.

Escape key de-selects.