### PR TITLE
Autocomplete

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -101,8 +101,12 @@ public class EditorGUI
 
     private final EventHandler<KeyEvent> key_handler = event ->
     {
+        // Don't steal delete, backspace, ... from inline editor
+        if (editor.getSelectedWidgetUITracker().isInlineEditorActive())
+            return;
+
         final KeyCode code = event.getCode();
-        // System.out.println("Editor Key: " + event);
+        // System.out.println("Editor Key: " + code);
 
         // Only handle delete, copy, paste when mouse inside editor
         final boolean in_editor = editor.getContextMenuNode()

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -300,18 +300,20 @@ public class SelectedWidgetUITracker extends Tracker
         inline_editor.resize(Math.max(100, tracker.getWidth()), Math.max(20, tracker.getHeight()));
         getChildren().add(inline_editor);
 
-        //add autocomplete menu if editing property PVName
+        // Add autocomplete menu if editing property PVName
         if (property.getName().equals(CommonWidgetProperties.propPVName.getName()))
             PVAutocompleteMenu.INSTANCE.attachField(inline_editor);
 
-        // On enter, update the property. On Escape, just close
+        // On enter, update the property. On Escape, just close.
+        inline_editor.setOnAction(event ->
+        {
+            undo.execute(new SetMacroizedWidgetPropertyAction(property, inline_editor.getText()));
+            closeInlineEditor();
+        });
         inline_editor.setOnKeyPressed(event ->
         {
             switch (event.getCode())
             {
-            case ENTER:
-                undo.execute(new SetMacroizedWidgetPropertyAction(property, inline_editor.getText()));
-                // Fall through, close editor
             case ESCAPE:
                 event.consume();
                 closeInlineEditor();

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PVWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PVWidget.java
@@ -80,7 +80,7 @@ public class PVWidget extends VisibleWidget
     {
         super.defineProperties(properties);
         properties.add(pv_name = propPVName.createProperty(this, ""));
-        properties.add(pv_value = runtimePropPVValue.createProperty(this, RUNTIME_VALUE_NO_PV));
+        properties.add(pv_value = runtimePropPVValue.createProperty(this, null));
         properties.add(propBorderAlarmSensitive.createProperty(this, true));
     }
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import java.util.Objects;
+
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.RotationStep;
@@ -119,6 +121,7 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
      */
     private String computeText(final VType value)
     {
+        Objects.requireNonNull(model_widget, "No widget");
         if (value == null)
             return "<" + model_widget.propPVName().getValue() + ">";
         if (value == PVWidget.RUNTIME_VALUE_NO_PV)

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/ProposalService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/ProposalService.java
@@ -14,6 +14,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Logger;
 
+import org.phoebus.framework.jobs.NamedThreadFactory;
+
 /** Proposal Service
  *
  *  <p>When asked to lookup proposals for some text entered by user,
@@ -41,7 +43,7 @@ public class ProposalService
         public void handleProposals(String name, int priority, List<Proposal> proposals);
     }
 
-    private final ExecutorService pool = Executors.newCachedThreadPool();
+    private final ExecutorService pool = Executors.newCachedThreadPool(new NamedThreadFactory("ProposalService"));
     private final History history = new History();
     protected final List<ProposalProvider> providers;
     private final List<Future<?>> submitted = new ArrayList<>();

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteItem.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.ui.autocomplete;
+
+import javafx.scene.Node;
+
+/** Item shown in an {@link AutocompletePopup}
+ *  @author Kay Kasemir
+ */
+class AutocompleteItem
+{
+    final Node representation;
+    final Runnable action;
+
+    /** @param representation Node to show in list
+     *  @param action Action to run when item is selected. <code>null</code> for non-invokable items
+     */
+    AutocompleteItem(final Node representation, final Runnable action)
+    {
+        this.representation = representation;
+        this.action = action;
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteMenu.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteMenu.java
@@ -299,11 +299,10 @@ public class AutocompleteMenu
      */
     private void invokeAction(final TextInputControl field)
     {
-        logger.log(Level.FINE, () -> "InvokeAction: Selected " + field.getText());
-        if (field != null)
-            proposal_service.addToHistory(field.getText());
         if (field instanceof TextField)
         {
+            logger.log(Level.FINE, () -> "InvokeAction: Selected " + field.getText());
+            proposal_service.addToHistory(field.getText());
             final EventHandler<ActionEvent> action = ((TextField)field).getOnAction();
             if (action != null)
                 action.handle(new ActionEvent(field, null));

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteMenu.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompleteMenu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@ package org.phoebus.ui.autocomplete;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.phoebus.framework.autocomplete.MatchSegment;
 import org.phoebus.framework.autocomplete.Proposal;
@@ -19,11 +21,7 @@ import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-import javafx.geometry.Bounds;
-import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCode;
@@ -31,7 +29,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
 /** Menu for use with auto-completion.
@@ -42,49 +39,51 @@ import javafx.scene.text.TextFlow;
  *  @author Amanda Carpenter - Original version in Display Builder
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class AutocompleteMenu
 {
-    /** Result of a lookup, packaged for display in menu. */
+    // First implementation used a ContextMenu.
+    // The menu, however, tends to automatically select the item under the mouse.
+    // When simply typing text and pressing 'enter',
+    // that would accidentally pick the unexpectedly selected menu item
+    // instead of simply confirming what's entered.
+    // A popup window with list allows more control.
+    public static final Logger logger = Logger.getLogger(AutocompleteMenu.class.getPackageName());
+
+    /** Font used to highlight section of proposal */
+    private final Font header_font, highlight_font;
+
+    private final ProposalService proposal_service;
+
+    /** Result of a lookup, packaged with header for display in list */
     private class Result
     {
-        final SeparatorMenuItem header;
+        final Label header;
         final int priority;
         final List<Proposal> proposals;
 
         Result(final String name, final int priority, final List<Proposal> proposals)
         {
-            // Create non-selectable menu item
-            // CustomMenuItem seems natural, but it's traversed when using menu.
-            // http://tiwulfx.panemu.com/2013/01/02/creating-custom-menu-separator-in-javafx
-            // describes use of SeparatorMenuItem.setContent().
-            final Label label = new Label(name);
-            label.setFont(header_font);
-            header = new SeparatorMenuItem();
-            header.setContent(label);
+            header = new Label(name);
+            header.setFont(header_font);
 
             this.priority = priority;
             this.proposals = proposals;
         }
     }
 
-    private final ProposalService proposal_service;
-
+    /** All results. SYNC on access */
     private final TreeSet<Result> results = new TreeSet<>((a, b) -> a.priority - b.priority);
 
-    /** Context menu, shared by all attached fields,
+    /** Popup, shared by all attached fields,
      *  because shown for at most one field at a time.
-     *
-     *  <p>User data is set to the field that 'show()'s the menu.
      */
-    private final ContextMenu menu = new ContextMenu();
-
-    private boolean selected_menu_item = false;
-
+    private final AutocompletePopup menu = new AutocompletePopup();
 
     /** Toggle menu. On 'ENTER', add the manually entered value to history */
     private final EventHandler<KeyEvent> key_pressed_filter = event ->
     {
-        // System.out.println("Text field Key press " + event.getCode() + " on " + event.getSource());
+        logger.log(Level.FINE, () -> "Text field Key press " + event.getCode() + " on " + event.getSource());
         toggleMenu(event);
         if (event.isConsumed())
             return;
@@ -92,6 +91,7 @@ public class AutocompleteMenu
         final KeyCode code = event.getCode();
         if (code == KeyCode.ENTER)
         {
+            logger.log(Level.FINE, () -> "Add to history: " + field.getText());
             updateHistory(field.getText());
             menu.hide();
         }
@@ -108,7 +108,7 @@ public class AutocompleteMenu
      */
     private final EventHandler<KeyEvent> key_released_filter = event ->
     {
-        // System.out.println("Text field Key release " + event.getCode() + " on " + event.getSource());
+        logger.log(Level.FINE, () -> "Text field Key release " + event.getCode() + " on " + event.getSource());
         final TextField field = (TextField) event.getSource();
         final KeyCode code = event.getCode();
         if (code != KeyCode.SPACE    &&
@@ -129,7 +129,6 @@ public class AutocompleteMenu
         if (! focus)
         {
             menu.hide();
-            menu.getItems().clear();
             synchronized (results)
             {
                 results.clear();
@@ -137,54 +136,14 @@ public class AutocompleteMenu
         }
     };
 
-    /** Font used to highlight section of proposal */
-    private final Font header_font, highlight_font;
-
     /** Create autocomplete menu */
     public AutocompleteMenu(final ProposalService service)
     {
         this.proposal_service = service;
 
         final Font default_font = Font.getDefault();
-        header_font = Font.font(default_font.getFamily(), FontWeight.EXTRA_BOLD, default_font.getSize()+1);
-        highlight_font = Font.font(default_font.getFamily(), FontWeight.EXTRA_BOLD, default_font.getSize());
-
-        menu.addEventFilter(KeyEvent.KEY_PRESSED, event ->
-        {
-            // System.out.println("Menu Key press " + event.getCode() + " on " + event.getSource());
-            if (event.getCode() == KeyCode.ENTER)
-            {   // The menu will see 'ENTER' keys.
-                selected_menu_item = false;
-                // Let menu react, then check later
-                final TextInputControl field = (TextInputControl) menu.getUserData();
-                if (field != null)
-                    Platform.runLater(() ->
-                    {
-                        // If that key invokes a menu item -> Done.
-                        // Sometimes, however, when no menu item is active,
-                        // the ENTER key goes nowhere.
-                        // In that case, simulate 'enter' on the text field.
-                        if (selected_menu_item == false)
-                            invokeAction(field);
-                    });
-            }
-            else
-            {
-                toggleMenu(event);
-                // Pressing space in the active TextInputControl
-                // would be caught by the menu and activate the first menu item?!
-                // --> Filter plain SPACE
-                if (! event.isConsumed()  &&  event.getCode() == KeyCode.SPACE)
-                    event.consume();
-            }
-        });
-
-        menu.setOnHidden(event ->
-        {
-            // Speed GC by releasing items, since menu stays in memory forever
-            menu.getItems().clear();
-            menu.setUserData(null);
-        });
+        header_font = Font.font(default_font.getFamily(), FontWeight.BOLD, default_font.getSize());
+        highlight_font = Font.font(default_font.getFamily(), FontWeight.BOLD, default_font.getSize());
     }
 
     /** Attach the completion menu to a text field
@@ -250,18 +209,7 @@ public class AutocompleteMenu
 
     private void showMenuForField(final TextInputControl field)
     {
-        menu.setUserData(field);
-
-        // Same functionality as
-        //    menu.show(field, Side.BOTTOM, 0, 0);
-        // but preventing the menu from keeping an `ownerNode` reference
-        // to the field, which in turn keeps a reference to the UI
-        // and thus data of the attached field.
-        final Bounds bounds = field.localToScreen(field.getLayoutBounds());
-        menu.show(field.getScene().getWindow(), bounds.getMinX(), bounds.getMaxY());
-        // Alas, the menu.focused property can still hold on for a while ..
-        // So best is for all UI to release application data when closed,
-        // since complete disposal of the UI can take some time.
+        menu.show(field);
     }
 
     private void updateHistory(final String text)
@@ -282,17 +230,7 @@ public class AutocompleteMenu
 
     private void handleLookupResult(final TextInputControl field, final String text, final String name, final int priority, final List<Proposal> proposals)
     {
-        final List<MenuItem> items = new ArrayList<>();
-
-        // Assume the user is typing in the text field.
-        // When the menu is shown, the first item will _sometimes_ be auto-selected.
-        // When user presses ENTER, the text that the user just entered in the text field
-        // is replaced by the value of the first menu item, because it had been unwittingly invoked.
-        // By starting the menu with a bogus no-op item, that problem is averted.
-        // By making the text of that item match what the user entered,
-        // this almost appears to be on-purpose.
-        final MenuItem bogus = new MenuItem(null, new Text(text));
-        items.add(bogus);
+        final List<AutocompleteItem> items = new ArrayList<>();
 
         synchronized (results)
         {
@@ -303,16 +241,17 @@ public class AutocompleteMenu
             // then list proposals
             for (Result result : results)
             {
-                items.add(result.header);
+                // Pressing 'Enter' on header simply forwards the enter to the text field
+                items.add(new AutocompleteItem(result.header, () -> invokeAction(field)));
                 for (Proposal proposal : result.proposals)
-                    items.add(createMenuItem(field, text, proposal));
+                    items.add(createItem(field, text, proposal));
             }
         }
 
         // Update and show menu on UI thread
         Platform.runLater(() ->
         {
-            menu.getItems().setAll(items);
+            menu.setItems(items);
             if (! menu.isShowing())
                 showMenuForField(field);
         });
@@ -321,10 +260,10 @@ public class AutocompleteMenu
     /** @param field Field where user entered text
      *  @param text Text entered by user
      *  @param proposal Matching proposal
-     *  @return MenuItem that will apply the proposal
+     *  @return AutocompleteItem that will apply the proposal
      */
-    private MenuItem createMenuItem(final TextInputControl field,
-                                    final String text, final Proposal proposal)
+    private AutocompleteItem createItem(final TextInputControl field,
+                                        final String text, final Proposal proposal)
     {
         final TextFlow markup = new TextFlow();
         for (MatchSegment seg: proposal.getMatch(text))
@@ -341,21 +280,18 @@ public class AutocompleteMenu
                 match.setFont(highlight_font);
                 break;
             case NORMAL:
-                default:
+            default:
             }
             markup.getChildren().add(match);
         }
-        final MenuItem item = new MenuItem(null, markup);
-        item.setOnAction(event ->
+
+        return new AutocompleteItem(markup, () ->
         {
-            selected_menu_item = true;
             final String value = proposal.apply(text);
             field.setText(value);
             field.positionCaret(value.length());
             invokeAction(field);
         });
-
-        return item;
     }
 
     /** Try to invoke 'onAction' handler
@@ -363,6 +299,7 @@ public class AutocompleteMenu
      */
     private void invokeAction(final TextInputControl field)
     {
+        logger.log(Level.FINE, () -> "InvokeAction: Selected " + field.getText());
         if (field != null)
             proposal_service.addToHistory(field.getText());
         if (field instanceof TextField)
@@ -371,5 +308,6 @@ public class AutocompleteMenu
             if (action != null)
                 action.handle(new ActionEvent(field, null));
         }
+        menu.hide();
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.phoebus.ui.autocomplete;
 
+import static org.phoebus.ui.autocomplete.AutocompleteMenu.logger;
+
 import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 import javafx.geometry.Bounds;
 import javafx.scene.control.ListView;
@@ -20,6 +23,7 @@ import javafx.stage.Window;
 /** Popup for {@link AutocompleteItem}s
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 class AutocompletePopup extends PopupControl
 {
     private final AutocompletePopupSkin skin;
@@ -64,6 +68,11 @@ class AutocompletePopup extends PopupControl
         // held an `ownerNode` reference,
         // so not passing the field sped up GC.
         final Bounds bounds = field.localToScreen(field.getLayoutBounds());
+        if (bounds == null)
+        {
+            logger.log(Level.WARNING, "Cannot show popup", new Exception("No window"));
+            return;
+        }
 
         // Min. width of 620 is useful for long sim PVs
         ((ListView<?>) skin.getNode()).setPrefWidth(Math.max(620, bounds.getWidth()));

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.ui.autocomplete;
+
+import java.util.Collections;
+import java.util.List;
+
+import javafx.geometry.Bounds;
+import javafx.scene.control.ListView;
+import javafx.scene.control.PopupControl;
+import javafx.scene.control.TextInputControl;
+import javafx.stage.Window;
+
+/** Popup for {@link AutocompleteItem}s
+ *  @author Kay Kasemir
+ */
+class AutocompletePopup extends PopupControl
+{
+    private final AutocompletePopupSkin skin;
+
+    public AutocompletePopup()
+    {
+        skin = new AutocompletePopupSkin(this);
+        setSkin(skin);
+
+        // Speed GC by releasing items, since menu stays in memory forever
+        setOnHidden(event -> clear());
+    }
+
+    public void clear()
+    {
+        setItems(Collections.emptyList());
+    }
+
+    public void setItems(final List<AutocompleteItem> items)
+    {
+        skin.setItems(items);
+    }
+
+    public void show(final TextInputControl field)
+    {
+        // Back when using a ContextMenu,
+        //  menu.show(field, Side.BOTTOM, 0, 0);
+        // held an `ownerNode` reference,
+        // so not passing the field sped up GC.
+        final Bounds bounds = field.localToScreen(field.getLayoutBounds());
+
+        // Min. width of 620 is useful for long sim PVs
+        ((ListView<?>) skin.getNode()).setPrefWidth(Math.max(620, bounds.getWidth()));
+
+        final Window window = field.getScene().getWindow();
+        show(window, bounds.getMinX(), bounds.getMaxY());
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopup.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.phoebus.ui.autocomplete;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,6 +23,7 @@ import javafx.stage.Window;
 class AutocompletePopup extends PopupControl
 {
     private final AutocompletePopupSkin skin;
+    private WeakReference<TextInputControl> active_field;
 
     public AutocompletePopup()
     {
@@ -29,7 +31,18 @@ class AutocompletePopup extends PopupControl
         setSkin(skin);
 
         // Speed GC by releasing items, since menu stays in memory forever
-        setOnHidden(event -> clear());
+        setOnHidden(event ->
+        {
+            clear();
+            active_field = null;
+        });
+    }
+
+    TextInputControl getActiveField()
+    {
+        if (active_field == null)
+            return null;
+        return active_field.get();
     }
 
     public void clear()
@@ -44,8 +57,10 @@ class AutocompletePopup extends PopupControl
 
     public void show(final TextInputControl field)
     {
+        active_field = new WeakReference<>(field);
+
         // Back when using a ContextMenu,
-        //  menu.show(field, Side.BOTTOM, 0, 0);
+        //   menu.show(field, Side.BOTTOM, 0, 0);
         // held an `ownerNode` reference,
         // so not passing the field sped up GC.
         final Bounds bounds = field.localToScreen(field.getLayoutBounds());

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopupSkin.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopupSkin.java
@@ -16,6 +16,7 @@ import javafx.scene.Node;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Skin;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
@@ -70,6 +71,7 @@ class AutocompletePopupSkin implements Skin<AutocompletePopup>
 
     private void handleKey(final KeyEvent event)
     {
+        final TextInputControl field = popup.getActiveField();
         switch (event.getCode())
         {
         case ESCAPE:
@@ -79,6 +81,28 @@ class AutocompletePopupSkin implements Skin<AutocompletePopup>
         case ENTER:
             logger.log(Level.FINE, () -> "Pressed enter in list");
             runSelectedAction();
+            break;
+        case LEFT:
+            // Forward left/right from list which ignores them anyway
+            // to text field where user might want to move the cursor.
+            // Unclear why the caretposition is already updated
+            // in the 'shift' case, but still necessary to trigger selection.
+            if (field != null)
+            {
+                if (event.isShiftDown())
+                    field.selectPositionCaret(field.getCaretPosition());
+                else
+                    field.backward();
+            }
+            break;
+        case RIGHT:
+            if (field != null)
+            {
+                if (event.isShiftDown())
+                    field.selectPositionCaret(field.getCaretPosition());
+                else
+                    field.forward();
+            }
             break;
         default:
         }

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopupSkin.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/AutocompletePopupSkin.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.ui.autocomplete;
+
+import static org.phoebus.ui.autocomplete.AutocompleteMenu.logger;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.Skin;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+
+/** Skin for for {@link AutocompletePopup}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class AutocompletePopupSkin implements Skin<AutocompletePopup>
+{
+    private final AutocompletePopup popup;
+    private final ListView<AutocompleteItem> list = new ListView<>();
+
+    private class AutocompleteCell extends ListCell<AutocompleteItem>
+    {
+        @Override
+        protected void updateItem(final AutocompleteItem item, boolean empty)
+        {
+            super.updateItem(item, empty);
+            if (item == null  || empty)
+                setGraphic(null);
+            else
+                setGraphic(item.representation);
+        }
+    }
+
+    public AutocompletePopupSkin(final AutocompletePopup popup)
+    {
+        this.popup = popup;
+        list.setCellFactory(view -> new AutocompleteCell());
+
+        list.setOnMouseClicked(this::handleClick);
+        list.setOnKeyPressed(this::handleKey);
+    }
+
+    public void setItems(final List<AutocompleteItem> items)
+    {
+        list.getItems().setAll(items);
+
+        // Size list to show items
+        list.setPrefHeight(items.size() * 24 + 5);
+    }
+
+    private void handleClick(final MouseEvent event)
+    {
+        if (event.getButton() == MouseButton.PRIMARY)
+        {
+            logger.log(Level.FINE, () -> "Clicked in list");
+            runSelectedAction();
+        }
+    }
+
+    private void handleKey(final KeyEvent event)
+    {
+        switch (event.getCode())
+        {
+        case ESCAPE:
+            logger.log(Level.FINE, () -> "Pressed escape in list");
+            popup.hide();
+            break;
+        case ENTER:
+            logger.log(Level.FINE, () -> "Pressed enter in list");
+            runSelectedAction();
+            break;
+        default:
+        }
+    }
+
+    private void runSelectedAction()
+    {
+        final AutocompleteItem selected = list.getSelectionModel().getSelectedItem();
+        if (selected != null  &&  selected.action != null)
+            selected.action.run();
+    }
+
+    @Override
+    public AutocompletePopup getSkinnable()
+    {
+        return popup;
+    }
+
+    @Override
+    public Node getNode()
+    {
+        return list;
+    }
+
+    @Override
+    public void dispose()
+    {
+        list.getItems().clear();
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/autocomplete/PVAutocompleteMenu.java
+++ b/core/ui/src/main/java/org/phoebus/ui/autocomplete/PVAutocompleteMenu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/core/ui/src/test/java/org/phoebus/ui/autocomplete/AutocompleteMenuDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/autocomplete/AutocompleteMenuDemo.java
@@ -7,6 +7,10 @@
  *******************************************************************************/
 package org.phoebus.ui.autocomplete;
 
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
@@ -24,6 +28,11 @@ public class AutocompleteMenuDemo extends Application
     @Override
     public void start(final Stage stage) throws Exception
     {
+        final Logger logger = Logger.getLogger("");
+        logger.setLevel(Level.FINE);
+        for (Handler handler : logger.getHandlers())
+            handler.setLevel(logger.getLevel());
+
         final GridPane layout = new GridPane();
         layout.setHgap(5);
         layout.setVgap(5);

--- a/phoebus-product/src/main/resources/logging.properties
+++ b/phoebus-product/src/main/resources/logging.properties
@@ -18,8 +18,11 @@ java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$
 # but otherwise the source is more useful to locate the originating code.
 # java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s [%2$s] %5$s%6$s%n
 
-sun.net.www.protocol.http.HttpURLConnection.level = CONFIG
+# Throttle messages for certain packages
+# Raise back up from 'WARNING' to debug
 
+# Core java and general 3rd party libs
+sun.net.www.protocol.http.HttpURLConnection.level = CONFIG
 javafx.scene.control.level = WARNING
 javafx.css.level = WARNING
 javafx.scene.focus.level = WARNING
@@ -35,29 +38,30 @@ com.sun.speech.freetts.Voice.level = WARNING
 com.sun.speech.freetts.en.PartOfSpeechTagger.level = WARNING
 com.sun.speech.freetts.relp.AudioOutput.level = WARNING
 com.sun.jersey.level = WARNING
-
-# Throttle messages for certain packages
-# Raise back up from 'WARNING' to debug
 com.cosylab.epics.caj.level = WARNING
 org.epics.pvaccess.client.level = WARNING
+
+# Core packages 
+org.phoebus.framework.rdb.level = WARNING
 org.phoebus.framework.workbench.level = WARNING
+org.phoebus.security.level = WARNING
 org.phoebus.ui.javafx.BufferUtil.level = WARNING
 org.phoebus.ui.docking.level = WARNING
+org.phoebus.ui.autocomplete.level = WARNING
+org.phoebus.pv.level = WARNING
 org.phoebus.ui.application.PhoebusApplication.level = WARNING
 org.phoebus.ui.application.ApplicationLauncherService.level = WARNING
-org.phoebus.framework.rdb.level = WARNING
-org.phoebus.pv.level = WARNING
+
+# Applications
 org.phoebus.applications.filebrowser.level = WARNING
 org.phoebus.applications.pvtree.level = WARNING
 org.phoebus.applications.viewer3d.level = WARNING
 org.phoebus.archive.reader.level = WARNING
-org.phoebus.security.level = WARNING
+org.csstudio.javafx.rtplot.level = CONFIG
 org.csstudio.trends.databrowser3.level = WARNING
 org.csstudio.display.builder.level = WARNING
 org.csstudio.display.builder.model.level = WARNING
 org.csstudio.display.builder.runtime.level = WARNING
-org.csstudio.javafx.rtplot.level = CONFIG
 org.phoebus.applications.alarm.level = INFO
 org.phoebus.applications.email.level = WARNING
 org.csstudio.scan.level = WARNING
-


### PR DESCRIPTION
Fixes #469 by updating the autocompletion UI to a popup with list instead of a context menu to list the suggestions. Compared to previous version, ...

 * mouse which happens to be over a suggestion no longer activates that item.
   Need to either click it, or navigate to it via cursor up/down and then press Enter.

 * inline editor (double-click on widget with PV or text) accepts entered text or PV name with just one "Enter" instead of requiring pressing enter twice

 * inline editor handles 'backspace' and 'delete' which used to be suppressed
