### PR TITLE
Text Entry widget: Submit on leaving widget, fix missing cursor

### DIFF
--- a/app/display/model/src/main/resources/examples/controls_textentry.bob
+++ b/app/display/model/src/main/resources/examples/controls_textentry.bob
@@ -185,12 +185,14 @@ starting a new line on each newline character in the text.
 Optionally, it can also wrap words to a new line when
 reaching the end of a line.
 
-Since pressing 'Enter' now simply starts a new line,
-'Control-Enter' now confirms editing and writes the entered value to the PV.</text>
+With 'Enter' now simply starting a new line, 'Control-Enter' confirms editing and writes the entered value to the PV.
+Since pressing 'Control-Enter' seems too hard for some users, the multi-lined text field will also submit the entered value to the PV when simply leaving the widget by clicking elsewhere.
+To cancel editing and revert to the original value, press 'Escape'.
+</text>
     <x>470</x>
     <y>391</y>
-    <width>359</width>
-    <height>210</height>
+    <width>370</width>
+    <height>260</height>
     <font use_class="true">
       <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>

--- a/app/display/model/src/main/resources/examples/controls_textentry.bob
+++ b/app/display/model/src/main/resources/examples/controls_textentry.bob
@@ -185,6 +185,8 @@ starting a new line on each newline character in the text.
 Optionally, it can also wrap words to a new line when
 reaching the end of a line.
 
+When activated, the multi-line variant will not select the complete text because users are more likely to edit just a subsection of the longer text.
+
 With 'Enter' now simply starting a new line, 'Control-Enter' confirms editing and writes the entered value to the PV.
 Since pressing 'Control-Enter' seems too hard for some users, the multi-lined text field will also submit the entered value to the PV when simply leaving the widget by clicking elsewhere.
 To cancel editing and revert to the original value, press 'Escape'.
@@ -192,7 +194,7 @@ To cancel editing and revert to the original value, press 'Escape'.
     <x>470</x>
     <y>391</y>
     <width>370</width>
-    <height>260</height>
+    <height>290</height>
     <font use_class="true">
       <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>

--- a/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
@@ -213,7 +213,7 @@ public class DBRHelper
             try
             {
                 if (is_array)
-                    return VEnumArray.of(new ArrayInteger(ArrayShort.of(xx.getEnumValue())), enum_meta, convertAlarm(dbr), convertTime(dbr));
+                    return VEnumArray.of(ArrayShort.of(xx.getEnumValue()), enum_meta, convertAlarm(dbr), convertTime(dbr));
                 return VEnum.of(xx.getEnumValue()[0], enum_meta, convertAlarm(dbr), convertTime(dbr));
             }
             catch (IndexOutOfBoundsException ex)


### PR DESCRIPTION
Import from RCP version, https://github.com/kasemir/org.csstudio.display.builder/issues/523

Fixes multi-line cursor and selection, https://github.com/kasemir/org.csstudio.display.builder/issues/524, by going back to managed widget