### PR TITLE
Data Browser: Fix to allow closing after error during startup

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -858,7 +858,11 @@ public class Model
     public void stop()
     {
         if (!is_running)
-            throw new RuntimeException("Model wasn't started");
+        {
+            // Warn. Throwing exception would prevent closing when there was an error during start
+            logger.log(Level.WARNING, "Data Browser Model wasn't started");
+            return;
+        }
         is_running = false;
         for (ModelItem item : items)
         {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -325,7 +325,11 @@ public class PVItem extends ModelItem
     public void stop()
     {
         if (pv == null)
-            throw new RuntimeException("Not running " + getName());
+        {   // Warn. Throwing exception would prevent closing when there was an error during start
+            logger.log(Level.WARNING, "Data Browser PV closed while not running: " + getName());
+            return;
+        }
+
         pv_flow.dispose();
         if (scanner != null)
         {


### PR DESCRIPTION
When data browser doesn't fully start up because of e.g. buggy config file, it refused to later close down.
Now it closes.