### PR TITLE
Show user ID in status bar (optional)

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -28,6 +28,7 @@ public class Preferences
     public static final String welcome;
     public static final int ui_monitor_period;
     public static final String[] hide_spi_menu;
+    public static final boolean status_show_user;
 
     static
     {
@@ -39,5 +40,6 @@ public class Preferences
         welcome = prefs.get("welcome");
         ui_monitor_period = prefs.getInt("ui_monitor_period");
         hide_spi_menu = prefs.get("hide_spi_menu").split("\\s*,\\s*");
+        status_show_user = prefs.getBoolean("status_show_user");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/statusbar/StatusBar.java
+++ b/core/ui/src/main/java/org/phoebus/ui/statusbar/StatusBar.java
@@ -7,21 +7,33 @@
  ******************************************************************************/
 package org.phoebus.ui.statusbar;
 
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.javafx.ToolbarHelper;
 
+import javafx.geometry.Insets;
 import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 
 /** Application status bar
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class StatusBar extends HBox
 {
     private static final StatusBar instance = new StatusBar();
 
     private StatusBar()
     {
-        super(5, ToolbarHelper.createSpring());
+        super(5);
+        setPadding(new Insets(0, 5, 5, 5));
+
+        // Show User ID?
+        if (Preferences.status_show_user)
+            getChildren().add(new Label(System.getProperty("user.name")));
+
+        // Filler between standard options and additions (update, progress, ...)
+        getChildren().add(ToolbarHelper.createSpring());
     }
 
     /** @return Singleton instance */
@@ -46,8 +58,7 @@ public class StatusBar extends HBox
 
     /** Remove item from the status bar
      *
-     *
-     * @param item Item to remove
+     *  @param item Item to remove
      */
     public void removeItem(final Node item)
     {

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -47,3 +47,6 @@ home_display=examples:/01_main.bob?app=display_runtime,Example Display
 # i.e. the minimum detected UI freeze duration
 # Set to 0 to disable
 ui_monitor_period=500
+
+# Show user ID in status bar?
+status_show_user=true


### PR DESCRIPTION
Shows user ID in status bar, similar to the RCP version, but only showing the user ID, no attempt to "change user", since that never had any effect anyway, was only used for alarm UI.

Useful when people run css from "su.." as other user, and then not sure which instance they're looking at.

By default on, but preference setting allows to disable.