### PR TITLE
Add performance monitor

### DIFF
--- a/app/perfmon/.classpath
+++ b/app/perfmon/.classpath
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="/core-ui"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/app/perfmon/.project
+++ b/app/perfmon/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app-perfmon</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/app/perfmon/build.xml
+++ b/app/perfmon/build.xml
@@ -1,0 +1,21 @@
+<project default="app-perfmon">
+  <import file="../../dependencies/ant_settings.xml"/>
+
+  <target name="app-perfmon">
+    <mkdir dir="${classes}"/>
+    <javac destdir="${classes}">
+      <src path="${src}"/>
+      <classpath>
+        <path refid="app-classpath"/>
+      	<pathelement path="../../core/ui/${build}/core-ui-${version}.jar"/>
+        <pathelement path="../../core/framework/${build}/core-framework-${version}.jar"/>
+      </classpath>
+    </javac>
+
+    <jar destfile="${build}/app-perfmon-${version}.jar">
+      <fileset dir="${classes}"/>
+      <fileset dir="${resources}"/>
+    </jar>
+  </target>
+
+</project>

--- a/app/perfmon/doc/index.rst
+++ b/app/perfmon/doc/index.rst
@@ -1,0 +1,26 @@
+Performance Monitor
+===================
+
+Invoking the menu Applications, Debug, Performance monitor
+adds a button to the status bar that displays performance information.
+Invoking it again will remove it.
+
+
+Memory
+------
+Displays how much memory is allocated, and how much of that is available.
+For example, "Avail: 28% of 0.21GB".
+
+Pressing the button triggers a garbage collection.
+
+
+Frame Rate
+----------
+Measures the JavaFX frame rate, nominally 60Hz.
+
+System properties that can influence the result:
+
+`-Dquantum.multithreaded=true`
+`-Djavafx.animation.fullspeed=true`
+`-Djavafx.animation.framerate=120`
+`-Djavafx.animation.pulse=120`

--- a/app/perfmon/pom.xml
+++ b/app/perfmon/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.phoebus</groupId>
+    <artifactId>app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>app-perfmon</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-ui</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-framework</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/app/perfmon/src/main/java/org/phoebus/app/perfmon/FPSMonitor.java
+++ b/app/perfmon/src/main/java/org/phoebus/app/perfmon/FPSMonitor.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.app.perfmon;
+
+import java.util.function.DoubleConsumer;
+
+import javafx.animation.AnimationTimer;
+
+/** Frame-per-second monitor
+ *  @author Kay Kasemir
+ */
+public class FPSMonitor extends AnimationTimer
+{
+    // Number of frames to use for average
+    // Based on nominal 60Hz, this updates every 3 seconds
+    private static final int AVG = 60*3;
+
+    private final DoubleConsumer fps_handler;
+    private long updates = 0;
+    private long last = 0;
+    private double fps = 60.0;
+
+    /** @param fps_handler Invoked with frames-per-second */
+    public FPSMonitor(DoubleConsumer fps_handler)
+    {
+        this.fps_handler = fps_handler;
+    }
+
+    @Override
+    public void handle(long now)
+    {
+        // System.out.println(now);
+        if (++updates > AVG)
+        {
+            if (last > 0)
+            {
+                long nanos = (now - last)  / AVG;
+                fps = 1.0e9 / nanos;
+                fps_handler.accept(fps);
+            }
+            updates = 0;
+            last = now;
+        }
+    }
+}

--- a/app/perfmon/src/main/java/org/phoebus/app/perfmon/OpenPerfMon.java
+++ b/app/perfmon/src/main/java/org/phoebus/app/perfmon/OpenPerfMon.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.app.perfmon;
+
+import org.phoebus.framework.spi.MenuEntry;
+import org.phoebus.ui.statusbar.StatusBar;
+
+/** Menu entry (SPI) for adding/removing performance monitor status bar entry
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class OpenPerfMon implements MenuEntry
+{
+    private static PerfMonButton button;
+
+    @Override
+    public String getName()
+    {
+        return "Performance Monitor";
+    }
+
+    @Override
+    public String getMenuPath()
+    {
+        return "Debug";
+    }
+
+    @Override
+    public Void call() throws Exception
+    {
+        if (button == null)
+        {
+            button = new PerfMonButton();
+            StatusBar.getInstance().addItem(button);
+        }
+        else
+        {
+            button.dispose();
+            StatusBar.getInstance().removeItem(button);
+            button = null;
+        }
+        return null;
+    }
+}

--- a/app/perfmon/src/main/java/org/phoebus/app/perfmon/PerfMonButton.java
+++ b/app/perfmon/src/main/java/org/phoebus/app/perfmon/PerfMonButton.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.app.perfmon;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.Tooltip;
+
+/** Button (meant for status bar) that shows performance info
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PerfMonButton extends Button
+{
+    private final FPSMonitor fps_monitor;
+
+    public PerfMonButton()
+    {
+        updateFPS(60.0);
+        fps_monitor = new FPSMonitor(this::updateFPS);
+        fps_monitor.start();
+        setTooltip(new Tooltip("Press for GC"));
+        setOnAction(event ->
+        {
+            Runtime.getRuntime().gc();
+        });
+    }
+
+    private void updateFPS(double fps)
+    {
+        final long free = Runtime.getRuntime().freeMemory();
+        final long total = Runtime.getRuntime().totalMemory();
+
+        final long avail = (int) ((free * 100) / total);
+        final double gb = total / 1024.0 / 1024.0 / 1024.0;
+
+        setText(String.format("Avail: %d%% of %.2fGB. FPS: %.1f", avail, gb, fps));
+    }
+
+    public void dispose()
+    {
+        fps_monitor.stop();
+    }
+}

--- a/app/perfmon/src/main/resources/META-INF/services/org.phoebus.framework.spi.MenuEntry
+++ b/app/perfmon/src/main/resources/META-INF/services/org.phoebus.framework.spi.MenuEntry
@@ -1,0 +1,1 @@
+org.phoebus.app.perfmon.OpenPerfMon

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -24,5 +24,6 @@
     <module>scan</module>
     <module>channel</module>
     <module>3dViewer</module>
+    <module>perfmon</module>
   </modules>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@
     <ant target="clean" dir="app/rtplot"/>
     <ant target="clean" dir="app/databrowser"/>
     <ant target="clean" dir="app/3dViewer"/>
+    <ant target="clean" dir="app/perfmon"/>
     <ant target="clean" dir="app/display/model"/>
     <ant target="clean" dir="app/display/representation"/>
     <ant target="clean" dir="app/display/representation-javafx"/>
@@ -89,6 +90,7 @@
     <ant dir="app/rtplot"/>
     <ant dir="app/databrowser"/>
     <ant dir="app/3dViewer"/>
+    <ant dir="app/perfmon"/>
     <ant dir="app/display/model"/>
     <ant dir="app/display/representation"/>
     <ant dir="app/display/representation-javafx"/>

--- a/core/ui/src/main/java/org/phoebus/ui/statusbar/StatusBar.java
+++ b/core/ui/src/main/java/org/phoebus/ui/statusbar/StatusBar.java
@@ -43,4 +43,14 @@ public class StatusBar extends HBox
     {
         getChildren().add(item);
     }
+
+    /** Remove item from the status bar
+     *
+     *
+     * @param item Item to remove
+     */
+    public void removeItem(final Node item)
+    {
+        getChildren().remove(item);
+    }
 }

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -93,6 +93,11 @@
       <artifactId>app-3dViewer</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>app-perfmon</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
     
     <!-- diirt
     <dependency>


### PR DESCRIPTION
Adds Debug -> performance monitor menu entry which toggles a toolbar entry for displaying memory and frame-per-second info. Pushing the button toggles GC.

![perfmon](https://user-images.githubusercontent.com/1932421/47458981-f766ff00-d7a8-11e8-8b57-1e29d48ba640.png)
