### PR TITLE
Alarm import fix when deleting existing entries

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/TimeWarp.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/TimeWarp.java
@@ -89,7 +89,7 @@ public class TimeWarp
 
     private static final Pattern LEGACY_SECONDS = Pattern.compile("([0-9]+)\\.([0-9]+) sec.*");
     // Actually allows "m", "min", "minuteshours", but also "mintisenu".. Fine.
-    private static final Pattern LEGACY_MINUTES = Pattern.compile("([0-9]+\\.[0-9]+) min[utes]*");
+    private static final Pattern LEGACY_MINUTES = Pattern.compile("([0-9.]+) min[utes]*");
     // Actually allows "h", "hour", "hours", but also "horsurrs".. Fine.
     private static final Pattern LEGACY_HOURS = Pattern.compile("([0-9.]+) h[ours]*");
     private static final Pattern LEGACY_DAYS = Pattern.compile("([0-9.]+) day(s)*");
@@ -101,13 +101,19 @@ public class TimeWarp
     {
         String spec = legacy_spec.replace("-", "");
 
+        long days = 0;
+        long minutes = 0;
+        long secs = 0, ms = 0;
+
         Matcher legacy = LEGACY_DAYS.matcher(spec);
         if (legacy.find())
         {
             // TimeParser can only handle full days, not floating point
-            // Truncate
-            final double days = Double.parseDouble(legacy.group(1));
-            spec = spec.substring(0,legacy.start()) + Math.round(days) + " days" + spec.substring(legacy.end());
+            // Truncate days, then use rest as minutes
+            double d = Double.parseDouble(legacy.group(1));
+            days += d;
+            minutes += (d - days)*24*60;
+            spec = spec.substring(0,legacy.start()) + " " + spec.substring(legacy.end());
         }
 
         legacy = LEGACY_HOURS.matcher(spec);
@@ -116,9 +122,8 @@ public class TimeWarp
             // TimeParser can only handle full hours, not floating point
             // Convert to minutes
             final double hours = Double.parseDouble(legacy.group(1));
-            final long minutes = Math.round(hours * 60.0);
-            // Replace "hh.hh h" with "mmmm minutes"
-            spec = spec.substring(0,legacy.start()) + minutes + " minutes" + spec.substring(legacy.end());
+            minutes += Math.round(hours * 60.0);
+            spec = spec.substring(0,legacy.start()) + " " + spec.substring(legacy.end());
         }
 
         legacy = LEGACY_MINUTES.matcher(spec);
@@ -126,21 +131,31 @@ public class TimeWarp
         {
             // TimeParser can only handle full minutes, not floating point
             // Convert to seconds
-            final double minutes = Double.parseDouble(legacy.group(1));
-            final long secs = Math.round(minutes * 60.0);
+            final double min = Double.parseDouble(legacy.group(1));
+            secs += Math.round(min * 60.0);
             // Replace "mm.mm m" with "mmmm secconds"
-            spec = spec.substring(0,legacy.start()) + secs + " seconds" + spec.substring(legacy.end());
+            spec = spec.substring(0,legacy.start()) + " " + spec.substring(legacy.end());
         }
 
         legacy = LEGACY_SECONDS.matcher(spec);
         if (legacy.find())
         {
+            secs += Long.parseLong(legacy.group(1));
             // Pad to nanosecs
             final String padded = (legacy.group(2) + "000000000").substring(0, 9);
-            final long nano = Long.parseLong(padded);
             // .. but then only use the ms
-            spec = spec.substring(0,legacy.start()) + legacy.group(1) + " seconds " + (nano/1000000) + " ms";
+            ms += Long.parseLong(padded) / 1000000;
+            spec = spec.substring(0,legacy.start());
         }
+
+        if (days > 0)
+            spec = days + " days ";
+        if (minutes > 0)
+            spec = spec + " " + minutes + " minutes";
+        if (secs > 0)
+            spec = spec + " " + secs + " seconds";
+        if (ms > 0)
+            spec = spec + " " + ms + " ms";
         return TimeParser.parseTemporalAmount(spec);
     }
 }

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/model/TimeWarpTest.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/model/TimeWarpTest.java
@@ -51,6 +51,9 @@ public class TimeWarpTest
         amount = TimeWarp.parseLegacy("  -2.00 hours    ");
         assertThat(amount, equalTo(Duration.ofHours(2)));
 
+        amount = TimeWarp.parseLegacy(" -1 day -2.00 hours -3 minutes   ");
+        assertThat(amount, equalTo(Duration.ofMinutes(24L*60 + 2*60 + 3)));
+
         amount = TimeWarp.parseLegacy("-2.00 h");
         assertThat(amount, equalTo(Duration.ofHours(2)));
 

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -160,9 +160,15 @@ public class PhoebusApplication extends Application {
         public void activeDockItemChanged(final DockItem item)
         {
             if (item instanceof DockItemWithInput)
+            {
+                logger.log(Level.INFO, "Activated " + item);
                 active_item_with_input = new WeakReference<>((DockItemWithInput) item);
+            }
             else
+            {
+                logger.log(Level.INFO, "Activated " + item + ", no input");
                 active_item_with_input = NO_ACTIVE_ITEM_WITH_INPUT;
+            }
         }
     };
 

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmLogic.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmLogic.java
@@ -532,6 +532,15 @@ public class AlarmLogic // implements GlobalAlarmListener
         listener.alarmStateChanged(current, alarm);
     }
 
+    /** Dispose alarm logic
+     *
+     *  <p>Cancel delayed check.
+     */
+    public void dispose()
+    {
+        delayed_check.cancel();
+    }
+
     /** @return String representation for debugging */
     @SuppressWarnings("nls")
     @Override

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerPV.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerPV.java
@@ -110,7 +110,11 @@ public class AlarmServerPV extends AlarmTreeItem<AlarmState> implements AlarmTre
                 AutomatedActionsHelper.update(automated_actions, alarm.severity);
 
                 // Whenever logic computes new state, maximize up parent tree
-                getParent().maximizeSeverity();
+                final AlarmServerNode parent = getParent();
+                if (parent != null)
+                    parent.maximizeSeverity();
+                else
+                    logger.log(Level.FINE, getPathName() + " ignores delayed change to " + current + ", " + alarm + " since no longer in alarm tree");
             }
 
             @Override
@@ -337,6 +341,9 @@ public class AlarmServerPV extends AlarmTreeItem<AlarmState> implements AlarmTre
     {
         try
         {
+            // Cancel delayed
+            logic.dispose();
+
             // Cancel ongoing actions, but don't set to null
             // because in case there's another start() it needs
             // to find & trigger the actions


### PR DESCRIPTION
Remaining issue from #687:

When a config with PVs in alarm is deleted, the import deletes the items previous items, for example:
```
config:/root/path/PV1=null
config:/root/path=null
```
If the alarm server is running while the configuration is changed, is sees that PV1 is deleted. So it updates the parent 'path' to no longer be in alarm:
```
state:/root/path=OK
```
A client will see all these messages in order:
```
config:/root/path/PV1=null
config:/root/path=null
state:/root/path=OK
```
The client must ignore the state update for deleted items.