### PR TITLE
Self-update: Download into 'updates', then move in startup script

### DIFF
--- a/app/update/src/main/java/org/phoebus/applications/update/Update.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/Update.java
@@ -126,10 +126,13 @@ public class Update
         if (! update_zip.canRead())
             throw new Exception("Cannot read " + update_zip);
 
-        monitor.updateTaskName("Delete " + install_location);
-        monitor.worked(10);
-        logger.info("Deleting " + install_location);
-        FileHelper.delete(install_location);
+        if (install_location.exists())
+        {
+            monitor.updateTaskName("Delete " + install_location);
+            monitor.worked(10);
+            logger.info("Deleting " + install_location);
+            FileHelper.delete(install_location);
+        }
 
         // Un-zip new distribution
         final SubJobMonitor sub = new SubJobMonitor(monitor, 80);

--- a/app/update/src/main/java/org/phoebus/applications/update/Update.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/Update.java
@@ -125,8 +125,6 @@ public class Update
             return;
         if (! update_zip.canRead())
             throw new Exception("Cannot read " + update_zip);
-        if (! install_location.canWrite())
-            throw new Exception("Cannot write " + install_location);
 
         monitor.updateTaskName("Delete " + install_location);
         monitor.worked(10);

--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
@@ -79,7 +79,7 @@ public class UpdateApplication implements AppDescriptor
         // So download into a stage area.
         // The start script needs to be aware of this stage area
         // and move it to the install location on startup.
-        final File stage_area = new File(install_location.getParentFile(), "staged_update");
+        final File stage_area = new File(install_location.getParentFile(), "update");
         final StringBuilder buf = new StringBuilder();
         buf.append("You are running version  ")
            .append(TimestampFormats.DATETIME_FORMAT.format(Update.current_version))

--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
@@ -79,7 +79,7 @@ public class UpdateApplication implements AppDescriptor
         // So download into a stage area.
         // The start script needs to be aware of this stage area
         // and move it to the install location on startup.
-        final File stage_area = new File(install_location.getParentFile(), "update");
+        final File stage_area = new File(install_location, "update");
         final StringBuilder buf = new StringBuilder();
         buf.append("You are running version  ")
            .append(TimestampFormats.DATETIME_FORMAT.format(Update.current_version))

--- a/dependencies/ant_settings.xml
+++ b/dependencies/ant_settings.xml
@@ -48,7 +48,7 @@
 
   <target name="compile-app" description="Compile application">
     <mkdir dir="${classes}"/>
-    <javac srcdir="${src}" destdir="${classes}" classpathref="app-classpath"/>
+    <javac srcdir="${src}" destdir="${classes}" debug="${debug}" classpathref="app-classpath"/>
   </target>
 	
   <target name="jfxarch" description="Determine JavaFX architecture">

--- a/phoebus-product/phoebus.bat
+++ b/phoebus-product/phoebus.bat
@@ -1,15 +1,34 @@
-REM Phoebus launcher for Windows
-REM When deploying, you might want to change "TOP"
-REM to the absolute installation path
+@REM Phoebus launcher for Windows
+@REM Uses a JDK that's located next to this folder,
+@REM otherwise assumes JDK is on the PATH
 
-set V=0.0.1
+@cd %~P0
 
-IF EXIST product-%V%.jar (
+@IF EXIST "%~P0%..\jdk" (
+    set JAVA_HOME=%~P0%..\jdk
+    @path %JAVA_HOME%\bin
+    @ECHO Found JDK %JAVA_HOME%
+)
+
+if EXIST "update" (
+    @ECHO Installing update...
+    @rd /S/Q doc
+    @rd /S/Q lib
+    @move /Y update\*.* .
+    @move /Y update\doc .
+    @move /Y update\lib .
+    @rmdir update
+    @ECHO Updated.
+)
+
+@set V=0.0.1
+
+@IF EXIST product-%V%.jar (
   SET JAR=product-%V%.jar
 ) ELSE (
   SET JAR=product-%V%-SNAPSHOT.jar
 
 )
 
-java -jar %JAR% %*
+@java -jar %JAR% %*
 

--- a/phoebus-product/phoebus.bat
+++ b/phoebus-product/phoebus.bat
@@ -10,7 +10,7 @@
     @ECHO Found JDK %JAVA_HOME%
 )
 
-if EXIST "update" (
+@if EXIST "update" (
     @ECHO Installing update...
     @rd /S/Q doc
     @rd /S/Q lib
@@ -20,6 +20,8 @@ if EXIST "update" (
     @rmdir update
     @ECHO Updated.
 )
+
+@java -version
 
 @set V=0.0.1
 

--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -15,6 +15,17 @@ then
   TOP="$TOP/target"
 fi
 
+if [ -d "${TOP}/update" ]
+then
+  echo "Installing update..."
+  cd ${TOP}
+  rm -rf doc lib
+  mv update/* .
+  rmdir update
+  echo "Updated."
+fi
+
+
 V="0.0.1"
 
 # Use ant or maven jar?
@@ -26,6 +37,6 @@ else
 fi
 
 # To get one instance, use server mode
-OPT="-server 4918"
+# OPT="-server 4918"
 
 java -jar $JAR $OPT "$@" &


### PR DESCRIPTION
Wrapup of #669 :

On Windows, running product cannot update its jar files because they are locked.
Might be a bad idea to do that on other architectures as well.
Now downloading update into `${phoebus.install}/update`, and the start scripts then rename/move files from that folder before running the product.