### PR TITLE
pva:// Decode alarm ranges (was using wrong 'control' section)

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -259,7 +259,7 @@ class Decoders
                     ? noDisplay.getFormat()
                     : createNumberFormat(str.get());
             }
-            
+
             display = Range.of(PVStructureHelper.getDoubleValue(section, "limitLow", Double.NaN),
                                PVStructureHelper.getDoubleValue(section, "limitHigh", Double.NaN));
         }
@@ -279,7 +279,7 @@ class Decoders
             control = Range.undefined();
 
         // Decode valueAlarm_t valueAlarm
-        section = struct.getSubField(PVStructure.class, "control");
+        section = struct.getSubField(PVStructure.class, "valueAlarm");
         if (section != null)
         {
             alarm = Range.of(PVStructureHelper.getDoubleValue(section, "lowAlarmLimit", Double.NaN),


### PR DESCRIPTION
Can only decode complete alarm ranges, meaning both LOW and HIGH and/or both LOLO and HIHI need to be defined because of limitation in  `org.epics.util.stats.Range`, see 
https://github.com/epics-base/epicsCoreJava/issues/56