### PR TITLE
Handle missing widgets 547

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetIcons.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetIcons.java
@@ -44,7 +44,7 @@ public class WidgetIcons
             logger.log(Level.FINE, "Obtaining icon for widget type " + type);
             return new Image(descriptor.getIconURL().toExternalForm());
         }
-        catch (Exception ex)
+        catch (Throwable ex)
         {
             logger.log(Level.WARNING, "Cannot obtain widget for " + type, ex);
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseWidgetRepresentations.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseWidgetRepresentations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@ import static java.util.Map.entry;
 
 import java.util.Map;
 
+import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.widgets.ActionButtonWidget;
 import org.csstudio.display.builder.model.widgets.ArcWidget;
@@ -62,10 +63,20 @@ import org.csstudio.display.builder.representation.spi.WidgetRepresentationsServ
  */
 public class BaseWidgetRepresentations implements WidgetRepresentationsService
 {
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({ "unchecked", "rawtypes", "nls" })
     @Override
     public <TWP, TW> Map<WidgetDescriptor, WidgetRepresentationFactory<TWP, TW>> getWidgetRepresentationFactories()
     {
+        final WidgetDescriptor unknown_widget = new WidgetDescriptor(WidgetRepresentationFactory.UNKNOWN, null, WidgetRepresentationFactory.UNKNOWN, null, "Unknown Widget")
+        {
+            @Override
+            public Widget createWidget()
+            {
+                // Cannot create instance
+                return null;
+            }
+        };
+
         return Map.ofEntries(
             entry(ActionButtonWidget.WIDGET_DESCRIPTOR,    () -> (WidgetRepresentation) new ActionButtonRepresentation()),
             entry(ArcWidget.WIDGET_DESCRIPTOR,             () -> (WidgetRepresentation) new ArcRepresentation()),
@@ -104,6 +115,7 @@ public class BaseWidgetRepresentations implements WidgetRepresentationsService
             entry(ThermometerWidget.WIDGET_DESCRIPTOR,     () -> (WidgetRepresentation) new ThermometerRepresentation()),
             entry(Viewer3dWidget.WIDGET_DESCRIPTOR,        () -> (WidgetRepresentation) new Viewer3dRepresentation()),
             entry(WebBrowserWidget.WIDGET_DESCRIPTOR,      () -> (WidgetRepresentation) new WebBrowserRepresentation()),
-            entry(XYPlotWidget.WIDGET_DESCRIPTOR,          () -> (WidgetRepresentation) new XYPlotRepresentation()));
+            entry(XYPlotWidget.WIDGET_DESCRIPTOR,          () -> (WidgetRepresentation) new XYPlotRepresentation()),
+            entry(unknown_widget,                          () -> (WidgetRepresentation) new UnknownRepresentation()));
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
@@ -23,6 +26,7 @@ import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.representation.WidgetRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -83,10 +87,18 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
                     index = container.get().getProperty(ChildrenProperty.DESCRIPTOR).getValue().indexOf(model_widget);
             }
 
+            final ObservableList<Node> children = JFXRepresentation.getChildren(parent);
             if (index < 0)
-                JFXRepresentation.getChildren(parent).add(jfx_node);
+                children.add(jfx_node);
+            else if (index <= children.size())
+                children.add(index, jfx_node);
             else
-                JFXRepresentation.getChildren(parent).add(index, jfx_node);
+            {
+                // If one of the other sibling widgets cannot be represented,
+                // the 'index' will be useless.
+                logger.log(Level.WARNING, "Cannot represent " + model_widget + " at index " + index + " within parent, which has only " + children.size() + " nodes");
+                children.add(jfx_node);
+            }
 
             if (toolkit.isEditMode())
             {   // Any visible item can be 'clicked' to allow editor to 'select' it

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/UnknownRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/UnknownRepresentation.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.representation.javafx.widgets;
+
+import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
+import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.WidgetProperty;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderStroke;
+import javafx.scene.layout.BorderStrokeStyle;
+import javafx.scene.layout.BorderWidths;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.paint.Color;
+
+/** Creates JavaFX item for unknown model widget
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class UnknownRepresentation extends JFXBaseRepresentation<Label, Widget>
+{
+    private static final Color COLOR = Color.DARKGRAY;
+    private static final Border BORDER = new Border(new BorderStroke(COLOR, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT, Insets.EMPTY));
+    private final DirtyFlag dirty_size = new DirtyFlag();
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
+
+    @Override
+    public Label createJFXNode() throws Exception
+    {
+        final Label label = new Label("<" + model_widget.getType() + ">");
+        label.setBorder(BORDER);
+        label.setAlignment(Pos.CENTER);
+        label.setTextFill(COLOR);
+        label.setWrapText(true);
+        return label;
+    }
+
+    @Override
+    protected void registerListeners()
+    {
+        super.registerListeners();
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        super.unregisterListeners();
+    }
+
+    private void sizeChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
+    {
+        dirty_size.mark();
+        toolkit.scheduleUpdate(this);
+    }
+
+    @Override
+    public void updateChanges()
+    {
+        super.updateChanges();
+        if (dirty_size.checkAndClear())
+            jfx_node.setPrefSize(model_widget.propWidth().getValue(),
+                                 model_widget.propHeight().getValue());
+    }
+}

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -282,14 +282,17 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
      *  @return Toolkit item that represents the widget
      *  @see #disposeWidget(Object, Widget)
      */
+    @SuppressWarnings("unchecked")
     public void representWidget(final TWP parent, final Widget widget)
     {
-        @SuppressWarnings("unchecked")
-        final WidgetRepresentationFactory<TWP, TW> factory = (WidgetRepresentationFactory<TWP, TW>) factories.get(widget.getType());
+        WidgetRepresentationFactory<TWP, TW> factory = (WidgetRepresentationFactory<TWP, TW>) factories.get(widget.getType());
         if (factory == null)
         {
             logger.log(Level.SEVERE, "Lacking representation for " + widget.getType());
-            return;
+            // Check for a generic "unknown" representation
+            factory = (WidgetRepresentationFactory<TWP, TW>) factories.get(WidgetRepresentationFactory.UNKNOWN);
+            if (factory == null)
+                return;
         }
 
         final TWP re_parent;

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentationFactory.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentationFactory.java
@@ -16,8 +16,12 @@ import org.csstudio.display.builder.model.Widget;
  *  @param <TW> Toolkit widget base class
  */
 @FunctionalInterface
+@SuppressWarnings("nls")
 public interface WidgetRepresentationFactory<TWP, TW>
 {
+    /** Type used to represent unknown widgets */
+    public static final String UNKNOWN = "UNKNOWN";
+
     /** Construct representation for a model widget
      *  @throws Exception on error
      */


### PR DESCRIPTION
If a widget cannot be represented because it's not implemented/ported, prevent crash.
In addition, show a placeholder if 'UNKNOWN' representation is available.

#547