### PR TITLE
Unmanaged widgets

### DIFF
--- a/app/display/model/src/main/resources/examples/plots_databrowser.bob
+++ b/app/display/model/src/main/resources/examples/plots_databrowser.bob
@@ -60,27 +60,4 @@ In addition, the context menu of the widget allows opening the full Data Browser
     <y>480</y>
     <tooltip>$(actions)</tooltip>
   </widget>
-  <widget type="databrowser" version="2.0.0">
-    <name>Data Browser_2</name>
-    <file>../../../../../../../../test3.plt</file>
-    <x>20</x>
-    <y>620</y>
-    <width>680</width>
-    <height>290</height>
-    <selection_value_pv>loc://cursor&lt;VTable&gt;</selection_value_pv>
-  </widget>
-  <widget type="table" version="2.0.0">
-    <name>Table</name>
-    <pv_name>loc://cursor&lt;VTable&gt;</pv_name>
-    <x>740</x>
-    <y>640</y>
-    <columns>
-      <column>
-        <name>Trace</name>
-        <width>100</width>
-        <editable>false</editable>
-      </column>
-    </columns>
-    <editable>false</editable>
-  </widget>
 </display>

--- a/app/display/model/src/main/resources/examples/template_and_script/many_bytemons.bob
+++ b/app/display/model/src/main/resources/examples/template_and_script/many_bytemons.bob
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display version="2.0.0">
+  <name>Many Instances</name>
+  <scripts>
+    <script file="EmbeddedPy">
+      <text><![CDATA[# This script is attached to a display
+# and triggered by a PV like 
+#     loc://initial_trigger$(DID)(1)
+# to execute once when the display is loaded.
+
+from org.csstudio.display.builder.runtime.script import ScriptUtil
+from org.csstudio.display.builder.model import WidgetFactory
+
+width = 100
+height = 25
+gap = 5
+
+display = widget.getDisplayModel()
+rows = 35
+for i in range(500):
+    x = gap + (i / rows) * (width+gap)
+    y = 40 + (height+gap)*(i % rows)
+
+    w = WidgetFactory.getInstance().getWidgetDescriptor("byte_monitor").createWidget();
+    w.setPropertyValue("x", x)
+    w.setPropertyValue("y", y)
+    w.setPropertyValue("width", width)
+    w.setPropertyValue("height", height)
+    w.setPropertyValue("pv_name", "sim://ramp(0, 15, 0.1)")
+    w.setPropertyValue("numBits", 4)
+
+    display.runtimeChildren().addChild(w)
+    
+]]></text>
+      <pv_name>loc://initial_trigger$(DID)(1)</pv_name>
+    </script>
+  </scripts>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Many Byte Monitors</text>
+    <width>490</width>
+    <height>31</height>
+    <font>
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+  </widget>
+</display>

--- a/app/display/model/src/main/resources/examples/template_and_script/many_leds.bob
+++ b/app/display/model/src/main/resources/examples/template_and_script/many_leds.bob
@@ -11,17 +11,17 @@
 from org.csstudio.display.builder.runtime.script import ScriptUtil
 from org.csstudio.display.builder.model import WidgetFactory
 
-width = 50
-height = 25
+width = 20
+height = 20
 gap = 5
 
 display = widget.getDisplayModel()
 rows = 35
-for i in range(500):
+for i in range(2000):
     x = gap + (i / rows) * (width+gap)
     y = 40 + (height+gap)*(i % rows)
 
-    w = WidgetFactory.getInstance().getWidgetDescriptor("textentry").createWidget();
+    w = WidgetFactory.getInstance().getWidgetDescriptor("led").createWidget();
     w.setPropertyValue("x", x)
     w.setPropertyValue("y", y)
     w.setPropertyValue("width", width)
@@ -36,7 +36,7 @@ for i in range(500):
   </scripts>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>Many Text Entries</text>
+    <text>Many LEDs</text>
     <width>490</width>
     <height>31</height>
     <font>

--- a/app/display/model/src/main/resources/examples/template_and_script/many_textentries.bob
+++ b/app/display/model/src/main/resources/examples/template_and_script/many_textentries.bob
@@ -17,11 +17,11 @@ gap = 5
 
 display = widget.getDisplayModel()
 rows = 35
-for i in range(2000):
+for i in range(500):
     x = gap + (i / rows) * (width+gap)
     y = 40 + (height+gap)*(i % rows)
 
-    w = WidgetFactory.getInstance().getWidgetDescriptor("textupdate").createWidget();
+    w = WidgetFactory.getInstance().getWidgetDescriptor("textentry").createWidget();
     w.setPropertyValue("x", x)
     w.setPropertyValue("y", y)
     w.setPropertyValue("width", width)

--- a/app/display/model/src/main/resources/examples/template_and_script/many_texts.bob
+++ b/app/display/model/src/main/resources/examples/template_and_script/many_texts.bob
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display version="2.0.0">
+  <name>Many Instances</name>
+  <scripts>
+    <script file="EmbeddedPy">
+      <text><![CDATA[# This script is attached to a display
+# and triggered by a PV like 
+#     loc://initial_trigger$(DID)(1)
+# to execute once when the display is loaded.
+
+print("??")
+from org.csstudio.display.builder.runtime.script import ScriptUtil
+from org.csstudio.display.builder.model import WidgetFactory
+
+width = 50
+height = 25
+gap = 5
+
+display = widget.getDisplayModel()
+rows = 35
+for i in range(2000):
+    x = gap + (i / rows) * (width+gap)
+    y = 40 + (height+gap)*(i % rows)
+
+    w = WidgetFactory.getInstance().getWidgetDescriptor("textupdate").createWidget();
+    w.setPropertyValue("x", x)
+    w.setPropertyValue("y", y)
+    w.setPropertyValue("width", width)
+    w.setPropertyValue("height", height)
+    w.setPropertyValue("pv_name", "sim://noise(-5,5,0.1)")
+
+    display.runtimeChildren().addChild(w)
+    print(i)
+    
+]]></text>
+      <pv_name>loc://initial_trigger$(DID)(1)</pv_name>
+    </script>
+  </scripts>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Many Text Updates</text>
+    <width>490</width>
+    <height>31</height>
+    <font>
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+  </widget>
+</display>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -56,8 +56,6 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         value_color = colors[0];
 
         final Pane pane = new Pane();
-        pane.setMinSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
-        pane.setMaxSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
 
         // Avoid expensive Node.notifyParentOfBoundsChange()
         pane.setManaged(false);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -73,12 +73,12 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             led = new Ellipse();
         led.getStyleClass().add("led");
         led.setManaged(false);
-        
+
         label = new Label();
         label.getStyleClass().add("led_label");
         label.setAlignment(Pos.CENTER);
         label.setManaged(false);
-        
+
         jfx_node.getChildren().addAll(led, label);
     }
 
@@ -227,9 +227,11 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         if (dirty_content.checkAndClear())
         {
             led.setFill(value_color);
-            label.setText(value_label);
-            // If text changed, is layout required?
-            // label.layout();
+            if (! value_label.equals(label.getText()))
+            {
+                label.setText(value_label);
+                label.layout();
+            }
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -58,6 +58,9 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         final Pane pane = new Pane();
         pane.setMinSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
         pane.setMaxSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
+
+        // Avoid expensive Node.notifyParentOfBoundsChange()
+        pane.setManaged(false);
         return pane;
     }
 
@@ -69,9 +72,13 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         else
             led = new Ellipse();
         led.getStyleClass().add("led");
+        led.setManaged(false);
+        
         label = new Label();
         label.getStyleClass().add("led_label");
         label.setAlignment(Pos.CENTER);
+        label.setManaged(false);
+        
         jfx_node.getChildren().addAll(led, label);
     }
 
@@ -200,7 +207,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             final int w = model_widget.propWidth().getValue();
             final int h = model_widget.propHeight().getValue();
 
-            jfx_node.setPrefSize(w, h);
+            jfx_node.resize(w, h);
             if (led instanceof Ellipse)
             {
                 final Ellipse ell = (Ellipse) led;
@@ -215,12 +222,14 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
                 rect.setWidth(w);
                 rect.setHeight(h);
             }
-            label.setPrefSize(w, h);
+            label.resize(w, h);
         }
         if (dirty_content.checkAndClear())
         {
             led.setFill(value_color);
             label.setText(value_label);
+            // If text changed, is layout required?
+            // label.layout();
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -67,8 +67,6 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         square_led = model_widget.propSquare().getValue();
         horizontal = model_widget.propHorizontal().getValue();
         addLEDs(pane);
-        pane.setMinSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
-        pane.setMaxSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
         pane.setManaged(false);
         return pane;
     }
@@ -180,7 +178,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                     else
                     {
                         label.relocate(x+2*rad+gap, y);
-                        label.setPrefSize(led_w-2*rad-gap, led_h);
+                        label.resize(led_w-2*rad-gap, led_h);
                     }
                 }
             }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -69,6 +69,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         addLEDs(pane);
         pane.setMinSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
         pane.setMaxSize(Pane.USE_PREF_SIZE, Pane.USE_PREF_SIZE);
+        pane.setManaged(false);
         return pane;
     }
 
@@ -135,6 +136,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                 label.getStyleClass().add("led_label");
                 label.setFont(text_font);
                 label.setTextFill(text_color);
+                label.setManaged(false);
             }
             else
                 label = null;
@@ -151,7 +153,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                 if (label != null)
                 {
                     label.relocate(x, y);
-                    label.setPrefSize(led_w, led_h);
+                    label.resize(led_w, led_h);
                     label.setAlignment(Pos.CENTER);
                     if (horizontal)
                         label.setRotate(-90);
@@ -172,7 +174,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                         label.getTransforms().setAll(new Rotate(-90.0));
                         // label.setBackground(new Background(new BackgroundFill(Color.BISQUE, CornerRadii.EMPTY, Insets.EMPTY)));
                         label.relocate(x, y+led_h);
-                        label.setPrefSize(led_h - 2*rad - gap, led_w);
+                        label.resize(led_h - 2*rad - gap, led_w);
                         label.setAlignment(Pos.CENTER_RIGHT);
                     }
                     else
@@ -183,11 +185,14 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                 }
             }
             led.getStyleClass().add("led");
+            led.setManaged(false);
             if (save_colorVals != null && i < save_colorVals.length)
                 led.setFill(save_colorVals[i]);
 
             leds[i] = led;
             labels[i] = label;
+            if (label != null)
+                label.layout();
             x += dx;
             y += dy;
         }
@@ -369,7 +374,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         {
             final int w = model_widget.propWidth().getValue();
             final int h = model_widget.propHeight().getValue();
-            jfx_node.setPrefSize(w, h);
+            jfx_node.resize(w, h);
             addLEDs(jfx_node, w, h, horizontal);
         }
         if (dirty_content.checkAndClear())

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -137,6 +137,11 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
                 }
             });
         }
+
+        // Reduce expensive Node.notifyParentOfBoundsChange() calls
+        // by handling pos & size in here
+        text.setManaged(false);
+
         return text;
     }
 
@@ -310,8 +315,8 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
     {
         super.updateChanges();
         if (dirty_size.checkAndClear())
-            jfx_node.setPrefSize(model_widget.propWidth().getValue(),
-                                 model_widget.propHeight().getValue());
+            jfx_node.resize(model_widget.propWidth().getValue(),
+                            model_widget.propHeight().getValue());
         if (dirty_style.checkAndClear())
         {
             final StringBuilder style = new StringBuilder(100);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -76,6 +76,12 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
         }
         final Label label = new Label();
         label.getStyleClass().add("text_update");
+
+        // This code manages layout,
+        // because otherwise for example border changes would trigger
+        // expensive Node.notifyParentOfBoundsChange() recursing up the scene graph
+        label.setManaged(false);
+
         return label;
     }
 
@@ -194,24 +200,24 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
             switch (rotation)
             {
             case NONE:
-                jfx_node.setPrefSize(width, height);
+                jfx_node.resize(width, height);
                 if (was_ever_transformed)
                     jfx_node.getTransforms().clear();
                 break;
             case NINETY:
-                jfx_node.setPrefSize(height, width);
+                jfx_node.resize(height, width);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-height, 0));
                 was_ever_transformed = true;
                 break;
             case ONEEIGHTY:
-                jfx_node.setPrefSize(width, height);
+                jfx_node.resize(width, height);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-width, -height));
                 was_ever_transformed = true;
                                break;
             case MINUS_NINETY:
-                jfx_node.setPrefSize(height, width);
+                jfx_node.resize(height, width);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(0, -width));
                 was_ever_transformed = true;
@@ -257,6 +263,8 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
                 ((Label)jfx_node).setText(value_text);
             else
                 ((TextArea)jfx_node).setText(value_text);
+            // Since jfx_node.isManaged() == false, need to trigger layout
+            jfx_node.layout();
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -161,6 +161,7 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
         image_plot = new RTImagePlot(! toolkit.isEditMode());
         image_plot.setUpdateThrottle(RepresentationUpdateThrottle.plot_update_delay, TimeUnit.MILLISECONDS);
         image_plot.setAutoscale(false);
+        image_plot.setManaged(false);
 
         if (! toolkit.isEditMode())
         {
@@ -456,8 +457,7 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
         {
             final int w = model_widget.propWidth().getValue();
             final int h = model_widget.propHeight().getValue();
-            image_plot.setPrefWidth(w);
-            image_plot.setPrefHeight(h);
+            image_plot.resize(w, h);
         }
         image_plot.requestUpdate();
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -382,6 +382,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         plot.setUpdateThrottle(RepresentationUpdateThrottle.plot_update_delay, TimeUnit.MILLISECONDS);
         plot.showToolbar(false);
         plot.showCrosshair(false);
+        plot.setManaged(false);
 
         // Create PlotMarkers once. Not allowing adding/removing them at runtime
         if (! toolkit.isEditMode())
@@ -564,8 +565,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         {
             final int w = model_widget.propWidth().getValue();
             final int h = model_widget.propHeight().getValue();
-            plot.setPrefWidth(w);
-            plot.setPrefHeight(h);
+            plot.resize(w, h);
         }
         plot.requestUpdate();
     }


### PR DESCRIPTION
Make some widgets 'unmanaged', especially those that often have an alarm border.

The border changes trigger calls to Node.notifyParentOfBoundsChange up the scene graph.
By making the main widget Node unmanaged, CPU usage was found to be reduced respectively update rates improved.

https://github.com/kasemir/org.csstudio.display.builder/issues/489