### PR TITLE
 XYPlot: Use update throttle to avoid out-of-order handling of X vs. Y

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -285,11 +285,17 @@ public class EditorGUI
         // Handle copy/paste/...
         layout.addEventFilter(KeyEvent.KEY_PRESSED, key_handler);
 
-        // Request keyboard focus when mouse enters,
-        // to allow 'paste' etc.
-        // Without this filter, user would first need to select some widget
-        // before 'paste' is possible
-        layout.addEventFilter(MouseEvent.MOUSE_ENTERED, event ->  layout.requestFocus());
+        // We used to request keyboard focus when mouse enters,
+        // to allow copy/paste between two windows.
+        // Without this filter, user first needs to select some widget in the 'other'
+        // before 'paste' is possible in the 'other' window.
+        //   layout.addEventFilter(MouseEvent.MOUSE_ENTERED, event -> layout.requestFocus());
+        // The side effect, however, is that this breaks the natural focus handling:
+        // Use edits some property, for example a Label's text.
+        // Mouse moves by accident out and back into the window
+        // -> Focus now on 'layout', and that means the next Delete or Backspace
+        // meant to edit the text will instead delete the widget.
+        // https://github.com/kasemir/org.csstudio.display.builder/issues/486
 
         return layout;
     }

--- a/app/display/model/src/main/resources/examples/pvaccess/example.db
+++ b/app/display/model/src/main/resources/examples/pvaccess/example.db
@@ -1,0 +1,17 @@
+# Run as 
+#     softIocPVA -d example.db 
+
+record(calc, "counter01")
+{
+   field(SCAN, ".1 second")
+   field(INPA, "counter01")
+   field(CALC, "A<50 ? A+0.5 : 0")
+   field(EGU,  "counts")
+   field(PREC, "1")
+   field(HOPR, "50")
+   field(LOPR, "0")
+   field(HIGH, "30")
+   field(HIHI, "40")
+   field(HSV,  "MINOR")
+   field(HHSV, "MAJOR")
+}

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -246,7 +246,8 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         // PV changed value -> runtime updated X/Y value property -> valueChanged()
         private void valueChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
         {
-            logger.log(Level.CONFIG, model_widget.getName() + " " + property.getName() + " on " + Thread.currentThread());
+            logger.log(Level.FINE, () -> model_widget.getName() + " " + property.getName() + " on " + Thread.currentThread());
+            // Trigger computeTrace()
             throttle.trigger();
         }
 
@@ -308,7 +309,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
                 }
             }
 
-            logger.log(Level.CONFIG, () ->
+            logger.log(Level.FINE, () ->
             {
                 final StringBuilder buf = new StringBuilder();
                 buf.append(model_widget.getName()).append(" update ");
@@ -321,8 +322,6 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
 
             // Decouple from CAJ's PV thread
             final XYVTypeDataProvider latest = new XYVTypeDataProvider(x_data, y_data, error);
-            logger.log(Level.CONFIG, "Update to " + latest);
-
             trace.updateData(latest);
             plot.requestUpdate();
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYVTypeDataProvider.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYVTypeDataProvider.java
@@ -116,6 +116,6 @@ public class XYVTypeDataProvider implements PlotDataProvider<Double>
     @Override
     public String toString()
     {
-        return "XYVTypeDataProvider, lock: " + lock.toString();
+        return "XYVTypeDataProvider, " + items.length + " items, lock: " + lock.toString();
     }
 }


### PR DESCRIPTION
Import of RCP version, for kasemir/org.csstudio.display.builder#247