### PR TITLE
Kafka update

### DIFF
--- a/app/alarm/Readme.md
+++ b/app/alarm/Readme.md
@@ -21,11 +21,10 @@ Download Kafka as described on https://kafka.apache.org/quickstart
     cd examples
     
     # Use wget, 'curl -O', or web browser
-    wget http://mirrors.gigenet.com/apache/kafka/1.1.0/kafka_2.11-1.1.0.tgz
-
-    tar -vzxf kafka_2.11-1.1.0.tgz
-    ln -s kafka_2.11-1.1.0 kafka
-    
+    wget http://mirrors.gigenet.com/apache/kafka/2.0.0/kafka_2.11-2.0.0.tgz
+    tar -vzxf kafka_2.11-2.0.0.tgz
+    ln -s kafka_2.11-2.0.0 kafka
+     
 Check `config/zookeeper.properties` and `config/server.properties`.
 By default these contain settings for keeping data in `/tmp/`, which works for initial tests,
 but risks that Linux will delete the data.
@@ -69,21 +68,6 @@ For tests, you can use localhost:
     listeners=PLAINTEXT://localhost:9092
     advertised.host.name = localhost
     advertised.listeners=PLAINTEXT://localhost:9092
-
-If you are using Java 10 or newer, the Zookeeper start script may fail when it
-checks for the Java Version, because it mistakes Java 10 as Java "1", resulting in the following error:
-
-     kafka/bin/kafka-run-class.sh: line 252: .. syntax error in expression ..
-
-If you are using Java 10, change kafka-run-class.sh line 252 from
-
-     JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p')
-into
-
-     JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([^.-])./\1p')
-
-
-
 
 Start local instance:
 

--- a/app/alarm/Readme.md
+++ b/app/alarm/Readme.md
@@ -14,7 +14,13 @@ They receive the most recent configuration and state, and from then on updates.
 Kafka Installation
 ------------------
 
-Download Kafka as described on https://kafka.apache.org/quickstart
+Download Kafka as described on https://kafka.apache.org/quickstart.
+
+The following describes a setup under the `examples` folder
+of the source tree, which allows using the other scripts in examples
+for a quick start.
+A production setup on for example Linux would typically install
+kafka in `/opt/kafka`.
 
     # The 'examples' folder of this project contains some example scripts
     # that can be used with a kafka server in the same directory
@@ -69,7 +75,8 @@ For tests, you can use localhost:
     advertised.host.name = localhost
     advertised.listeners=PLAINTEXT://localhost:9092
 
-Start local instance:
+Start local instance. The following describes a manual startup which is useful
+for initial tests:
 
     # Zookeeper must be started first.
     sh start_zookeeper.sh
@@ -81,7 +88,22 @@ Start local instance:
     # it will fail to start and close with a null pointer exception. 
     # Simply start kafka after zookeeper is running to recover.
 
-Refer to `*.service` scripts for installing Zookeeper and Kafka as Linux services.
+
+For a Linux-based production setup, consider using the `*.service` scripts
+for running Zookeeper, Kafka and the alarm server as Linux services:
+
+    sudo cp *.service /etc/systemd/system
+
+    # Start manually
+    sudo systemctl start zookeeper.service
+    sudo systemctl start kafka.service
+    sudo systemctl start alarm_server.service
+
+    # Enable startup when host boots
+    sudo systemctl enable zookeeper.service
+    sudo systemctl enable kafka.service
+    sudo systemctl enable alarm_server.service
+
     
 Kafka Demo
 ----------

--- a/app/alarm/examples/alarm_server.service
+++ b/app/alarm/examples/alarm_server.service
@@ -1,0 +1,36 @@
+# File /etc/systemd/system/alarm_server.service
+#
+# After changes
+#   sudo systemctl daemon-reload
+#
+# Start/status/stop
+#   sudo systemctl start alarm_server.service
+#   sudo systemctl status alarm_server.service
+#   sudo systemctl stop alarm_server.service
+#
+# Start when computer boots:
+#   sudo systemctl enable alarm_server.service
+#
+# Log file:
+#   less +GF /home/controls/css/phoebus-alarm-server/console.log
+#
+# Console:
+#   telnet localhost 4609
+
+[Unit]
+Description=Phoebus Alarm Server
+After=kafka.service
+
+[Service]
+User=DESIRED_USER
+Group=DESIRED_GROUP
+Environment=JAVA_HOME=/PATH/TO/JDK
+Environment=SERVER=/PATH/TO/phoebus-alarm-server
+Environment=PORT=4609
+Environment=CONFIG=Accelerator
+Environment=PATH=/PATH/TO/JDK/bin:/usr/bin
+ExecStart=/usr/bin/procServ --foreground --noautorestart --name alarm-server --chdir ${SERVER} --logfile ${SERVER}/console.log ${PORT} ./alarm-server.sh -settings /PATH/TO/phoebus.ini -config ${CONFIG}
+# Systemd stops alarm server by killing the process
+
+[Install]
+WantedBy=multi-user.target

--- a/app/alarm/examples/kafka.service
+++ b/app/alarm/examples/kafka.service
@@ -19,11 +19,12 @@ After=network.target remote-fs.target zookeeper.service
 
 [Service]
 Type=simple
-User=controls
-Group=users
-Environment=JAVA_HOME=/opt/jdk-10
+User=DESIRED_USER
+Group=DESIRED_GROUP
+Environment=JAVA_HOME=/PATH/TO/JDK
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
 ExecStop=/opt/kafka/bin/kafka-server-stop.sh
 
 [Install]
 WantedBy=multi-user.target
+

--- a/app/alarm/examples/zookeeper.service
+++ b/app/alarm/examples/zookeeper.service
@@ -1,16 +1,15 @@
-# /etc/systemd/system/zookeeper.service
+# File /etc/systemd/system/zookeeper.service
 #
 # Start/status/stop
 #   sudo systemctl start zookeeper.service
 #   sudo systemctl status zookeeper.service
 #   sudo systemctl stop zookeeper.service
-# 
+#
 # Start when computer boots:
 #   sudo systemctl enable zookeeper.service
-# 
+#
 # When running, it should listen on localhost:2181
 #   netstat -an | fgrep 2181
-
 
 [Unit]
 Description=Apache Zookeeper server (Kafka)

--- a/app/alarm/examples/zookeeper.service
+++ b/app/alarm/examples/zookeeper.service
@@ -1,15 +1,16 @@
-# File /etc/systemd/system/zookeeper.service
+# /etc/systemd/system/zookeeper.service
 #
 # Start/status/stop
 #   sudo systemctl start zookeeper.service
 #   sudo systemctl status zookeeper.service
 #   sudo systemctl stop zookeeper.service
-#
+# 
 # Start when computer boots:
 #   sudo systemctl enable zookeeper.service
-#
+# 
 # When running, it should listen on localhost:2181
 #   netstat -an | fgrep 2181
+
 
 [Unit]
 Description=Apache Zookeeper server (Kafka)
@@ -19,9 +20,9 @@ After=network.target remote-fs.target
 
 [Service]
 Type=simple
-User=controls
-Group=users
-Environment=JAVA_HOME=/opt/jdk-10
+User=DESIRED_USER
+Group=DESIRED_GROUP
+Environment=JAVA_HOME=/PATH/TO/JDK
 ExecStart=/opt/kafka/bin/zookeeper-server-start.sh /opt/kafka/config/zookeeper.properties
 ExecStop=/opt/kafka/bin/zookeeper-server-stop.sh
 

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -39,12 +39,12 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/jackson-annotations-2.9.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/jackson-core-2.9.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/jackson-databind-2.9.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/kafka-clients-1.1.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/kafka-clients-2.0.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/slf4j-api-1.7.25.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/reactive-streams-1.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/rxjava-2.1.14.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/freetts-1.2.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/kafka-streams-1.1.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/kafka-streams-2.0.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/commons-codec-1.10.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/commons-logging-1.1.3.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-6.3.1.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -222,12 +222,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
 
     <!-- Reactive ('Flow') API used by PV -->

--- a/services/alarm-config-logger/pom.xml
+++ b/services/alarm-config-logger/pom.xml
@@ -44,12 +44,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.client</groupId>

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
@@ -14,11 +14,11 @@ import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
@@ -38,7 +38,7 @@ public class AlarmStateLogger implements Runnable {
     private final String topic;
     private Map<String, Object> serdeProps;
     private final Serde<AlarmStateMessage> alarmStateMessageSerde;
-    
+
     private final Pattern pattern = Pattern.compile("(\\w*://\\S*)");
 
     private IndexNameHelper indexNameHelper;
@@ -65,7 +65,7 @@ public class AlarmStateLogger implements Runnable {
         KStream<String, AlarmStateMessage> alarms = builder.stream(topic+"State",
                 Consumed.with(Serdes.String(), alarmStateMessageSerde)
                         .withTimestampExtractor(new TimestampExtractor() {
-                            
+
                             @Override
                             public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
                                 return record.timestamp();
@@ -113,14 +113,9 @@ public class AlarmStateLogger implements Runnable {
                     }
 
                     @Override
-                    public KeyValue<String, AlarmStateMessage> punctuate(long timestamp) {
-                        return null;
-                    }
-
-                    @Override
                     public void close() {
                         // TODO Auto-generated method stub
-                        
+
                     }
                 };
             }
@@ -132,7 +127,7 @@ public class AlarmStateLogger implements Runnable {
         try
         {
             indexNameHelper = new IndexNameHelper(topic + "_alarms", indexDateSpanUnits, indexDateSpanValue);
-        } 
+        }
         catch (Exception ex)
         {
             logger.log(Level.SEVERE, "Time based index creation failed.", ex);


### PR DESCRIPTION
Updates kafka setup info to 2.0.0
and also updates kafka client libs to 2.0.0.

Kafka now runs with JDK11, no need for #400.

Tested with both all new server and client,
as well as new client talking to older server.


