### PR TITLE
Display editor: Keep widget order when 'morphing' or undo-doing widget removal

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/MorphWidgetsMenu.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/MorphWidgetsMenu.java
@@ -134,8 +134,9 @@ public class MorphWidgetsMenu extends Menu
             else
             {
                 final Widget replacement = createNewWidget(descriptor, widget);
+                final int index = ChildrenProperty.getParentsChildren(widget).getValue().indexOf(widget);
                 steps.execute(new RemoveWidgetsAction(selection, List.of(widget)));
-                steps.execute(new AddWidgetAction(selection, target, replacement));
+                steps.execute(new AddWidgetAction(selection, target, replacement, index));
                 replacements.add(replacement);
                 ++i;
             }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/AddWidgetAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/AddWidgetAction.java
@@ -23,19 +23,26 @@ public class AddWidgetAction extends UndoableAction
     private final WidgetSelectionHandler selection;
     private final ChildrenProperty children;
     private final Widget widget;
+    private final int index;
 
     public AddWidgetAction(final WidgetSelectionHandler selection, final ChildrenProperty children, final Widget widget)
+    {
+        this(selection, children, widget, -1);
+    }
+
+    public AddWidgetAction(final WidgetSelectionHandler selection, final ChildrenProperty children, final Widget widget, final int index)
     {
         super(Messages.AddWidget);
         this.selection = selection;
         this.children = children;
         this.widget = widget;
+        this.index = index;
     }
 
     @Override
     public void run()
     {
-        children.addChild(widget);
+        children.addChild(index, widget);
         selection.setSelection(Arrays.asList(widget));
     }
 


### PR DESCRIPTION
Import of https://github.com/kasemir/org.csstudio.display.builder/pull/547