### PR TITLE
Reduce plot zoom threshold

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
@@ -66,7 +66,7 @@ abstract class PlotCanvasBase extends ImageView
      *  Smaller regions are likely the result of an accidental
      *  click-with-jerk, which would result into a huge zoom step.
      */
-    protected static final int ZOOM_PIXEL_THRESHOLD = 20;
+    protected static final int ZOOM_PIXEL_THRESHOLD = 5;
 
     /** Strokes used for mouse feedback */
     protected static final BasicStroke MOUSE_FEEDBACK_BACK = new BasicStroke(3, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER),


### PR DESCRIPTION
A sophisticated user suggested reducing the plot zoom threshold which was 20 pixels to something close to the smallest visible width.