### PR TITLE
Update: Helper script and example for configuring product distrib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ To run the Phoebus application:
    *Run* ➜ *Run Main Project* menu item.
 
 
-## Complete Distribution, including manual
+## Complete Distribution, including manual and self-update
 
     # Obtain sources for Documentation and Product
     git clone https://github.com/kasemir/phoebus-doc.git
@@ -181,6 +181,18 @@ To run the Phoebus application:
     # Fetch dependencies
 	( cd phoebus; mvn clean verify -f dependencies/pom.xml )
 
+    # Create settings.ini for the product with current date
+    # and URL of your update site.
+    # Update site contains '$(arch)' which client will replace with
+    # its host OS (linux, mac, win).
+    # Note that this example replaces an existing product/settings.ini.
+    # If your product already contains settings.ini,
+    # consider using '>>' to append instead of replacing.
+    URL='https://controlssoftware.sns.ornl.gov/css_phoebus/nightly/phoebus-$(arch).zip'
+    ( cd phoebus;
+      app/update/mk_update_settings.sh $URL > phoebus-product/settings.ini
+    ) 
+    
     # Build product & bundle for distribution, including the documentation
     ( cd phoebus; ant clean dist )
    

--- a/app/update/mk_update_settings.sh
+++ b/app/update/mk_update_settings.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+then
+    echo 'Usage:  mk_update_settings.sh  url'
+    echo ''
+    echo 'URL, for example http://your.update.site/path/to/product-$(arch).zip,'
+    echo 'is where the update process will check for a new version.'
+    echo 'It may contain $(arch), which gets replaced by "linux", "mac" or "win"'
+    echo 'depending on the OS.'
+    echo ''
+    echo 'Redirect the output into a file settings.ini'
+    echo 'in the product directory, which will be bundled in the product distribution ZIP.'
+    echo ''
+fi
+
+URL="$1"
+# Use end of today as version, so anything build on the next day will look new
+# and suggest update
+VERSION=`date +'%Y-%m-%d 23:59'`
+
+echo ""
+echo "# Self-update"
+echo "org.phoebus.applications.update/current_version=$VERSION"
+echo "org.phoebus.applications.update/update_url=$URL"

--- a/phoebus-product/build.xml
+++ b/phoebus-product/build.xml
@@ -59,6 +59,7 @@
   <target name="dist" depends="jfxarch, product" description="Pack for distribution">
     <zip destfile="${build}/phoebus-${version}-${jfxarch}.zip">
       <zipfileset dir="${build}" includes="**/*.jar" prefix="phoebus-${version}"/>
+      <zipfileset dir="." includes="settings.ini" fullpath="phoebus-${version}/settings.ini"/>
       <zipfileset dir="." includes="phoebus.sh" fullpath="phoebus-${version}/phoebus.sh" filemode="755"/>
       <zipfileset dir="." includes="phoebus.bat" fullpath="phoebus-${version}/phoebus.bat"/>
       <zipfileset dir="." includes="phoebus.xml" fullpath="phoebus-${version}/phoebus.xml"/>


### PR DESCRIPTION
Adds a script and describes build process which includes 'settings.ini' that hold the build date and an update URL to enable self-updates.

#456