### PR TITLE
PV proposals for pva:// and mqtt://

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposal.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposal.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.autocomplete;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Proposal for "mqtt://..." PVs
+ *
+ *  <p>Description includes the optional type,
+ *  which are shown as {@link MatchSegment#COMMENT}
+ *  until the user provides parameters for them.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class MqttProposal extends Proposal
+{
+    private final String type;
+
+    public MqttProposal(final String path, final String type)
+    {
+        super(path);
+        this.type = type;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        final StringBuilder buf = new StringBuilder();
+        buf.append(value);
+        if (type != null)
+            buf.append('<').append(type).append('>');
+        return buf.toString();
+    }
+
+    /** Split complete PV into path, type
+     *
+     *  @param text
+     *  @return
+     */
+    static List<String> splitPathType(final String text)
+    {
+        final List<String> result = new ArrayList<>();
+
+        // Check for <type in mqtt://path<type>
+        int sep = text.indexOf('<');
+        if (sep >= 0)
+        {   // "path"
+            result.add(text.substring(0, sep).trim());
+
+            // Find end of <type>
+            int pos = text.indexOf('>', sep+1);
+            if (pos < 0)
+                // <type... is not terminated, use all as type
+                result.add(text.substring(sep+1).trim());
+            else
+                // <"type">
+                result.add(text.substring(sep+1, pos).trim());
+        }
+        else
+        {   // Just path, no type
+            result.add(text.trim());
+            result.add(null);
+        }
+        return result;
+    }
+
+    @Override
+    public List<MatchSegment> getMatch(final String text)
+    {
+        // Does text contain parameters?
+        final List<String> split = splitPathType(text);
+        if (split.size() < 1)
+            return List.of();
+
+        final List<MatchSegment> segs = new ArrayList<>(split.size());
+
+        String path = split.get(0).trim();
+        if (path.equals("mqtt://"))
+        {   // Just "mqtt://" matches, add "path"
+            segs.add(MatchSegment.match(path));
+            segs.add(MatchSegment.normal("path"));
+        }
+        else // Show (partial) match between entered path and this proposal
+            segs.addAll(super.getMatch(path));
+
+        // No type provided?
+        if (split.get(1) == null)
+            segs.add(MatchSegment.comment("<VType>"));
+        else if (type.toLowerCase().indexOf(split.get(1).toLowerCase()) >= 0)
+            // Recognize piece of type, accept for full type
+            segs.add(MatchSegment.match("<" + type + ">"));
+        else
+            // No type entered, would use this proposal's type when accepted
+            segs.add(MatchSegment.normal("<" + type + ">"));
+
+        return segs;
+    }
+}

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposal.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposal.java
@@ -74,7 +74,7 @@ public class MqttProposal extends Proposal
     @Override
     public List<MatchSegment> getMatch(final String text)
     {
-        // Does text contain parameters?
+        // Does text contain anything?
         final List<String> split = splitPathType(text);
         if (split.size() < 1)
             return List.of();

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposalProvider.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/MqttProposalProvider.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.autocomplete;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.phoebus.framework.spi.PVProposalProvider;
+
+/** Provider of {@link MqttProposal}s
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class MqttProposalProvider implements PVProposalProvider
+{
+    public static final MqttProposalProvider INSTANCE = new MqttProposalProvider();
+
+    private static final List<Proposal> generic = List.of(new MqttProposal("mqtt://path", "VType"));
+
+    private MqttProposalProvider()
+    {
+        // Singleton
+    }
+
+    @Override
+    public String getName()
+    {
+        return "MQTT PV";
+    }
+
+    /** Get proposals
+     *
+     *  @param text Text entered by user
+     *  @return {@link Proposal}s that could be applied to the text
+     */
+    @Override
+    public List<Proposal> lookup(final String text)
+    {
+        if (! text.startsWith("mqtt://"))
+            return generic;
+
+        final List<Proposal> result = new ArrayList<>();
+        final List<String> split = MqttProposal.splitPathType(text);
+
+        // Use the entered name, but add "mqtt://".
+        // Default to just "mqtt://path"
+        String name = split.get(0).trim();
+        if (name.isEmpty())
+            name = "mqtt://path";
+        else if (! name.startsWith("mqtt://"))
+            name = "mqtt://" + name;
+
+        // Use the entered type, or default to "VType"
+        String type = split.get(1);
+        if (type != null)
+        {
+            result.add(new MqttProposal(name, "VDouble"));
+            result.add(new MqttProposal(name, "VString"));
+        }
+        else
+            result.add(new MqttProposal(name, "VType"));
+        return result;
+    }
+}

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,10 +7,11 @@
  *******************************************************************************/
 package org.phoebus.framework.autocomplete;
 
-
 import java.util.ServiceLoader;
 
+import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.framework.spi.PVProposalProvider;
+import org.phoebus.framework.workbench.WorkbenchPreferences;
 
 /** Autocompletion Service for PVs
  *  @author Kay Kasemir
@@ -22,7 +23,14 @@ public class PVProposalService extends ProposalService
 
     private PVProposalService()
     {
-        super(SimProposalProvider.INSTANCE, LocProposalProvider.INSTANCE);
+        // Enable built-in proposal providers
+        final PreferencesReader prefs = new PreferencesReader(WorkbenchPreferences.class, "/autocomplete_preferences.properties");
+        if (prefs.getBoolean("enable_loc_pv_proposals"))
+            providers.add(LocProposalProvider.INSTANCE);
+        if (prefs.getBoolean("enable_sim_pv_proposals"))
+            providers.add(SimProposalProvider.INSTANCE);
+        if (prefs.getBoolean("enable_mqtt_pv_proposals"))
+            providers.add(MqttProposalProvider.INSTANCE);
 
         // Use SPI to add site-specific PV name providers
         for (PVProposalProvider add : ServiceLoader.load(PVProposalProvider.class))

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
@@ -29,6 +29,8 @@ public class PVProposalService extends ProposalService
             providers.add(LocProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_sim_pv_proposals"))
             providers.add(SimProposalProvider.INSTANCE);
+        if (prefs.getBoolean("enable_pva_pv_proposals"))
+            providers.add(PvaProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_mqtt_pv_proposals"))
             providers.add(MqttProposalProvider.INSTANCE);
 

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/PvaProposalProvider.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/PvaProposalProvider.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.autocomplete;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.phoebus.framework.spi.PVProposalProvider;
+
+/** Provider of {@link PvaProposal}s
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PvaProposalProvider implements PVProposalProvider
+{
+    public static final PvaProposalProvider INSTANCE = new PvaProposalProvider();
+
+    private static final List<Proposal> generic = List.of(new Proposal("pva://name"));
+
+    private PvaProposalProvider()
+    {
+        // Singleton
+    }
+
+    @Override
+    public String getName()
+    {
+        return "PV Access PV";
+    }
+
+    /** Get proposals
+     *  @param text Text entered by user
+     *  @return {@link Proposal}s that could be applied to the text
+     */
+    @Override
+    public List<Proposal> lookup(String text)
+    {
+        if (! text.startsWith("pva://"))
+            return generic;
+
+        final List<Proposal> result = new ArrayList<>();
+
+        // Use the entered name, but add "pva://".
+        // Default to just "pva://path"
+        if (text.isEmpty())
+            text = "pva://path";
+        else if (! text.startsWith("pva://"))
+            text = "pva://" + text;
+
+        result.add(new Proposal(text));
+        // If there's at least "pva://" plus one character for the name,
+        // mention that it's possible to address subfields
+        if (text.length() > 6  &&  text.indexOf('/', 7) < 0)
+        {
+            result.add(new Proposal(text + "/subfield"));
+            result.add(new Proposal(text + "/subfield/subelement"));
+        }
+        return result;
+    }
+}

--- a/core/framework/src/main/resources/autocomplete_preferences.properties
+++ b/core/framework/src/main/resources/autocomplete_preferences.properties
@@ -1,0 +1,10 @@
+# ------------------------------------------
+# Package org.phoebus.framework.autocomplete
+# ------------------------------------------
+
+# Enable the built-in PV proposal providers?
+enable_loc_pv_proposals=true
+enable_sim_pv_proposals=true
+enable_mqtt_pv_proposals=false
+
+# Site-specific proposal providers can be added via PVProposalProvider SPI

--- a/core/framework/src/main/resources/autocomplete_preferences.properties
+++ b/core/framework/src/main/resources/autocomplete_preferences.properties
@@ -5,6 +5,8 @@
 # Enable the built-in PV proposal providers?
 enable_loc_pv_proposals=true
 enable_sim_pv_proposals=true
+enable_pva_pv_proposals=true
 enable_mqtt_pv_proposals=false
 
-# Site-specific proposal providers can be added via PVProposalProvider SPI
+# Site-specific proposal providers can be added via PVProposalProvider SPI,
+# and disabled by removing the contribution.

--- a/core/pv/doc/index.rst
+++ b/core/pv/doc/index.rst
@@ -38,7 +38,7 @@ As shown, when accessing structures, the path to a nested structure element can 
 
 Simulated
 ---------
-Simulated process variables are ueful for tests. They do not communicate with the control system.
+Simulated process variables are useful for tests. They do not communicate with the control system.
 
 The provided simulated process variables are:
     * flipflop(update_seconds)


### PR DESCRIPTION
Implements #528 
pva:// proposals are by default enabled, mqtt:// props are not.
All the built-in proposals (loc, sim, pva, mqtt) can be enabled/disabled via preferences, no need to built custom product.