### PR TITLE
#468 fixing the stream creation properties

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmCmdLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmCmdLogger.java
@@ -40,8 +40,7 @@ public class AlarmCmdLogger implements Runnable {
         super();
         this.topic = topic;
 
-        MessageParser<AlarmCommandMessage> messageParser = new MessageParser<AlarmCommandMessage>(
-                AlarmCommandMessage.class);
+        MessageParser<AlarmCommandMessage> messageParser = new MessageParser<AlarmCommandMessage>(AlarmCommandMessage.class);
         alarmCommandMessageSerde = Serdes.serdeFrom(messageParser, messageParser);
     }
 
@@ -50,7 +49,7 @@ public class AlarmCmdLogger implements Runnable {
 
         logger.info("Starting the stream consumer");
 
-        Properties props = PropertiesHelper.getProperties();
+        Properties props = new Properties(PropertiesHelper.getProperties());
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-" + topic + "-alarm-cmd");
         if (!props.containsKey(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)) {
             props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
@@ -58,7 +57,8 @@ public class AlarmCmdLogger implements Runnable {
 
         StreamsBuilder builder = new StreamsBuilder();
         KStream<String, AlarmCommandMessage> alarms = builder.stream(topic + "Command", Consumed
-                .with(Serdes.String(), alarmCommandMessageSerde).withTimestampExtractor(new TimestampExtractor() {
+                .with(Serdes.String(), alarmCommandMessageSerde)
+                .withTimestampExtractor(new TimestampExtractor() {
 
                     @Override
                     public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
@@ -111,7 +111,7 @@ public class AlarmCmdLogger implements Runnable {
         final CountDownLatch latch = new CountDownLatch(1);
 
         // attach shutdown handler to catch control-c
-        Runtime.getRuntime().addShutdownHook(new Thread("streams-" + topic + "-alarm-shutdown-hook") {
+        Runtime.getRuntime().addShutdownHook(new Thread("streams-" + topic + "-alarm-cmd-shutdown-hook") {
             @Override
             public void run() {
                 streams.close(10, TimeUnit.SECONDS);

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
@@ -54,7 +54,7 @@ public class AlarmStateLogger implements Runnable {
     public void run() {
         logger.info("Starting the stream consumer");
 
-        Properties props = PropertiesHelper.getProperties();
+        Properties props = new Properties(PropertiesHelper.getProperties());
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-"+topic+"-alarm-state");
         if (!props.containsKey(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)) {
             props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
@@ -141,7 +141,7 @@ public class AlarmStateLogger implements Runnable {
         final CountDownLatch latch = new CountDownLatch(1);
 
         // attach shutdown handler to catch control-c
-        Runtime.getRuntime().addShutdownHook(new Thread("streams-"+topic+"-alarm-shutdown-hook") {
+        Runtime.getRuntime().addShutdownHook(new Thread("streams-"+topic+"-alarm-state-shutdown-hook") {
             @Override
             public void run() {
                 streams.close(10, TimeUnit.SECONDS);


### PR DESCRIPTION
@tanviash can you test this to ensure that both state and cmd messages are now being logged
based on the error in issue #468, Now that error message is no longer present and the stream topology seems correctly created