### PR TITLE
Fix alarm message handling when item deleted

### DIFF
--- a/app/alarm/examples/send_commands.sh
+++ b/app/alarm/examples/send_commands.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Send text to topic.
+# Originally created for commands, but can also be used to create test messages
+# by for example connecting to the Accelerator (config) topic and sending
+# /Accelerator/Main/SomePV!{"user":"me","host":"my.host","description":"SomePV"}
 
 if [ $# -ne 1 ]
 then
@@ -6,7 +11,7 @@ then
     exit 1
 fi
 
-topic="$1Command"
+topic="$1"
 
 echo "Example commands:"
 echo "dump!"

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClientLeaf.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClientLeaf.java
@@ -26,6 +26,8 @@ public class AlarmClientLeaf extends AlarmTreeItemWithState<ClientState> impleme
 {
     private volatile String description;
 
+    private volatile long timestamp = 0;
+
     private final AtomicBoolean enabled = new AtomicBoolean(true);
     private final AtomicBoolean latching = new AtomicBoolean(true);
     private final AtomicBoolean annunciating = new AtomicBoolean(true);
@@ -40,6 +42,22 @@ public class AlarmClientLeaf extends AlarmTreeItemWithState<ClientState> impleme
         super(parent, name, Collections.emptyList());
         description = name;
         state = new ClientState(SeverityLevel.OK, "", "", Instant.now(), SeverityLevel.OK, "");
+    }
+
+    /** @param timestamp Timestamp for this update (epoch millisec)
+     *  @param state State
+     *  @return <code>true</code> if this changed the state
+     */
+    public boolean setState(final long timestamp, ClientState state)
+    {
+        this.timestamp = timestamp;
+        return setState(state);
+    }
+
+    /** @return Timestamp of last state update (epoch millisec) */
+    public long getLastUpdateTimestamp()
+    {
+        return timestamp;
     }
 
     /** When requesting a configuration update,

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/KafkaHelper.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/KafkaHelper.java
@@ -10,9 +10,7 @@ package org.phoebus.applications.alarm.client;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -88,7 +86,6 @@ public class KafkaHelper
                     }
                     else
                         logger.info("Reading updates for " + part.topic());
-
             }
 
             @Override
@@ -120,7 +117,7 @@ public class KafkaHelper
 
         return producer;
     }
-    
+
     /**
      * Aggregate multiple topics into a single topic using KafkaStreams.
      * @param kafka_servers - Sever to connect to.
@@ -131,23 +128,17 @@ public class KafkaHelper
      */
     public static KafkaStreams aggregateTopics(String kafka_servers, List<String> topics, String aggregate_topic)
     {
-        Map<String, Object> props = new HashMap<>();
-        
+        final Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "Stream-To-Long-Term");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafka_servers);
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        
-        StreamsConfig config = new StreamsConfig(props);
 
-        StreamsBuilder builder = new StreamsBuilder();
-        
+        final StreamsBuilder builder = new StreamsBuilder();
+
         // Aggregate the topics by mapping the topic key value pairs one to one into the aggregate topic.
         builder.<String, String>stream(topics).mapValues(pair -> pair).to(aggregate_topic);
-        
-        KafkaStreams aggregate_stream = new KafkaStreams(builder.build(), config);
-        
-        return aggregate_stream;
-    }
 
+        return new KafkaStreams(builder.build(), props);
+    }
 }

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelReader.java
@@ -233,11 +233,11 @@ public class JsonModelReader
         return false;
     }
 
-    public static boolean updateAlarmState(final AlarmTreeItem<?> node, final Object json)
+    public static boolean updateAlarmState(final long timestamp, final AlarmTreeItem<?> node, final Object json)
     {
         final JsonNode actual = (JsonNode) json;
         if (node instanceof AlarmClientLeaf)
-            return updateAlarmLeafState((AlarmClientLeaf) node, actual);
+            return updateAlarmLeafState(timestamp, (AlarmClientLeaf) node, actual);
         if (node instanceof AlarmClientNode)
             return updateAlarmNodeState((AlarmClientNode) node, actual);
         return false;
@@ -297,14 +297,15 @@ public class JsonModelReader
         return new ClientState(severity, message, value, time, current_severity, current_message);
     }
 
-    /** @param node Node to update from json
+    /** @param timestamp Timestamp of the update
+     *  @param node Node to update from json
      *  @param json Json that might contain {@link ClientState}
      *  @return <code>true</code> if this changed the alarm state of the node
      */
-    private static boolean updateAlarmLeafState(final AlarmClientLeaf node, final JsonNode json)
+    private static boolean updateAlarmLeafState(final long timestamp, final AlarmClientLeaf node, final JsonNode json)
     {
         final ClientState state = parseClientState(json);
-        return (state != null)  &&  node.setState(state);
+        return (state != null)  &&  node.setState(timestamp, state);
     }
 
     private static boolean updateAlarmNodeState(final AlarmClientNode node, final JsonNode json)

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
@@ -105,6 +105,7 @@ public class ScrollBarRepresentation extends RegionBaseRepresentation<ScrollBar,
     {
         super.registerListeners();
         model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
         model_widget.propLimitsFromPV().addUntypedPropertyListener(this::limitsChanged);
         model_widget.propMinimum().addUntypedPropertyListener(this::limitsChanged);
         model_widget.propMaximum().addUntypedPropertyListener(this::limitsChanged);


### PR DESCRIPTION
As mentioned in #408, the alarm client reads messages from both the 'config' and 'state' topics. When an item is deleted and then added back in, the 'delete' messages from the config topic can arrive after the state messages, resulting in the wrong PV state being displayed.