### PR TITLE
Display builder mem leak fix imports

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ChildrenProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ChildrenProperty.java
@@ -47,7 +47,7 @@ public class ChildrenProperty extends RuntimeWidgetProperty<List<Widget>>
      *  <u>not</u> the complete old resp. new value.
      */
     public static final WidgetPropertyDescriptor<List<Widget>> DESCRIPTOR =
-            new WidgetPropertyDescriptor<List<Widget>>(
+            new WidgetPropertyDescriptor<>(
                     WidgetPropertyCategory.RUNTIME, "children", "Child widgets")
     {
         @Override
@@ -239,5 +239,14 @@ public class ChildrenProperty extends RuntimeWidgetProperty<List<Widget>>
     public void readFromXML(final ModelReader model_reader, final Element property_xml) throws Exception
     {
         model_reader.readWidgets(this, property_xml);
+    }
+
+    /** Dispose, i.e. clear list
+     *
+     *  <p>Prevents further use by replacing it with immutable, empty list
+     */
+    void dispose()
+    {
+        value = Collections.emptyList();
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java
@@ -262,6 +262,15 @@ public class DisplayModel extends Widget
         return gridVisible;
     }
 
+    /** Dispose the model
+     *
+     *  <p>Removes all widgets and prevents adding new widgets
+     */
+    public void dispose()
+    {
+        children.dispose();
+    }
+
     @Override
     public String toString()
     {

--- a/app/display/model/src/test/java/org/csstudio/display/builder/model/DisplayModelUnitTest.java
+++ b/app/display/model/src/test/java/org/csstudio/display/builder/model/DisplayModelUnitTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.model;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.csstudio.display.builder.model.widgets.LabelWidget;
+import org.junit.Test;
+
+/** Test {@link DisplayModel}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class DisplayModelUnitTest
+{
+    @Test
+    public void testDisplayModel()
+    {
+        final DisplayModel model = new DisplayModel();
+
+        model.runtimeChildren().addChild(new LabelWidget());
+        model.runtimeChildren().addChild(new LabelWidget());
+        assertThat(model.getChildren().size(), equalTo(2));
+
+        model.dispose();
+        assertThat(model.getChildren().size(), equalTo(0));
+
+        try
+        {
+            model.runtimeChildren().addChild(new LabelWidget());
+            fail("Was able to add widget to disposed model");
+        }
+        catch (UnsupportedOperationException ex)
+        {
+            // Expected
+        }
+    }
+}

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -138,10 +138,10 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     private static final float GRID_LINE_WIDTH = 0.222F;
 
     /** Update model size indicators (in edit mode) */
-    private WidgetPropertyListener<Integer> model_size_listener = ( p, o, n ) -> execute(this::updateModelSizeIndicators);
+    private final WidgetPropertyListener<Integer> model_size_listener = ( p, o, n ) -> execute(this::updateModelSizeIndicators);
 
     /** Update background color, grid */
-    private UntypedWidgetPropertyListener background_listener = ( p, o, n ) -> execute(this::updateBackground);
+    private final UntypedWidgetPropertyListener background_listener = ( p, o, n ) -> execute(this::updateBackground);
 
     private Line horiz_bound, vert_bound;
     private Pane widget_parent;
@@ -974,6 +974,11 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     {
         if (! widget_parent.getChildren().isEmpty())
             logger.log(Level.WARNING, "Display representation still contains items on shutdown", widget_parent.getChildren());
+
+        widget_parent = null;
+        model_root = null;
+        scroll_body = null;
+        zoom_listener = null;
         super.shutdown();
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -214,6 +214,7 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     {
         Objects.requireNonNull(jfx_node);
         JFXRepresentation.getChildren(jfx_node.getParent()).remove(jfx_node);
+        jfx_node = null;
     }
 
     /** Get parent that would be used for child-widgets.

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -296,6 +296,8 @@ public class TabsRepresentation extends JFXBaseRepresentation<TabPane, TabsWidge
         for (TabItemProperty tab : model_widget.propTabs().getValue())
             for (Widget child : tab.children().getValue())
                 toolkit.execute(() -> toolkit.disposeWidget(child));
+
+        jfx_node.getTabs().clear();
 
         super.dispose();
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,12 +32,18 @@ public class TooltipSupport
     /** Legacy tool tip: "$(pv_name)\n$(pv_value)" where number of '\n' can vary */
     private final static Pattern legacy_tooltip = Pattern.compile("\\$\\(pv_name\\)\\s*\\$\\(pv_value\\)");
 
+    /** System property to disable tool tips (for debugging problems seen on Linux) */
+    private static boolean disable_tooltips = Boolean.parseBoolean(System.getProperty("org.csstudio.display.builder.disable_tooltips"));
+
     /** Attach tool tip
      *  @param node Node that should have the tool tip
      *  @param tooltip_property Tool tip to show
      */
     public static void attach(final Node node, final WidgetProperty<String> tooltip_property)
     {
+        if (disable_tooltips)
+            return;
+
         // Patch legacy tool tips that defaulted to pv name & value,
         // even for static widgets
         final StringWidgetProperty ttp = (StringWidgetProperty)tooltip_property;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/DataBrowserRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/DataBrowserRepresentation.java
@@ -273,8 +273,14 @@ public class DataBrowserRepresentation extends RegionBaseRepresentation<Pane, Da
     {
         super.dispose();
         if (controller != null  &&  controller.isRunning())
+        {
             controller.stop();
+            controller = null;
+        }
         if (plot != null)
+        {
             plot.dispose();
+            plot = null;
+        }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -412,6 +412,7 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
     public void dispose()
     {
         image_plot.dispose();
+        image_plot = null;
         super.dispose();
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -602,6 +602,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
     public void dispose()
     {
         plot.dispose();
+        plot = null;
         super.dispose();
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYVTypeDataProvider.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYVTypeDataProvider.java
@@ -35,6 +35,7 @@ import org.phoebus.util.array.ListNumber;
  *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class XYVTypeDataProvider implements PlotDataProvider<Double>
 {
     public static final ListNumber EMPTY = new ArrayDouble(new double[0], true);

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -366,7 +366,7 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
         if (representation != null)
         {
             logger.log(Level.FINE, "Disposing {0} for {1}", new Object[] { representation, widget });
-            representation.dispose();
+            representation.destroy();
         }
         // else: Widget has no representation because not implemented for this toolkit
     }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,5 +74,14 @@ abstract public class WidgetRepresentation<TWP, TW, MW extends Widget>
      *  <p>Called when model widget has been removed.
      */
     abstract public void dispose();
-}
 
+    /** Called internally to dispose() and then remove model & toolkit links */
+    void destroy()
+    {
+        dispose();
+
+        // Speedup GC
+        model_widget = null;
+        toolkit = null;
+    }
+}

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -169,6 +169,8 @@ public class ActionUtil
         // .. while UI thread removes the representation
         final ToolkitRepresentation<Object, Object> toolkit = ToolkitRepresentation.getToolkit(model);
         toolkit.disposeRepresentation(model);
+
+        model.dispose();
     }
 
     /** Write a PV

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -621,10 +621,17 @@ public class PhoebusApplication extends Application {
         ToolbarEntryService.getInstance().listToolbarEntries().forEach((entry) -> {
             final AtomicBoolean open_new = new AtomicBoolean();
 
-            final Button button = new Button(entry.getName());
+            // If entry has icon, use that with name as tool tip.
+            // Otherwise use the label as button text.
+            final Button button = new Button();
             final Image icon = entry.getIcon();
-            if (icon != null)
+            if (icon == null)
+                button.setText(entry.getName());
+            else
+            {
                 button.setGraphic(new ImageView(icon));
+                button.setTooltip(new Tooltip(entry.getName()));
+            }
 
             // Want to handle button presses with 'Control' in different way,
             // but action event does not carry key modifier information.


### PR DESCRIPTION
With RCP, they help releasing mem that's otherwise held for a long time.
With phoebus, these are more GC assistance than leak fixes, imported to keep the code similar.
