### PR TITLE
#712 removing oracle jdk 9 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: java
 dist: trusty
 jdk:
-  - oraclejdk9
   - openjdk11
 
 before_install:


### PR DESCRIPTION
Considering we are moving eclipse based cs-studio to jdk11 it makes sense to remove the oracle jdk9 from CI build
