### PR TITLE
File Browser: Context menu item to use selected folder as base

### DIFF
--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
@@ -320,6 +320,9 @@ public class FileBrowserController {
                     }
                     contextMenu.getItems().add(openWith);
                 }
+
+                if (file.isDirectory())
+                    contextMenu.getItems().add(new SetBaseDirectory(file, this::setRoot));
             }
 
             contextMenu.getItems().add(new CopyPath(selectedItems));

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/Messages.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/Messages.java
@@ -61,6 +61,7 @@ public class Messages
     public static String Rename;
     public static String RenameHdr;
     public static String RenameJobName;
+    public static String SetBaseDirectory;
     // ---
     // --- Keep alphabetically sorted and 'in sync' with messages.properties!
     // ---

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/SetBaseDirectory.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/SetBaseDirectory.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.filebrowser;
+
+import java.io.File;
+import java.util.function.Consumer;
+
+import javafx.scene.control.MenuItem;
+import javafx.scene.image.ImageView;
+
+/** Menu item that sets the base directory of the file browser
+ *  @author Kay Kasemir
+ */
+public class SetBaseDirectory extends MenuItem
+{
+    /** @param directory Directory to set */
+    public SetBaseDirectory(final File directory, final Consumer<File> setter)
+    {
+        super(Messages.SetBaseDirectory, new ImageView(FileTreeCell.folder_icon));
+        setOnAction(event -> setter.accept(directory));
+    }
+}
+

--- a/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
+++ b/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
@@ -41,3 +41,4 @@ Refresh=Refresh
 Rename=Rename
 RenameHdr=Enter new name:
 RenameJobName=Rename 
+SetBaseDirectory=Set as base directory

--- a/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
+++ b/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
@@ -41,4 +41,4 @@ Refresh=Refresh
 Rename=Rename
 RenameHdr=Enter new name:
 RenameJobName=Rename 
-SetBaseDirectory=Set as base directory
+SetBaseDirectory=Set as Base Directory


### PR DESCRIPTION
Makes file browser #135 more useful.

Context menu for a directory offers "Set as Base Directory" entry which focuses the file browser on that folder.


