### PR TITLE
Alarm log latch

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * A bean representing a alarm state message
- * 
+ *
  * @author Kunal Shroff
  *
  */
@@ -32,14 +32,11 @@ public class AlarmStateMessage {
 
     // The following fields are for logging purposes
     private Instant message_time;
+    private boolean latch;
 
     private String config;
     private String pv;
 
-
-    public AlarmStateMessage() {
-        super();
-    }
 
     public String getConfig() {
         return config;
@@ -63,6 +60,16 @@ public class AlarmStateMessage {
 
     public void setSeverity(String severity) {
         this.severity = severity;
+    }
+
+    public boolean isLatch()
+    {
+        return latch;
+    }
+
+    public void setLatch(boolean latch)
+    {
+        this.latch = latch;
     }
 
     public String getMessage() {
@@ -128,7 +135,7 @@ public class AlarmStateMessage {
 
     @JsonIgnore
     public void setInstant(Instant instant) {
-        this.time = new HashMap<String, String>();
+        this.time = new HashMap<>();
         this.time.put("seconds", String.valueOf(instant.getEpochSecond()));
         this.time.put("nano", String.valueOf(instant.getNano()));
     }

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
@@ -151,6 +151,7 @@ public class AlarmStateMessage {
         map.put("config", getConfig());
         map.put("pv", getPv());
         map.put("severity", getSeverity());
+        map.put("latch", Boolean.toString(isLatch()));
         map.put("message", getMessage());
         map.put("value", getValue());
         map.put("time", formatter.format(getInstant()));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui.tree;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.phoebus.applications.alarm.client.AlarmClient;
@@ -39,6 +38,7 @@ class AddComponentAction extends MenuItem
     private static class AddComponentDialog extends Dialog<String>
     {
         private final TextField name = new TextField();
+        private final Label message = new Label();
         private final RadioButton type_node = new RadioButton("Node"),
                                   type_pv = new RadioButton("PV/s");
 
@@ -56,7 +56,7 @@ class AddComponentAction extends MenuItem
             type_node.setTooltip(new Tooltip("Create a new node in the alarm configuration hierachy"));
 
             type_pv.setToggleGroup(types);
-            type_pv.setTooltip(new Tooltip("Add a PV or a list of PV's to the alarm configuration"));
+            type_pv.setTooltip(new Tooltip("Add a PV or a list of space-separated PVs to the alarm configuration"));
 
             layout.add(new HBox(5, type_node, type_pv), 1, 0);
 
@@ -72,6 +72,10 @@ class AddComponentAction extends MenuItem
             name.setTooltip(new Tooltip("Name of new node or PV"));
             GridPane.setHgrow(name, Priority.ALWAYS);
             layout.add(name, 1, 1);
+
+            layout.add(message, 1, 2);
+
+            name.textProperty().addListener( (prop, old, value) -> checkName(value));
 
             setTitle("Add Component to " + parent.getPathName());
             getDialogPane().setContent(layout);
@@ -90,9 +94,29 @@ class AddComponentAction extends MenuItem
             type_pv.selectedProperty().addListener(p -> Platform.runLater(() -> name.requestFocus()));
         }
 
+        private void checkName(final String name)
+        {
+            if (isPV())
+            {
+                final List<String> names = splitNames(name);
+                if (names.size() <= 1)
+                    message.setText("Enter one or more PV names, separated by spaces");
+                else
+                    message.setText("Adding " + names.size() + " PVs");
+            }
+            else
+                message.setText("");
+        }
+
         public boolean isPV()
         {
             return type_pv.isSelected();
+        }
+
+        // Allowing not just space as mentioned in tooltip and message, but also comma or semicolon
+        public static List<String> splitNames(final String names)
+        {
+            return List.of(names.split("[\\s,;]+"));
         }
     }
 
@@ -110,21 +134,16 @@ class AddComponentAction extends MenuItem
             final String new_name = dialog.showAndWait().orElse(null);
             if (new_name == null  ||  new_name.isEmpty())
                 return;
-            
+
             JobManager.schedule(getText(), monitor ->
             {
                 if (dialog.isPV())
                 {
-                    // allow the use of comma, semicolon, or space separated lists of pv's
-                    List<String> new_names = Arrays.asList(new_name.split("[\\s,;]+"));
-                    new_names.forEach(pv -> {
-                        model.addPV(parent.getPathName(), pv);
-                    });
+                    final List<String> new_names = AddComponentDialog.splitNames(new_name);
+                    new_names.forEach(pv ->  model.addPV(parent.getPathName(), pv));
                 }
                 else
-                {
                     model.addComponent(parent.getPathName(), new_name);
-                }
             });
         });
     }

--- a/services/alarm-logger/.classpath
+++ b/services/alarm-logger/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="src" output="target/classes" path="src/test/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
@@ -127,8 +127,8 @@ public class AlarmStateLogger implements Runnable {
                         value.setPv(pv);
 
                         // Did the severity for this PV change into MINOR, MAJOR, INVALID, UNDEFINED?
-                        // Then this message indicates the start of a latched alarm.
-                        // Otherwise the message indicates an update of the current_severity (still latched),
+                        // Then this message indicates that we just now "latch" the alarm.
+                        // Otherwise the message indicates an update of the current_severity (remaining latched),
                         // or an acknowledgement (same latched alarm),
                         // or an OK (alarm cleared).
                         final String severity = value.getSeverity();
@@ -136,8 +136,6 @@ public class AlarmStateLogger implements Runnable {
                         value.setLatch(! severity.equals(last_severity)  &&
                                        ! severity.equals("OK")           &&
                                        ! severity.endsWith("_ACK"));
-
-                        // System.out.println(pv + " - " + severity + (value.isLatch() ? " (latch)" : " (no change)"));
 
                         value.setMessage_time(Instant.ofEpochMilli(context.timestamp()));
                         return new KeyValue<>(key, value);

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmStateLogger.java
@@ -59,7 +59,7 @@ public class AlarmStateLogger implements Runnable {
      * Create a alarm state logger for the given alarm server topic * This runnable
      * will create the kafka streams for the given alarm messages which match the
      * format 'topicState'
-     * 
+     *
      * @param topic
      *            the alarm topic
      * @throws Exception
@@ -136,6 +136,8 @@ public class AlarmStateLogger implements Runnable {
                         value.setLatch(! severity.equals(last_severity)  &&
                                        ! severity.equals("OK")           &&
                                        ! severity.endsWith("_ACK"));
+
+                        // System.out.println(pv + " - " + severity + (value.isLatch() ? " (latch)" : " (no change)"));
 
                         value.setMessage_time(Instant.ofEpochMilli(context.timestamp()));
                         return new KeyValue<>(key, value);

--- a/services/alarm-logger/src/test/java/org/phoebus/alarm/logging/messages/MapperTest.java
+++ b/services/alarm-logger/src/test/java/org/phoebus/alarm/logging/messages/MapperTest.java
@@ -19,7 +19,7 @@ public class MapperTest {
 
     @Test
     public void AlarmStateMessageTest() {
-        String expectedJsonString = "{\"severity\":\"OK\",\"message\":\"OK\",\"value\":\"-2.5614483916185438\",\"time\":{\"seconds\":\"1531143702\",\"nanos\":\"487182900\"},\"current_severity\":\"OK\",\"current_message\":\"NONE\"}";
+        String expectedJsonString = "{\"severity\":\"OK\",\"message\":\"OK\",\"value\":\"-2.5614483916185438\",\"time\":{\"seconds\":\"1531143702\",\"nanos\":\"487182900\"},\"current_severity\":\"OK\",\"current_message\":\"NONE\",\"latch\":false}";
 
         AlarmStateMessage message = new AlarmStateMessage();
         message.setValue("-2.5614483916185438");
@@ -27,7 +27,7 @@ public class MapperTest {
         message.setMessage("OK");
         message.setCurrent_severity("OK");
         message.setCurrent_message("NONE");
-        HashMap<String, String> timeMap = new HashMap<String, String>();
+        HashMap<String, String> timeMap = new HashMap<>();
         timeMap.put("seconds", "1531143702");
         timeMap.put("nanos", "487182900");
         message.setTime(timeMap);

--- a/services/alarm-logger/startup/create_alarm_index.sh
+++ b/services/alarm-logger/startup/create_alarm_index.sh
@@ -28,6 +28,9 @@ curl -H 'Content-Type: application/json' -XPUT http://${es_host}:${es_port}/${1}
           "severity" : {
             "type" : "keyword"
           },
+          "latch" : {
+            "type" : "boolean"
+          },
           "message" : {
             "type" : "text"
           },
@@ -49,7 +52,7 @@ curl -H 'Content-Type: application/json' -XPUT http://${es_host}:${es_port}/${1}
             "type" : "text"
           },
           "mode" : {
-            "type" : "text"
+            "type" : "keyword"
           }
         }
       }

--- a/services/alarm-logger/startup/create_alarm_template.sh
+++ b/services/alarm-logger/startup/create_alarm_template.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
-if [ $# -ne 1 ]
-then
-    echo "Usage: create_alarm_template.sh"
-    exit 1
-fi
 
 es_host=localhost
 es_port=9200
@@ -90,3 +85,7 @@ curl -XPUT http://${es_host}:${es_port}/_template/alarms_cmd_template -H 'Conten
   }
 }
 '
+
+echo "Alarm templates:"
+curl -X GET "${es_host}:${es_port}/_template/*alarm*"
+

--- a/services/alarm-logger/startup/create_alarm_template.sh
+++ b/services/alarm-logger/startup/create_alarm_template.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ $# -ne 1 ]
 then
-    echo "Usage: create_alarm_index.sh accelerator"
+    echo "Usage: create_alarm_template.sh"
     exit 1
 fi
 
@@ -9,7 +9,7 @@ es_host=localhost
 es_port=9200
 
 # Create the elastic template with the correct mapping for alarm state messages.
-curl -XPUT http://${es_host}:${es_port}/_template/${1}_alarms_state_template -H 'Content-Type: application/json' -d'
+curl -XPUT http://${es_host}:${es_port}/_template/alarms_state_template -H 'Content-Type: application/json' -d'
 {
   "index_patterns":["*_alarms_state*"],
   "mappings" : {  
@@ -26,6 +26,9 @@ curl -XPUT http://${es_host}:${es_port}/_template/${1}_alarms_state_template -H 
           },
           "severity" : {
             "type" : "keyword"
+          },
+          "latch" : {
+            "type" : "boolean"
           },
           "message" : {
             "type" : "text"
@@ -48,7 +51,7 @@ curl -XPUT http://${es_host}:${es_port}/_template/${1}_alarms_state_template -H 
             "type" : "text"
           },
           "mode" : {
-            "type" : "text"
+            "type" : "keyword"
           }
         }
       }
@@ -56,8 +59,8 @@ curl -XPUT http://${es_host}:${es_port}/_template/${1}_alarms_state_template -H 
 }
 '
 
-# Create the elastic template with the correct mapping for alarm state messages.
-curl -XPUT http://${es_host}:${es_port}/_template/${1}_alarms_cmd_template -H 'Content-Type: application/json' -d'
+# Create the elastic template with the correct mapping for alarm command messages.
+curl -XPUT http://${es_host}:${es_port}/_template/alarms_cmd_template -H 'Content-Type: application/json' -d'
 {
   "index_patterns":["*_alarms_cmd*"],
   "mappings" : {  

--- a/services/alarm-logger/startup/create_alarm_template.sh
+++ b/services/alarm-logger/startup/create_alarm_template.sh
@@ -3,6 +3,9 @@
 es_host=localhost
 es_port=9200
 
+# The mapping names used in here need to match those used in the ElasticClientHelper:
+# "alarm", ""alarm_cmd", "alarm_config"
+
 # Create the elastic template with the correct mapping for alarm state messages.
 curl -XPUT http://${es_host}:${es_port}/_template/alarms_state_template -H 'Content-Type: application/json' -d'
 {
@@ -91,7 +94,7 @@ curl -XPUT http://${es_host}:${es_port}/_template/alarms_config_template -H 'Con
 {
   "index_patterns":["*_alarms_config*"],
   "mappings" : {  
-    "alarm_cmd" : {
+    "alarm_config" : {
         "properties" : {
           "APPLICATION-ID" : {
             "type" : "text"

--- a/services/alarm-logger/startup/delete_alarm_template.sh
+++ b/services/alarm-logger/startup/delete_alarm_template.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
-if [ $# -ne 1 ]
-then
-    echo "Usage: create_alarm_index.sh Accelerator"
-    exit 1
-fi
-
 es_host=localhost
 es_port=9200
 
 # Delete the elastic template with the correct mapping for alarm state messages.
-curl -XDELETE http://${es_host}:${es_port}/_template/${1}_alarms_state_template
+curl -XDELETE http://${es_host}:${es_port}/_template/alarms_state_template
 
 # Delete the elastic template with the correct mapping for alarm cmd messages.
-curl -XDELETE http://${es_host}:${es_port}/_template/${1}_alarms_cmd_template
+curl -XDELETE http://${es_host}:${es_port}/_template/alarms_cmd_template
+
+echo "Alarm templates:"
+curl -X GET "${es_host}:${es_port}/_template/*alarm*"


### PR DESCRIPTION
Alarm logger adds a "latch" field to the Elasticsearch docs to simplify reporting changes in alarm state vs. change in PV severity, #518

Makes "mode" field use keyword instead of text because it has very limited set of values.

Fix mapping name mentioned in #516 