### PR TITLE
core-pv: Remove dependency on core-util

### DIFF
--- a/core/pv/.classpath
+++ b/core/pv/.classpath
@@ -6,7 +6,6 @@
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/python"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
-	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry exported="true" kind="lib" path="/phoebus-target/target/lib/epics-util-1.0.1-SNAPSHOT.jar"/>
 	<classpathentry exported="true" kind="lib" path="/phoebus-target/target/lib/vtype-1.0.1-SNAPSHOT.jar"/>

--- a/core/pv/src/test/java/org/phoebus/pv/ReactivePVTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/ReactivePVTest.java
@@ -21,7 +21,6 @@ import org.epics.vtype.Time;
 import org.epics.vtype.VNumber;
 import org.epics.vtype.VType;
 import org.junit.Test;
-import org.phoebus.util.time.TimestampFormats;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.disposables.Disposable;
@@ -176,14 +175,14 @@ public class ReactivePVTest
             .throttleLast(3, TimeUnit.SECONDS)
             .subscribe(value ->
             {
-                System.out.println("Last  : " + value + " @ " + TimestampFormats.MILLI_FORMAT.format(Instant.now()));
+                System.out.println("Last  : " + value + " @ " + Instant.now());
             });
         final Disposable latest = pv
             .onValueEvent(BackpressureStrategy.BUFFER)
             .throttleLatest(3, TimeUnit.SECONDS)
             .subscribe(value ->
             {
-                System.out.println("Latest: " + value + " @ " + TimestampFormats.MILLI_FORMAT.format(Instant.now()));
+                System.out.println("Latest: " + value + " @ " + Instant.now());
             });
 
         Thread.sleep(11000);


### PR DESCRIPTION
Was only used to print something in test.
Core-pv is easier to use outside of phoebus when deps are minimal.