### PR TITLE
App wrappers

### DIFF
--- a/app/3dViewer/src/test/java/org/phoebus/app/viewer3d/Demo3dViewer.java
+++ b/app/3dViewer/src/test/java/org/phoebus/app/viewer3d/Demo3dViewer.java
@@ -8,8 +8,8 @@
 package org.phoebus.app.viewer3d;
 
 import org.phoebus.applications.viewer3d.Viewer3dPane;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -17,7 +17,7 @@ import javafx.stage.Stage;
  * Demo class for the {@link Viewer3dPane} class.
  * @author Evan Smith
  */
-public class Demo3dViewer extends Application
+public class Demo3dViewer extends ApplicationWrapper
 {
     @Override
     public void start(Stage primaryStage) throws Exception
@@ -31,6 +31,6 @@ public class Demo3dViewer extends Application
     
     public static void main(String[] args)
     {
-        launch(args);
+        launch(Demo3dViewer.class, args);
     }
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmAreaUIDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmAreaUIDemo.java
@@ -9,8 +9,8 @@ package org.phoebus.applications.alarm;
 
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.ui.area.AlarmAreaView;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -18,7 +18,7 @@ import javafx.stage.Stage;
  *  @author Evan Smith
  */
 @SuppressWarnings("nls")
-public class AlarmAreaUIDemo extends Application
+public class AlarmAreaUIDemo extends ApplicationWrapper
 {
     @Override
 	public void start(final Stage stage) throws Exception
@@ -38,6 +38,6 @@ public class AlarmAreaUIDemo extends Application
 
 	public static void main(String[] args)
 	{
-		launch(args);
+		launch(AlarmAreaUIDemo.class, args);
 	}
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTableDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTableDemo.java
@@ -10,8 +10,8 @@ package org.phoebus.applications.alarm;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.ui.table.AlarmTableMediator;
 import org.phoebus.applications.alarm.ui.table.AlarmTableUI;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -19,7 +19,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlarmTableDemo extends Application
+public class AlarmTableDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -38,6 +38,6 @@ public class AlarmTableDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AlarmTableDemo.class, args);
     }
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTableUIDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTableUIDemo.java
@@ -20,8 +20,8 @@ import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.applications.alarm.ui.table.AlarmInfoRow;
 import org.phoebus.applications.alarm.ui.table.AlarmTableUI;
 import org.phoebus.framework.jobs.NamedThreadFactory;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Scene;
@@ -31,7 +31,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlarmTableUIDemo extends Application
+public class AlarmTableUIDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -99,6 +99,6 @@ public class AlarmTableUIDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AlarmTableUIDemo.class, args);
     }
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTreeUIDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AlarmTreeUIDemo.java
@@ -9,8 +9,8 @@ package org.phoebus.applications.alarm;
 
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.ui.tree.AlarmTreeView;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -18,7 +18,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlarmTreeUIDemo extends Application
+public class AlarmTreeUIDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -38,6 +38,6 @@ public class AlarmTreeUIDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AlarmTreeUIDemo.class, args);
     }
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AnnunciatorTableDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/AnnunciatorTableDemo.java
@@ -9,8 +9,8 @@ package org.phoebus.applications.alarm;
 
 import org.phoebus.applications.alarm.talk.TalkClient;
 import org.phoebus.applications.alarm.ui.annunciator.AnnunciatorTable;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -19,7 +19,7 @@ import javafx.stage.Stage;
  *  @author Evan Smith
  */
 @SuppressWarnings("nls")
-public class AnnunciatorTableDemo extends Application
+public class AnnunciatorTableDemo extends ApplicationWrapper
 {
     final TalkClient client = new TalkClient(AlarmSystem.server, AlarmSystem.config_name);
     final AnnunciatorTable table = new AnnunciatorTable(client);
@@ -33,16 +33,12 @@ public class AnnunciatorTableDemo extends Application
         stage.setTitle("Alarm Annunciator Table Demo");
         stage.show();
         client.start();
-    }
-
-    @Override
-    public void stop()
-    {
-        table.shutdown();
+        
+        stage.setOnCloseRequest(event -> table.shutdown());
     }
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AnnunciatorTableDemo.class, args);
     }
 }

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TitleDetailTableDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TitleDetailTableDemo.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import org.phoebus.applications.alarm.model.TitleDetail;
 import org.phoebus.applications.alarm.ui.tree.TitleDetailTable;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.BorderPane;
@@ -22,7 +22,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TitleDetailTableDemo extends Application
+public class TitleDetailTableDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -56,6 +56,6 @@ public class TitleDetailTableDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(TitleDetailTableDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/formula/FormulaDialogDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/formula/FormulaDialogDemo.java
@@ -12,15 +12,15 @@ import java.util.List;
 import org.csstudio.apputil.formula.ui.FormulaDialog;
 import org.csstudio.apputil.formula.ui.FormulaPane;
 import org.csstudio.apputil.formula.ui.InputItem;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of the {@link FormulaPane}
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class FormulaDialogDemo extends Application
+public class FormulaDialogDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -43,6 +43,6 @@ public class FormulaDialogDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(FormulaDialogDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/formula/FormulaPaneDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/formula/FormulaPaneDemo.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import org.csstudio.apputil.formula.ui.FormulaPane;
 import org.csstudio.apputil.formula.ui.InputItem;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
@@ -23,7 +23,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class FormulaPaneDemo extends Application
+public class FormulaPaneDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -52,6 +52,6 @@ public class FormulaPaneDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(FormulaPaneDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/AddPVDialogDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/AddPVDialogDemo.java
@@ -9,15 +9,15 @@ package org.csstudio.trends.databrowser3.ui;
 
 import org.csstudio.trends.databrowser3.model.Model;
 import org.csstudio.trends.databrowser3.model.PVItem;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of the {@link AddPVDialog}
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AddPVDialogDemo extends Application
+public class AddPVDialogDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -35,6 +35,6 @@ public class AddPVDialogDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AddPVDialogDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/FontButtonDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/FontButtonDemo.java
@@ -9,8 +9,8 @@ package org.csstudio.trends.databrowser3.ui;
 
 import org.csstudio.trends.databrowser3.ui.plot.ModelBasedPlot;
 import org.csstudio.trends.databrowser3.ui.properties.FontButton;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.text.Font;
@@ -22,7 +22,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class FontButtonDemo extends Application
+public class FontButtonDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -40,6 +40,6 @@ public class FontButtonDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(FontButtonDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/ModelBasedPlotDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/ModelBasedPlotDemo.java
@@ -14,8 +14,8 @@ import java.util.concurrent.TimeUnit;
 import org.csstudio.trends.databrowser3.model.AxisConfig;
 import org.csstudio.trends.databrowser3.model.PVItem;
 import org.csstudio.trends.databrowser3.ui.plot.ModelBasedPlot;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
@@ -26,7 +26,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ModelBasedPlotDemo extends Application
+public class ModelBasedPlotDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -59,6 +59,6 @@ public class ModelBasedPlotDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ModelBasedPlotDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/PerspectiveDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/PerspectiveDemo.java
@@ -7,14 +7,15 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser3.ui;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 /** Demo of the {@link Perspective}
  *  @author Kay Kasemir
  */
-public class PerspectiveDemo extends Application
+public class PerspectiveDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -27,6 +28,6 @@ public class PerspectiveDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(PerspectiveDemo.class, args);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/SearchViewDemo.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/ui/SearchViewDemo.java
@@ -10,9 +10,9 @@ package org.csstudio.trends.databrowser3.ui;
 import org.csstudio.trends.databrowser3.model.Model;
 import org.csstudio.trends.databrowser3.ui.plot.ModelBasedPlot;
 import org.csstudio.trends.databrowser3.ui.search.SearchView;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.ui.undo.UndoableActionManager;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
@@ -20,7 +20,7 @@ import javafx.stage.Stage;
 /** Demo of the {@link ModelBasedPlot}
  *  @author Kay Kasemir
  */
-public class SearchViewDemo extends Application
+public class SearchViewDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -35,6 +35,6 @@ public class SearchViewDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(SearchViewDemo.class, args);
     }
 }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/poly/PointsEditorDemo.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/poly/PointsEditorDemo.java
@@ -9,8 +9,8 @@ package org.csstudio.display.builder.editor.poly;
 
 import org.csstudio.display.builder.editor.EditorUtil;
 import org.csstudio.display.builder.model.properties.Points;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.paint.Color;
@@ -22,7 +22,7 @@ import javafx.stage.Stage;
 /** Demo of {@link PointsEditor}
  *  @author Kay Kasemir
  */
-public class PointsEditorDemo extends Application
+public class PointsEditorDemo extends ApplicationWrapper
 {
     private final Points points = new Points();
     private final Polyline poly = new Polyline();
@@ -76,6 +76,6 @@ public class PointsEditorDemo extends Application
 
     public static void main(String[] args) throws Exception
     {
-        launch(args);
+        launch(PointsEditorDemo.class, args);
     }
 }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialogDemo.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialogDemo.java
@@ -12,15 +12,15 @@ import java.util.List;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.rules.RuleInfo;
 import org.csstudio.display.builder.model.widgets.LabelWidget;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.ui.undo.UndoableActionManager;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Standalone demo if the RulesDialog
  *  @author Kay Kasemir
  */
-public class RulesDialogDemo extends Application
+public class RulesDialogDemo extends ApplicationWrapper
 {
     /** JavaFX Start */
     @Override
@@ -38,6 +38,6 @@ public class RulesDialogDemo extends Application
      */
     public static void main(final String[] args) throws Exception
     {
-        launch(args);
+        launch(RulesDialogDemo.class, args);
     }
 }

--- a/app/display/editor/src/test/java/org/csstudio/display/builder/editor/EditorDemo.java
+++ b/app/display/editor/src/test/java/org/csstudio/display/builder/editor/EditorDemo.java
@@ -16,9 +16,9 @@ import java.util.logging.LogManager;
 
 import org.csstudio.display.builder.editor.actions.ActionDescription;
 import org.csstudio.display.builder.model.ModelPlugin;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.ui.javafx.ImageCache;
 
-import javafx.application.Application;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -29,7 +29,7 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
 @SuppressWarnings("nls")
-public class EditorDemo extends Application
+public class EditorDemo extends ApplicationWrapper
 {
     private static String display_file = "../model/src/main/resources/examples/01_main.bob";
     private EditorGUI editor;
@@ -101,6 +101,6 @@ public class EditorDemo extends Application
 
         LogManager.getLogManager().readConfiguration(new FileInputStream("../../../phoebus-product/src/main/resources/logging.properties"));
 
-        launch(args);
+        launch(EditorDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -77,6 +77,7 @@ import javafx.scene.shape.Line;
 import javafx.scene.transform.Scale;
 import javafx.scene.transform.Transform;
 import javafx.stage.Window;
+import javafx.util.Duration;
 
 /** Represent model items in JavaFX toolkit
  *
@@ -976,6 +977,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
             {
                 final Media sound = new Media(url);
                 final MediaPlayer player = new MediaPlayer(sound);
+                player.setStartTime(Duration.ZERO);
                 result.complete(new AudioFuture(player));
             }
             catch (Exception ex)

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/AudioDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/AudioDemo.java
@@ -9,20 +9,27 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import java.io.File;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.media.Media;
 import javafx.scene.media.MediaPlayer;
 import javafx.stage.Stage;
+import javafx.util.Duration;
 
 /** JFX Audio demo
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AudioDemo extends Application
+public class AudioDemo extends ApplicationWrapper
 {
+    // At least with JDK11 and Mac OS X,
+    // MediaPlayer will stop, presumably because of GC,
+    // unless we hold on to it via e.g. a static reference
+    static MediaPlayer player;
+    
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(AudioDemo.class, args);
     }
 
     @Override
@@ -33,18 +40,24 @@ public class AudioDemo extends Application
 
         // Windows and Mac OS X support WAV and MP3
         // Linux: WAV hangs, MP3 results in MediaException for unsupported format
-        final File file =
-        //                new File("../org.csstudio.display.builder.model/examples/audio/timer.wav");
-                          new File("../org.csstudio.display.builder.model/examples/timer/timer.mp3");
+        final File file = new File("../model/src/main/resources/examples/timer/timer.mp3");
         final Media audio = new Media(file.toURI().toString());
-        final MediaPlayer player = new MediaPlayer(audio);
-        player.setOnEndOfMedia( () -> player.stop());
-        player.play();
-
+        player = new MediaPlayer(audio);
+        player.setOnError(() -> System.out.println("Error!"));
         player.setOnStopped(() ->
         {
+            System.out.println("Stopped.");
             player.dispose();
             stage.close();
         });
+        player.setOnEndOfMedia( () ->
+        {
+            System.out.println("Done.");
+            player.stop();
+        });
+        // Wasn't necessary with JDK9, but is with 11 on Mac OS X
+        player.setStartTime(Duration.seconds(0));
+        player.play();
+        System.out.println("Playing...");
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas0.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas0.java
@@ -9,7 +9,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import java.util.concurrent.Semaphore;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -25,7 +26,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class Canvas0 extends Application
+public class Canvas0 extends ApplicationWrapper
 {
     private final Canvas canvas = DemoHelper.createCanvas();
     private final Text updates = new Text("0");
@@ -34,7 +35,7 @@ public class Canvas0 extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(Canvas0.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas1.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas1.java
@@ -9,7 +9,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -26,7 +27,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class Canvas1 extends Application
+public class Canvas1 extends ApplicationWrapper
 {
     private final Canvas canvas = DemoHelper.createCanvas();
     private final AtomicLong counter = new AtomicLong();
@@ -34,7 +35,7 @@ public class Canvas1 extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(Canvas1.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas2.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas2.java
@@ -10,7 +10,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -44,7 +45,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class Canvas2 extends Application
+public class Canvas2 extends ApplicationWrapper
 {
     final private Canvas[] canvas = new Canvas[]
     {
@@ -60,7 +61,7 @@ public class Canvas2 extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(Canvas2.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas3.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas3.java
@@ -10,7 +10,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -32,7 +33,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class Canvas3 extends Application
+public class Canvas3 extends ApplicationWrapper
 {
     private final int IMAGE_WIDTH = 400;
     private final int IMAGE_HEIGHT = 400;
@@ -60,7 +61,7 @@ public class Canvas3 extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(Canvas3.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas4.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/Canvas4.java
@@ -11,7 +11,8 @@ import java.awt.image.BufferedImage;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Scene;
@@ -36,7 +37,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class Canvas4 extends Application
+public class Canvas4 extends ApplicationWrapper
 {
     final private Canvas canvas = DemoHelper.createCanvas();
     private final AtomicLong counter = new AtomicLong();
@@ -47,7 +48,7 @@ public class Canvas4 extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(Canvas4.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/DragDropDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/DragDropDemo.java
@@ -9,7 +9,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import java.time.Instant;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.input.ClipboardContent;
@@ -26,7 +27,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class DragDropDemo extends Application
+public class DragDropDemo extends ApplicationWrapper
 {
     public static Scene createScene()
     {
@@ -87,6 +88,6 @@ public class DragDropDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(DragDropDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/GroupVsPaneDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/GroupVsPaneDemo.java
@@ -1,6 +1,7 @@
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
@@ -30,7 +31,7 @@ import javafx.stage.Stage;
  *  As you move the green rectangles "off screen", the group adjusts its bounds to incorporate the changes,
  *  wherever possible, whereas the pane remains fixed.<<
  */
-public class GroupVsPaneDemo extends Application
+public class GroupVsPaneDemo extends ApplicationWrapper
 {
     @Override
     public void start(Stage primaryStage)
@@ -80,6 +81,6 @@ public class GroupVsPaneDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(GroupVsPaneDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageScaling.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageScaling.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -28,13 +29,13 @@ import javafx.stage.Stage;
  *
  *  @author Kay Kasemir
  */
-public class ImageScaling extends Application
+public class ImageScaling extends ApplicationWrapper
 {
     private static final int HEIGHT = 25, WIDTH = 155;
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ImageScaling.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageScaling2.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageScaling2.java
@@ -11,7 +11,8 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Group;
 import javafx.scene.Scene;
@@ -24,14 +25,14 @@ import javafx.stage.Stage;
  *
  *  @author Kay Kasemir
  */
-public class ImageScaling2 extends Application
+public class ImageScaling2 extends ApplicationWrapper
 {
     private static final int WIDTH = 800, HEIGHT = 600;
     private static final int IMAGE_WIDTH = 155, IMAGE_HEIGHT = 25;
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ImageScaling2.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageViewSizeDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ImageViewSizeDemo.java
@@ -9,7 +9,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import java.io.FileInputStream;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
@@ -23,11 +24,11 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ImageViewSizeDemo extends Application
+public class ImageViewSizeDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ImageViewSizeDemo.class, args);
     }
 
     @Override
@@ -36,7 +37,7 @@ public class ImageViewSizeDemo extends Application
         final Image image;
         try
         {
-            image = new Image(new FileInputStream("icons/embedded_script.png"));
+            image = new Image(new FileInputStream("src/main/resources/icons/embedded_script.png"));
         }
         catch (Exception ex)
         {

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/MenuButtonDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/MenuButtonDemo.java
@@ -10,8 +10,8 @@ package org.csstudio.display.builder.representation.javafx.sandbox;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
@@ -31,11 +31,11 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class MenuButtonDemo extends Application
+public class MenuButtonDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(MenuButtonDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/NavigationTabsDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/NavigationTabsDemo.java
@@ -14,8 +14,8 @@ import java.util.stream.IntStream;
 import org.csstudio.display.builder.model.properties.Direction;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 import org.csstudio.display.builder.representation.javafx.widgets.NavigationTabs;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -27,7 +27,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class NavigationTabsDemo extends Application
+public class NavigationTabsDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -70,6 +70,6 @@ public class NavigationTabsDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(NavigationTabsDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/PaneEllipsesDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/PaneEllipsesDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.geometry.VPos;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
@@ -24,12 +25,11 @@ import javafx.stage.Stage;
 
 //incorporate changing values, somehow
 @SuppressWarnings("nls")
-public class PaneEllipsesDemo extends Application
+public class PaneEllipsesDemo extends ApplicationWrapper
 {
-
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(PaneEllipsesDemo.class, args);
     }
 
 	final int number = 8;

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SliderDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SliderDemo.java
@@ -8,8 +8,8 @@
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import org.csstudio.display.builder.representation.javafx.widgets.SliderMarkers;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.geometry.Orientation;
 import javafx.scene.Scene;
 import javafx.scene.control.Slider;
@@ -21,11 +21,11 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class SliderDemo extends Application
+public class SliderDemo extends ApplicationWrapper
 {
     public static void main(String [] args)
     {
-        launch(args);
+        launch(SliderDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SliderGlitchDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SliderGlitchDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.Scene;
@@ -30,11 +31,11 @@ import javafx.stage.Stage;
  * 
  * @author Amanda Carpenter
  */
-public class SliderGlitchDemo extends Application
+public class SliderGlitchDemo extends ApplicationWrapper
 {
     public static void main(String [] args)
     {
-        launch(args);
+        launch(SliderGlitchDemo.class, args);
     }
 
     double startDragX = 0, startDragY = 0;

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SpinnerDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SpinnerDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
@@ -26,11 +27,11 @@ import javafx.stage.Stage;
  *  @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class SpinnerDemo extends Application
+public class SpinnerDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(SpinnerDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SplitPaneDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/SplitPaneDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
@@ -21,13 +22,13 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class SplitPaneDemo extends Application
+public class SplitPaneDemo extends ApplicationWrapper
 {
     final String DEBUG_STYLE = "-fx-background-color: rgb(255, 100, 0, 0.2)";
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(SplitPaneDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/StringTableDemo.java
@@ -11,7 +11,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -27,7 +28,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class StringTableDemo extends Application
+public class StringTableDemo extends ApplicationWrapper
 {
     private ObservableList<List<StringProperty>> data = FXCollections.observableArrayList();
     private TableView<List<StringProperty>> table = new TableView<>(data);
@@ -98,6 +99,6 @@ public class StringTableDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(StringTableDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/TabDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/TabDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.geometry.Side;
 import javafx.scene.Group;
 import javafx.scene.Scene;
@@ -55,7 +56,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TabDemo extends Application
+public class TabDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -103,6 +104,6 @@ public class TabDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(TabDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ThermoDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ThermoDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
 import javafx.scene.Scene;
@@ -35,14 +36,14 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.VLineTo;
 import javafx.stage.Stage;
 
-public class ThermoDemo extends Application
+public class ThermoDemo extends ApplicationWrapper
 {
     private double myHeight = 200;
     private double myWidth = 100;
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ThermoDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/WebBrowserDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/WebBrowserDemo.java
@@ -8,8 +8,8 @@
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
 import org.csstudio.display.builder.model.ModelPlugin;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
@@ -34,14 +34,14 @@ import javafx.stage.Stage;
  * @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class WebBrowserDemo extends Application
+public class WebBrowserDemo extends ApplicationWrapper
 {
     private double width = 750;
     private double height = 500;
 
     public static void main(String [] args)
     {
-        launch(args);
+        launch(WebBrowserDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ZoomPan.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/ZoomPan.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.sandbox;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.beans.InvalidationListener;
 import javafx.scene.Group;
 import javafx.scene.Node;
@@ -49,7 +50,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings({ "nls", "unused" })
-public class ZoomPan extends Application
+public class ZoomPan extends ApplicationWrapper
 {
     private static boolean zoom_in = false;
 
@@ -117,6 +118,6 @@ public class ZoomPan extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(ZoomPan.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXActionsDialogDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXActionsDialogDemo.java
@@ -20,21 +20,20 @@ import org.csstudio.display.builder.model.properties.OpenDisplayActionInfo.Targe
 import org.csstudio.display.builder.model.properties.ScriptInfo;
 import org.csstudio.display.builder.model.properties.WritePVActionInfo;
 import org.csstudio.display.builder.representation.javafx.ActionsDialog;
-import org.csstudio.display.builder.representation.javafx.MacrosDialog;
 import org.phoebus.framework.macros.Macros;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
-/** Demo of {@link MacrosDialog}
+/** Demo of {@link ActionsDialog}
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class JFXActionsDialogDemo  extends Application
+public class JFXActionsDialogDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXActionsDialogDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXColorMapDialogDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXColorMapDialogDemo.java
@@ -9,18 +9,18 @@ package org.csstudio.display.builder.representation.test;
 
 import org.csstudio.display.builder.model.properties.PredefinedColorMaps;
 import org.csstudio.display.builder.representation.javafx.ColorMapDialog;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of {@link ColorMapDialog}
  *  @author Kay Kasemir
  */
-public class JFXColorMapDialogDemo  extends Application
+public class JFXColorMapDialogDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXColorMapDialogDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXColorPopOverDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXColorPopOverDemo.java
@@ -13,8 +13,8 @@ import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.ColorWidgetProperty;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.representation.javafx.WidgetColorPopOver;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.BorderPane;
@@ -25,11 +25,11 @@ import javafx.stage.Stage;
  */
 @SuppressWarnings("nls")
 
-public class JFXColorPopOverDemo  extends Application
+public class JFXColorPopOverDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXColorPopOverDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXFontPopOverDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXFontPopOverDemo.java
@@ -12,8 +12,8 @@ import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.FontWidgetProperty;
 import org.csstudio.display.builder.representation.javafx.WidgetFontPopOver;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.BorderPane;
@@ -23,7 +23,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class JFXFontPopOverDemo extends Application
+public class JFXFontPopOverDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -50,6 +50,6 @@ public class JFXFontPopOverDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXFontPopOverDemo.class, args);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXMacrosDialogDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXMacrosDialogDemo.java
@@ -9,19 +9,19 @@ package org.csstudio.display.builder.representation.test;
 
 import org.csstudio.display.builder.representation.javafx.MacrosDialog;
 import org.phoebus.framework.macros.Macros;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of {@link MacrosDialog}
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class JFXMacrosDialogDemo extends Application
+public class JFXMacrosDialogDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXMacrosDialogDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXPointsDialogDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXPointsDialogDemo.java
@@ -9,18 +9,18 @@ package org.csstudio.display.builder.representation.test;
 
 import org.csstudio.display.builder.model.properties.Points;
 import org.csstudio.display.builder.representation.javafx.PointsDialog;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of {@link PointsDialog}
  *  @author Kay Kasemir
  */
-public class JFXPointsDialogDemo  extends Application
+public class JFXPointsDialogDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXPointsDialogDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXScriptsDialogDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/JFXScriptsDialogDemo.java
@@ -15,19 +15,19 @@ import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.properties.ScriptInfo;
 import org.csstudio.display.builder.model.properties.ScriptPV;
 import org.csstudio.display.builder.representation.javafx.ScriptsDialog;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
 /** Demo of {@link ScriptsDialog}
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class JFXScriptsDialogDemo extends Application
+public class JFXScriptsDialogDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(JFXScriptsDialogDemo.class, args);
     }
 
     @Override

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/RepresentationDemoJavaFX.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/test/RepresentationDemoJavaFX.java
@@ -10,21 +10,21 @@ package org.csstudio.display.builder.representation.test;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXStageRepresentation;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Parent;
 import javafx.stage.Stage;
 
 /** Java FX Demo
  *  @author Kay Kasemir
  */
-public class RepresentationDemoJavaFX extends Application
+public class RepresentationDemoJavaFX extends ApplicationWrapper
 {
     public static DummyRuntime runtime;
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(RepresentationDemoJavaFX.class, args);
         runtime.shutdown();
     }
 

--- a/app/email/src/test/java/org/phoebus/applications/email/EmailDialogDemo.java
+++ b/app/email/src/test/java/org/phoebus/applications/email/EmailDialogDemo.java
@@ -8,11 +8,11 @@
 package org.phoebus.applications.email;
 
 import org.phoebus.applications.email.actions.SendEmailAction;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.stage.Stage;
 
-public class EmailDialogDemo extends Application
+public class EmailDialogDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -22,6 +22,6 @@ public class EmailDialogDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(EmailDialogDemo.class, args);
     }
 }

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/ListSelectionDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/ListSelectionDemo.java
@@ -4,16 +4,18 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
-public class ListSelectionDemo extends Application {
+public class ListSelectionDemo extends ApplicationWrapper {
 
     public static void main(String[] args) {
-        launch(args);
+        launch(ListSelectionDemo.class, args);
     }
 
     @Override

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryCalenderDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryCalenderDemo.java
@@ -15,6 +15,7 @@ import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookImpl;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.TagImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
 
 import javafx.application.Application;
@@ -23,10 +24,10 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
-public class LogEntryCalenderDemo extends Application {
+public class LogEntryCalenderDemo extends ApplicationWrapper {
 
     public static void main(String[] args) {
-        launch(args);
+        launch(LogEntryCalenderDemo.class, args);
     }
 
     @Override

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryDisplayDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryDisplayDemo.java
@@ -20,6 +20,7 @@ import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookImpl;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.TagImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -27,12 +28,12 @@ import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
-public class LogEntryDisplayDemo extends Application {
+public class LogEntryDisplayDemo extends ApplicationWrapper {
 
     ScheduledExecutorService ex = Executors.newSingleThreadScheduledExecutor();
 
     public static void main(String[] args) {
-        launch(args);
+        launch(LogEntryDisplayDemo.class, args);
     }
 
     @Override

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntrySearchDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntrySearchDemo.java
@@ -15,6 +15,7 @@ import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookImpl;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.TagImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
 
 import javafx.application.Application;
@@ -23,10 +24,10 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
-public class LogEntrySearchDemo extends Application {
+public class LogEntrySearchDemo extends ApplicationWrapper {
 
     public static void main(String[] args) {
-        launch(args);
+        launch(LogEntrySearchDemo.class, args);
     }
 
     @Override

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo.java
@@ -16,6 +16,7 @@ import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookImpl;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.TagImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -24,10 +25,10 @@ import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
-public class LogEntryTableDemo extends Application {
+public class LogEntryTableDemo extends ApplicationWrapper {
 
     public static void main(String[] args) {
-        launch(args);
+        launch(LogEntryTableDemo.class, args);
     }
 
     @Override

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo2.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo2.java
@@ -16,15 +16,16 @@ import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookImpl;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.TagImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
-public class LogEntryTableDemo2 extends Application {
+public class LogEntryTableDemo2 extends ApplicationWrapper {
 
     public static void main(String[] args) {
-        launch(args);
+        launch(LogEntryTableDemo2.class, args);
     }
 
     private LogEntryTableControl control;

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/QueryParserTest.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/QueryParserTest.java
@@ -1,6 +1,5 @@
 package org.phoebus.logbook.ui;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URI;

--- a/app/pace/src/test/java/org/csstudio/display/pace/GUIDemo.java
+++ b/app/pace/src/test/java/org/csstudio/display/pace/GUIDemo.java
@@ -9,8 +9,8 @@ package org.csstudio.display.pace;
 import org.csstudio.display.pace.gui.GUI;
 import org.csstudio.display.pace.model.Model;
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -18,7 +18,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class GUIDemo extends Application
+public class GUIDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -38,6 +38,6 @@ public class GUIDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(GUIDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/BasicPlotDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/BasicPlotDemo.java
@@ -19,8 +19,8 @@ import org.csstudio.javafx.rtplot.internal.MouseMode;
 import org.csstudio.javafx.rtplot.internal.Plot;
 import org.csstudio.javafx.rtplot.internal.TraceImpl;
 import org.csstudio.javafx.rtplot.internal.YAxisImpl;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
@@ -30,7 +30,7 @@ import javafx.stage.Stage;
 /** @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class BasicPlotDemo extends Application
+public class BasicPlotDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -134,8 +134,8 @@ public class BasicPlotDemo extends Application
         });
     }
 
-    public static void main(final String[] args)
+    public static void main(String[] args)
     {
-        launch(args);
+        launch(BasicPlotDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/ImagePlotDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/ImagePlotDemo.java
@@ -18,9 +18,9 @@ import java.util.logging.Logger;
 import org.csstudio.javafx.rtplot.internal.ImagePlot;
 import org.epics.util.array.ArrayDouble;
 import org.epics.util.array.ListDouble;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.ui.javafx.Styles;
 
-import javafx.application.Application;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
@@ -32,7 +32,7 @@ import javafx.stage.Stage;
 /** @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ImagePlotDemo extends Application
+public class ImagePlotDemo extends ApplicationWrapper
 {
     private static final int WIDTH = 600, HEIGHT = 400;
 
@@ -145,6 +145,6 @@ public class ImagePlotDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(ImagePlotDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TankDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TankDemo.java
@@ -12,7 +12,8 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
@@ -21,7 +22,7 @@ import javafx.stage.Stage;
 /** @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TankDemo extends Application
+public class TankDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -74,6 +75,6 @@ public class TankDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(TankDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TimePlotDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TimePlotDemo.java
@@ -16,8 +16,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.csstudio.javafx.rtplot.util.RGBFactory;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
@@ -28,7 +28,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TimePlotDemo extends Application
+public class TimePlotDemo extends ApplicationWrapper
 {
     final private static int MAX_SIZE = 10000;
 
@@ -142,6 +142,6 @@ public class TimePlotDemo extends Application
     }
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(TimePlotDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/ValuePlotDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/ValuePlotDemo.java
@@ -23,8 +23,8 @@ import org.csstudio.javafx.rtplot.data.PlotDataProvider;
 import org.csstudio.javafx.rtplot.data.SimpleDataItem;
 import org.csstudio.javafx.rtplot.internal.MouseMode;
 import org.csstudio.javafx.rtplot.util.RGBFactory;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -32,7 +32,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ValuePlotDemo extends Application
+public class ValuePlotDemo extends ApplicationWrapper
 {
     final private static int MAX_SIZE = 10000;
     final private static boolean USE_LOG = false;
@@ -198,6 +198,6 @@ public class ValuePlotDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        ApplicationWrapper.launch(ValuePlotDemo.class, args);
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/util/RGBFactoryDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/util/RGBFactoryDemo.java
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.csstudio.javafx.rtplot.util;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.layout.TilePane;
@@ -18,7 +19,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class RGBFactoryDemo extends Application
+public class RGBFactoryDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -43,7 +44,7 @@ public class RGBFactoryDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(RGBFactoryDemo.class, args);
     }
 
 }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/dataplot/DataPlotDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/dataplot/DataPlotDemo.java
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.csstudio.scan.ui.dataplot;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -15,7 +16,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class DataPlotDemo extends Application
+public class DataPlotDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -33,6 +34,6 @@ public class DataPlotDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(DataPlotDemo.class, args);
     }
 }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/datatable/DataTableDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/datatable/DataTableDemo.java
@@ -9,15 +9,15 @@ package org.csstudio.scan.ui.datatable;
 
 import org.csstudio.scan.client.Preferences;
 import org.csstudio.scan.client.ScanClient;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 /** Demo of {@link DataTable}
  *  @author Kay Kasemir
  */
-public class DataTableDemo extends Application
+public class DataTableDemo extends ApplicationWrapper
 {
     private static final int SCAN_ID = 66;
 
@@ -32,6 +32,6 @@ public class DataTableDemo extends Application
 
     public static void main(String[] args) throws Exception
     {
-        launch(args);
+        launch(DataTableDemo.class, args);
     }
 }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/editor/EditorDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/editor/EditorDemo.java
@@ -17,13 +17,13 @@ import org.csstudio.scan.command.LoopCommand;
 import org.csstudio.scan.command.ScanCommand;
 import org.csstudio.scan.command.SetCommand;
 import org.csstudio.scan.command.WaitCommand;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 @SuppressWarnings("nls")
-public class EditorDemo extends Application
+public class EditorDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -59,6 +59,6 @@ public class EditorDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(EditorDemo.class, args);
     }
 }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/editor/StringArrayEditorDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/editor/StringArrayEditorDemo.java
@@ -10,8 +10,8 @@ package org.csstudio.scan.ui.editor;
 import java.util.List;
 
 import org.csstudio.scan.ui.editor.properties.StringArrayEditor;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -19,7 +19,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class StringArrayEditorDemo extends Application
+public class StringArrayEditorDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -33,6 +33,6 @@ public class StringArrayEditorDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(StringArrayEditorDemo.class, args);
     }
 }

--- a/app/scan/ui/src/test/java/org/csstudio/scan/ui/monitor/ScansTableDemo.java
+++ b/app/scan/ui/src/test/java/org/csstudio/scan/ui/monitor/ScansTableDemo.java
@@ -14,8 +14,8 @@ import org.csstudio.scan.client.ScanInfoModel;
 import org.csstudio.scan.client.ScanInfoModelListener;
 import org.csstudio.scan.info.ScanInfo;
 import org.csstudio.scan.info.ScanServerInfo;
+import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -23,7 +23,7 @@ import javafx.stage.Stage;
 /** {@link ScansTable} demo
  *  @author Kay Kasemir
  */
-public class ScansTableDemo extends Application
+public class ScansTableDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -70,6 +70,6 @@ public class ScansTableDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(ScansTableDemo.class, args);
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/ApplicationWrapper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/ApplicationWrapper.java
@@ -1,0 +1,44 @@
+package org.phoebus.ui.javafx;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+/** Horrible no-good {@link Application} wrapper
+ * 
+ *  <p>As described on http://mail.openjdk.java.net/pipermail/openjfx-dev/2018-June/021977.html,
+ *  when the Main class extends Application,
+ *  the sun.launcher.LauncherHelper expects to find JFX on the module path.
+ *  Having it on the classpath is not sufficient and aborts with 
+ *  "Error: JavaFX runtime components are missing..".
+ *  
+ *  <p>This wrapper detaches the {@link Application} from the Main class,
+ *  so no matter if JFX is on the classpath or modulepath,
+ *  it's resolved and the application runs.
+ *    
+ *  @author Kay Kasemir
+ */
+abstract public class ApplicationWrapper
+{
+    private static Class<? extends ApplicationWrapper> clazz;
+
+    public static class Wrapper extends Application
+    {
+        private ApplicationWrapper actual;
+        
+        public void start(final Stage stage) throws Exception
+        {
+            actual = clazz.getConstructor().newInstance();
+            actual.start(stage);
+        }
+    }
+    
+    // Same as Application.start(Stage)...
+    abstract public void start(final Stage stage) throws Exception;
+    
+    // Same as Application.launch(clazz, args)
+    public static void launch(Class<? extends ApplicationWrapper> clazz, final String[] args)
+    {
+        ApplicationWrapper.clazz = clazz;
+        Application.launch(Wrapper.class, args);
+    }
+}

--- a/core/ui/src/test/java/org/phoebus/ui/autocomplete/AutocompleteMenuDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/autocomplete/AutocompleteMenuDemo.java
@@ -11,7 +11,8 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -23,7 +24,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AutocompleteMenuDemo extends Application
+public class AutocompleteMenuDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -58,6 +59,6 @@ public class AutocompleteMenuDemo extends Application
 
     public static void main(String[] args)
     {
-        Application.launch(args);
+        launch(AutocompleteMenuDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/dialog/AlertWithToggleDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/dialog/AlertWithToggleDemo.java
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.ui.dialog;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.control.Alert.AlertType;
 import javafx.stage.Stage;
 
@@ -15,7 +16,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlertWithToggleDemo  extends Application
+public class AlertWithToggleDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -35,6 +36,6 @@ public class AlertWithToggleDemo  extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(AlertWithToggleDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/dialog/ExceptionDetailsErrorDialogDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/dialog/ExceptionDetailsErrorDialogDemo.java
@@ -7,14 +7,15 @@
  ******************************************************************************/
 package org.phoebus.ui.dialog;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.stage.Stage;
 
 /** Demo of the error dialog
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ExceptionDetailsErrorDialogDemo  extends Application
+public class ExceptionDetailsErrorDialogDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -24,6 +25,6 @@ public class ExceptionDetailsErrorDialogDemo  extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(ExceptionDetailsErrorDialogDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/dialog/ListPickerDialogDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/dialog/ListPickerDialogDemo.java
@@ -9,7 +9,8 @@ package org.phoebus.ui.dialog;
 
 import java.util.List;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Dialog;
@@ -20,7 +21,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ListPickerDialogDemo  extends Application
+public class ListPickerDialogDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -41,6 +42,6 @@ public class ListPickerDialogDemo  extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(ListPickerDialogDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/dialog/PopOverDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/dialog/PopOverDemo.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.phoebus.ui.dialog;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -19,7 +20,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PopOverDemo extends Application
+public class PopOverDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage)
@@ -44,6 +45,6 @@ public class PopOverDemo extends Application
 
     public static void main(String[] args)
     {
-        launch(args);
+        launch(PopOverDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/docking/DockingDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/docking/DockingDemo.java
@@ -9,7 +9,8 @@ package org.phoebus.ui.docking;
 
 import java.util.List;
 
-import javafx.application.Application;
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Color;
@@ -21,7 +22,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class DockingDemo extends Application
+public class DockingDemo extends ApplicationWrapper
 {
     public static void main(String[] args)
     {
@@ -33,7 +34,7 @@ public class DockingDemo extends Application
                                    "java.runtime.version"))
             System.out.println(prop + " = " + System.getProperty(prop));
 
-        launch(args);
+        launch(DockingDemo.class, args);
     }
 
     @Override

--- a/core/ui/src/test/java/org/phoebus/ui/javafx/ClearingTextFieldDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/javafx/ClearingTextFieldDemo.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.phoebus.ui.javafx;
 
-import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.BorderPane;
@@ -18,11 +17,11 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ClearingTextFieldDemo extends Application
+public class ClearingTextFieldDemo extends ApplicationWrapper
 {
     public static void main(String[] args)
     {
-        launch(args);
+        launch(ClearingTextFieldDemo.class, args);
     }
 
     @Override

--- a/core/ui/src/test/java/org/phoebus/ui/javafx/MultiCheckboxComboDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/javafx/MultiCheckboxComboDemo.java
@@ -9,7 +9,6 @@ package org.phoebus.ui.javafx;
 
 import java.util.List;
 
-import javafx.application.Application;
 import javafx.beans.Observable;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -21,7 +20,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class MultiCheckboxComboDemo extends Application
+public class MultiCheckboxComboDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -49,6 +48,6 @@ public class MultiCheckboxComboDemo extends Application
 
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(MultiCheckboxComboDemo.class, args);
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/javafx/StringTableDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/javafx/StringTableDemo.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
@@ -29,11 +28,11 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class StringTableDemo extends Application
+public class StringTableDemo extends ApplicationWrapper
 {
     public static void main(final String[] args)
     {
-        launch(args);
+        launch(StringTableDemo.class, args);
     }
 
     @Override

--- a/core/ui/src/test/java/org/phoebus/ui/time/TimeRelativeIntervalPaneDemo.java
+++ b/core/ui/src/test/java/org/phoebus/ui/time/TimeRelativeIntervalPaneDemo.java
@@ -9,10 +9,10 @@ package org.phoebus.ui.time;
 
 import java.time.Duration;
 
+import org.phoebus.ui.javafx.ApplicationWrapper;
 import org.phoebus.ui.time.TemporalAmountPane.Type;
 import org.phoebus.util.time.TimeRelativeInterval;
 
-import javafx.application.Application;
 import javafx.geometry.HPos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -23,7 +23,7 @@ import javafx.stage.Stage;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TimeRelativeIntervalPaneDemo extends Application
+public class TimeRelativeIntervalPaneDemo extends ApplicationWrapper
 {
     @Override
     public void start(final Stage stage) throws Exception
@@ -51,6 +51,6 @@ public class TimeRelativeIntervalPaneDemo extends Application
 
     public static void main(final String[] args)
     {
-        Application.launch(args);
+        launch(TimeRelativeIntervalPaneDemo.class, args);
     }
 }


### PR DESCRIPTION
Fixing the Java 11 issue where `class Main extends Application` only works when the JavaFX files are on the module path, throwing exception when they are on the class path.

Adds an intermediate `ApplicationWrapper` class to work around this problem and allow existing Demo code to run with minimal changes.