### PR TITLE
AlarmConfigLogger update with unique stream name

### DIFF
--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
@@ -75,7 +75,7 @@ public class AlarmConfigLogger implements Runnable {
         group_id = "Alarm-" + UUID.randomUUID();
 
         props = PropertiesHelper.getProperties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-" + this.topic + "-alarm-config");
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "AlarmConfigLogger-streams-" + this.topic);
         if (!props.containsKey(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)) {
             props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         }


### PR DESCRIPTION
@tanviash I suspect that the name space overlap in the KStreams might have resulted in the messages being randomly consumed by either of the two alarm micro services when run on the same machine.
Hopefully the following patch should address that.