### PR TITLE
Font popover localization issue - part 1

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.properties.ColorWidgetProperty;
 import org.csstudio.display.builder.model.properties.WidgetColor;
+import org.phoebus.framework.nls.NLS;
 import org.phoebus.ui.dialog.PopOver;
 
 import javafx.fxml.FXMLLoader;
@@ -50,7 +51,7 @@ public class WidgetColorPopOver extends PopOver
 	    try
         {
             final URL fxml = WidgetColorPopOver.class.getResource("WidgetColorPopOver.fxml");
-            final InputStream iStream = WidgetColorPopOver.class.getResourceAsStream("messages.properties");
+            final InputStream iStream = NLS.getMessages(WidgetColorPopOver.class);
             final ResourceBundle bundle = new PropertyResourceBundle(iStream);
             final FXMLLoader fxmlLoader = new FXMLLoader(fxml, bundle);
             final Node content = (Node) fxmlLoader.load();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.properties.FontWidgetProperty;
 import org.csstudio.display.builder.model.properties.WidgetFont;
+import org.phoebus.framework.nls.NLS;
 import org.phoebus.ui.dialog.PopOver;
 
 import javafx.fxml.FXMLLoader;
@@ -43,7 +44,7 @@ public class WidgetFontPopOver extends PopOver
         try
         {
             final URL fxml = WidgetFontPopOver.class.getResource("WidgetFontPopOver.fxml");
-            final InputStream iStream = WidgetFontPopOver.class.getResourceAsStream("messages.properties");
+            InputStream iStream = NLS.getMessages(WidgetFontPopOver.class);
             final ResourceBundle bundle = new PropertyResourceBundle(iStream);
             final FXMLLoader fxmlLoader = new FXMLLoader(fxml, bundle);
             final Node content = (Node) fxmlLoader.load();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
@@ -44,7 +44,7 @@ public class WidgetFontPopOver extends PopOver
         try
         {
             final URL fxml = WidgetFontPopOver.class.getResource("WidgetFontPopOver.fxml");
-            InputStream iStream = NLS.getMessages(WidgetFontPopOver.class);
+            final InputStream iStream = NLS.getMessages(WidgetFontPopOver.class);
             final ResourceBundle bundle = new PropertyResourceBundle(iStream);
             final FXMLLoader fxmlLoader = new FXMLLoader(fxml, bundle);
             final Node content = (Node) fxmlLoader.load();

--- a/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
+++ b/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
@@ -120,4 +120,29 @@ public class NLS
             getLogger().log(Level.SEVERE, "Error reading properties for " + clazz.getName(), ex);
         }
     }
+
+    /** Get stream for messages
+     *  Tries to open "messages_{LOCALE}.properties",
+     *  falling back to generic "messages.properties" 
+     *  @param clazz Class relative to which message resources are located
+     *  @returns Stream for messages or null
+     */
+    public static InputStream getMessages(Class<?> clazz)
+    {
+        // First try "messages_de.properties", "messages_fr.properties", "messages_zh.properties", ...
+        // based on locale
+        String filename = "messages_" + Locale.getDefault().getLanguage() + ".properties";
+        InputStream msg_props = clazz.getResourceAsStream(filename);
+
+        // Fall back to default file
+        if (msg_props == null)
+        {
+            filename = "messages.properties";
+            msg_props = clazz.getResourceAsStream(filename);
+        }
+
+        if (msg_props == null)
+            getLogger().log(Level.SEVERE, "Cannot open '" + filename  + "' for " + clazz.getName());
+        return msg_props;
+    }
 }


### PR DESCRIPTION
Solving issue #448 
NLS.java - helper for internationalization fxml dialogs
Color and Font PopOvers - using NLS instead of fixed filename for messages.properties