### PR TITLE
Avoid BackingStoreException when renaming Preference files on Windows

### DIFF
--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/RenameAction.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/RenameAction.java
@@ -8,6 +8,8 @@
 package org.phoebus.applications.filebrowser;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.ui.dialog.DialogHelper;
@@ -45,7 +47,7 @@ public class RenameAction extends MenuItem
 
             JobManager.schedule(Messages.RenameJobName + item.getValue(), monitor ->
             {
-                file.renameTo(new File(file.getParentFile(), new_name));
+                Files.move(file.toPath(), (new File(file.getParentFile(), new_name)).toPath(), StandardCopyOption.REPLACE_EXISTING);
 
                 final FileTreeItem parent = (FileTreeItem)item.getParent();
                 Platform.runLater(() ->  parent.forceRefresh());

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/FileSystemPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/FileSystemPreferences.java
@@ -32,6 +32,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -597,11 +599,8 @@ class FileSystemPreferences extends AbstractPreferences {
                         FileOutputStream fos = new FileOutputStream(tmpFile);
                         FilePreferencesXmlSupport.exportMap(fos, prefsCache);
                         fos.close();
-                        if (!tmpFile.renameTo(prefsFile))
-                            throw new BackingStoreException("Can't rename " + tmpFile + " to " + prefsFile);
+                        Files.move(tmpFile.toPath(), prefsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     } catch (Exception e) {
-                        if (e instanceof BackingStoreException)
-                            throw (BackingStoreException) e;
                         throw new BackingStoreException(e);
                     }
                     return null;


### PR DESCRIPTION
See #377 