### PR TITLE
Fix XY Plot logscale

### DIFF
--- a/app/display/model/src/main/resources/examples/table_server/ca_table.bob
+++ b/app/display/model/src/main/resources/examples/table_server/ca_table.bob
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display version="2.0.0">
+  <name>Display</name>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <class>TITLE</class>
+    <text>Displaying Table From Channel Access</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>550</width>
+    <height>31</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_1</name>
+    <text>PV:</text>
+    <y>50</y>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update</name>
+    <pv_name>Demo:Table</pv_name>
+    <x>50</x>
+    <y>50</y>
+    <width>410</width>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_2</name>
+    <class>COMMENT</class>
+    <text>See ca_table_server.py</text>
+    <y>80</y>
+    <width>510</width>
+    <height>40</height>
+    <font use_class="true">
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <wrap_words use_class="true">true</wrap_words>
+  </widget>
+  <widget type="table" version="2.0.0">
+    <name>Table</name>
+    <y>120</y>
+    <width>310</width>
+    <columns>
+      <column>
+        <name>Column 1</name>
+        <width>100</width>
+        <editable>true</editable>
+      </column>
+      <column>
+        <name>Column 2</name>
+        <width>100</width>
+        <editable>true</editable>
+      </column>
+      <column>
+        <name>Column 3</name>
+        <width>100</width>
+        <editable>true</editable>
+      </column>
+    </columns>
+    <scripts>
+      <script file="EmbeddedPy">
+        <text><![CDATA[# Embedded python script
+from org.csstudio.display.builder.runtime.script import PVUtil, ScriptUtil
+
+# Fetch data from Channel Access,
+# in this case a string array
+data = PVUtil.getStringArray(pvs[0])
+
+# Package in rows
+rows = []
+for r in range(len(data) / 3):
+   i = 3*r
+   rows.append(list(data[i:(i+3)]))
+print(rows)
+
+widget.setValue(rows)
+]]></text>
+        <pv_name>Demo:Table</pv_name>
+      </script>
+    </scripts>
+    <row_selection_mode>true</row_selection_mode>
+    <selection_pv>loc://sel&lt;VTable&gt;</selection_pv>
+  </widget>
+  <widget type="table" version="2.0.0">
+    <name>Table_1</name>
+    <pv_name>loc://sel&lt;VTable&gt;</pv_name>
+    <x>350</x>
+    <y>270</y>
+    <width>420</width>
+    <height>140</height>
+    <columns>
+      <column>
+        <name>Column 1</name>
+        <width>100</width>
+        <editable>true</editable>
+      </column>
+    </columns>
+    <editable>false</editable>
+  </widget>
+</display>

--- a/app/display/model/src/main/resources/examples/table_server/ca_table_server.py
+++ b/app/display/model/src/main/resources/examples/table_server/ca_table_server.py
@@ -1,0 +1,62 @@
+# Python code that serves table data via Channel Access
+#
+# CA does not have a native table data type.
+# One option is a string array,
+# where the client knows about the number of columns
+# and reformates the flat list of cells as rows of columns.
+#
+# That's used here.
+#
+# The other option is to create a list(list),
+# then pickle into a byte array.
+# Since the client is also using python/jython,
+# it can un-pickle to get the list(list).
+#
+# pickle() allows for longer strings and changing
+# row and column counts, but the raw data is no
+# longer human readable as in the string array case.
+
+from pcaspy import SimpleServer, Driver
+import time
+
+prefix = 'Demo:'
+pvdb = {
+    'Table' : { 'type' : 'string', 'count' : 9 }
+}
+
+class MyDriver(Driver):
+    def __init__(self):
+        super(MyDriver, self).__init__()
+        
+        self.setParam('Table',
+                      [ 'A', 'B', 'C',
+                        'a', 'b', 'c',
+                        'x', 'y', 'z',
+                        'X', 'Y', 'Z'
+                      ]
+                     )
+
+
+server = SimpleServer()
+server.createPV(prefix, pvdb)
+driver = MyDriver()
+
+i = 0
+update = time.time() + 5
+while True:
+    # process CA transactions
+    server.process(0.1)
+    if time.time() > update:
+        i = i + 1
+        print("Update %d" % i)
+        si = str(i)
+        driver.setParam('Table',
+                      [ 'A'+si, 'B'+si, 'C'+si,
+                        'a'+si, 'b'+si, 'c'+si,
+                        'x'+si, 'y'+si, 'z'+si,
+                        'X'+si, 'Y'+si, 'Z'+si
+                      ]
+                     )
+        driver.updatePVs()
+        update = time.time() + 5
+    

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -122,6 +122,13 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
                 updateModelAxis(model_widget.propYAxes().getElement(index), y_axis);
         }
 
+        public void changedLogarithmic(final YAxis<?> y_axis)
+        {
+            final int index = plot.getYAxes().indexOf(y_axis);
+            if (index >= 0  &&  index < model_widget.propYAxes().size())
+                model_widget.propYAxes().getElement(index).logscale().setValue(y_axis.isLogarithmic());
+        };
+
         /** Invoked when auto scale is enabled or disabled by user interaction */
         @Override
         public void changedAutoScale(Axis<?> axis)


### PR DESCRIPTION
Import from RCP version:
In runtime, when using XY Plot config dialog to enable logscale, plot reverted to linear mode when showing/hiding toolbar.

Also import a new table example from RCP version.