### PR TITLE
PVA 'pipeline' support for monitor client

### DIFF
--- a/core/pva/build.xml
+++ b/core/pva/build.xml
@@ -15,4 +15,23 @@
             </manifest>
         </jar>
     </target>
+
+    <target name="spamdemo" depends="core-pva,pipeline">
+        <javac destdir="${classes}" debug="${debug}">
+            <src path="${test}/"/>
+            <include name="**/SpamDemo.java"/>
+        </javac>
+        
+        <java classname="org.epics.pva.client.SpamDemo">
+            <arg value="${pipeline}"/>
+            <classpath>
+                <pathelement path="${classes}"/>
+                <pathelement path="${resources}"/>
+            </classpath>
+        </java>
+    </target>
+    
+    <target name="pipeline" unless="pipeline">
+        <input addProperty="pipeline" message="Pipeline size:"/>
+    </target>
 </project>

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -255,12 +255,12 @@ class ClientTCPHandler extends TCPHandler
             // configure it
             send_buffer.order(buffer.order());
 
-            logger.log(Level.FINE, "Received set-byte-order for " + send_buffer.order());
+            logger.log(Level.FINE, () -> "Server Version " + server_version + " sent set-byte-order to " + send_buffer.order());
             // Payload indicates if the server will send messages in that same order,
             // or might change order for each message.
             // We always adapt based on the flags of each received message,
             // so ignore.
-            // sendBuffer byte order is locked at this time, though.
+            // send_buffer byte order is locked at this time, though.
         }
         else
             super.handleControlMessage(command, buffer);

--- a/core/pva/src/main/java/org/epics/pva/client/EchoHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/EchoHandler.java
@@ -47,7 +47,7 @@ public class EchoHandler implements CommandHandler<ClientTCPHandler>
             }
         }
         else
-            logger.log(Level.FINE, "Received ECHO");
+            logger.log(Level.FINE, "Received ECHO (no content)");
         tcp.markAlive();
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/client/EchoRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/EchoRequest.java
@@ -26,12 +26,15 @@ class EchoRequest implements RequestEncoder
     @Override
     public void encodeRequest(final byte version, final ByteBuffer buffer) throws Exception
     {
-        logger.log(Level.FINE, "Sending ECHO request");
         // Protocol always required server to echo the payload, but version 1 servers didn't
         if (version < 2)
+        {
+            logger.log(Level.FINE, () -> "Sending ECHO request (Version " + version + " without content)");
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_ECHO, 0);
+        }
         else
         {
+            logger.log(Level.FINE, () -> "Sending ECHO request (Version " + version + ")");
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_ECHO, CHECK.length);
             buffer.put(CHECK);
         }

--- a/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAData;
+import org.epics.pva.data.PVAInt;
 import org.epics.pva.data.PVAStructure;
 
 /** Description of the 'field(..)' request used to get/monitor a channel
@@ -72,10 +73,9 @@ class FieldRequest
             items.add(
                 new PVAStructure("record", "",
                     new PVAStructure("_options", "",
-                        new PVABool("pipeline", true)
-                        // , new PVAInt("queueSize", 100)
-                        ))
-                     );
+                        new PVABool("pipeline", true),
+                        new PVAInt("queueSize", pipeline)
+                        )));
         }
 
         // XXX Not using any client type registry,
@@ -185,6 +185,6 @@ class FieldRequest
     @Override
     public String toString()
     {
-        return desc.formatType();
+        return desc.format();
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
@@ -13,8 +13,8 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAData;
-import org.epics.pva.data.PVAString;
 import org.epics.pva.data.PVAStructure;
 
 /** Description of the 'field(..)' request used to get/monitor a channel
@@ -51,26 +51,31 @@ class FieldRequest
      */
     public FieldRequest(final String request)
     {
-        this(false, request);
+        this(0, request);
     }
 
     /** Parse field request
-     *  @param pipeline Enable 'pipeline' mode for monitor?
+     *  @param pipeline Number of elements for 'pipeline' mode, 0 to disable
      *  @param request Examples:
      *                 "", "field()",
      *                 "value", "field(value)",
      *                 "field(value, timeStamp.userTag)"
      */
-    public FieldRequest(final boolean pipeline, final String request)
+    public FieldRequest(final int pipeline, final String request)
     {
         final List<PVAData> items = new ArrayList<>();
 
-        if (pipeline)
+        if (pipeline > 0)
         {
             // record._options.pipeline=true
-            // 'camonitor' encodes as String 'true', not PVABoolean
-            final PVAStructure options = new PVAStructure("_options", "", new PVAString("pipeline", "true"));
-            items.add(new PVAStructure("record", "", options));
+            // 'camonitor' encodes as PVAString 'true', not PVABool
+            items.add(
+                new PVAStructure("record", "",
+                    new PVAStructure("_options", "",
+                        new PVABool("pipeline", true)
+                        // , new PVAInt("queueSize", 100)
+                        ))
+                     );
         }
 
         // XXX Not using any client type registry,

--- a/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
@@ -80,6 +80,7 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
 
             final FieldRequest field_request = new FieldRequest(request);
             field_request.encodeType(buffer);
+            field_request.encode(buffer);
             buffer.putInt(size_offset, buffer.position() - payload_start);
 
             init = false;

--- a/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
@@ -73,13 +73,14 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
             // Guess, assumes empty FieldRequest (6)
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_GET, 4+4+1+6);
+            final int payload_start = buffer.position();
             buffer.putInt(channel.sid);
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
             final FieldRequest field_request = new FieldRequest(request);
-            final int request_size = field_request.encodeType(buffer);
-            buffer.putInt(size_offset, 4+4+1+request_size);
+            field_request.encodeType(buffer);
+            buffer.putInt(size_offset, buffer.position() - payload_start);
 
             init = false;
         }

--- a/core/pva/src/main/java/org/epics/pva/client/MonitorRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/MonitorRequest.java
@@ -202,7 +202,10 @@ class MonitorRequest implements AutoCloseable, RequestEncoder, ResponseHandler
             // Notify listener of latest value
             listener.handleMonitor(channel, changes, overrun, data);
 
-            // With pipelining, once we receive nfree/2, request another nfree
+            // With pipelining, once we receive nfree/2, request as many again.
+            // With a responsive client, this jumps nfree up to the original 'pipeline' count.
+            // With a slow client, for example stuck in listener.handleMonitor(),
+            // the server will stop after sending nfree updates.
             if (pipeline > 0  &&
                 received_updates.incrementAndGet() >= pipeline/2)
             {

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -243,10 +243,28 @@ public class PVAChannel
      */
     public AutoCloseable subscribe(final String request, final MonitorListener listener) throws Exception
     {
+        return subscribe(request, 0, listener);
+    }
+
+    /** Start a pipelined subscription
+     *
+     *  <p>Asks the server to send a certain number of 'pipelined' updates.
+     *  Client automatically requests more updates as soon as half the pipelined updates
+     *  are received. In case the client gets overloaded and cannot do this,
+     *  the server will thus pause after sending the pipelined updates.
+     *
+     *  @param request Request, "" for all fields, or "field_a, field_b.subfield"
+     *  @param pipeline Number of updates to pipeline
+     *  @param listener Will be invoked with channel and latest value
+     *  @return {@link AutoCloseable}, used to close the subscription
+     *  @throws Exception on error
+     */
+    public AutoCloseable subscribe(final String request, final int pipeline, final MonitorListener listener) throws Exception
+    {
         // MonitorRequest submits itself to TCPHandler
         // and registers as response handler,
         // so we can later retrieve it via its requestID
-        return new MonitorRequest(this, request, listener);
+        return new MonitorRequest(this, request, pipeline, listener);
     }
 
     /** Invoke remote procecure call (RPC)

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -86,6 +86,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
 
             final FieldRequest field_request = new FieldRequest(request);
             field_request.encodeType(buffer);
+            field_request.encode(buffer);
             buffer.putInt(size_offset, buffer.position() - payload_start);
 
             init = false;

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -79,13 +79,14 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             // Guess, assumes empty FieldRequest (6)
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_PUT, 4+4+1+6);
+            final int payload_start = buffer.position();
             buffer.putInt(channel.sid);
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
             final FieldRequest field_request = new FieldRequest(request);
-            final int request_size = field_request.encodeType(buffer);
-            buffer.putInt(size_offset, 4+4+1+request_size);
+            field_request.encodeType(buffer);
+            buffer.putInt(size_offset, buffer.position() - payload_start);
 
             init = false;
         }

--- a/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
+++ b/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
@@ -101,6 +101,9 @@ public class PVAHeader
     /** Sub command to initialize GET/PUT/MONITOR/RPC (get data description) */
     public static final byte CMD_SUB_INIT = 0x08;
 
+    /** MONITOR PIPELINE flag */
+    public static final byte CMD_SUB_PIPELINE = (byte) 0x80;
+
     /** Sub command to (re)start getting monitor values */
     public static final byte CMD_SUB_START = 0x44;
 

--- a/core/pva/src/main/java/org/epics/pva/server/MonitorHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/MonitorHandler.java
@@ -73,7 +73,7 @@ class MonitorHandler implements CommandHandler<ServerTCPHandler>
         }
         else
         {
-            logger.log(Level.WARNING, () -> "Ignoring MONITOR request for " + pv + ", subcommand " + subcmd);
+            logger.log(Level.WARNING, () -> "Ignoring MONITOR request for " + pv + ", subcommand 0x" + Integer.toHexString(Byte.toUnsignedInt(subcmd)));
         }
     }
 }

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -100,7 +100,7 @@ public class ClientDemo
 
         // Subscribe for 10 seconds...
         final AtomicInteger updates = new AtomicInteger();
-        final AutoCloseable subscription = channel.subscribe("", (ch, changes, overruns, data) ->
+        final AutoCloseable subscription = channel.subscribe("", 4, (ch, changes, overruns, data) ->
         {
             System.out.println(data);
             updates.incrementAndGet();

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -36,6 +36,7 @@ public class ClientDemo
         try
         {
             LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
+            // Logger.getLogger("").setLevel(Level.CONFIG);
         }
         catch (Exception ex)
         {
@@ -97,18 +98,19 @@ public class ClientDemo
         final PVAChannel channel = pva.getChannel("ramp");
         channel.connect().get(5, TimeUnit.SECONDS);
 
-        // Subscribe for 3 seconds...
+        // Subscribe for 10 seconds...
         final AtomicInteger updates = new AtomicInteger();
         final AutoCloseable subscription = channel.subscribe("", (ch, changes, overruns, data) ->
         {
             System.out.println(data);
             updates.incrementAndGet();
         });
-        TimeUnit.SECONDS.sleep(3);
+        TimeUnit.SECONDS.sleep(10);
         assertTrue(updates.get() > 0);
 
         // Unsubscribe, check that updates subside
         subscription.close();
+        System.out.println("Subscription closed");
         updates.set(0);
         TimeUnit.SECONDS.sleep(3);
         assertThat(updates.get(), equalTo(0));

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -94,30 +94,38 @@ public class ClientDemo
     @Test
     public void testMonitor() throws Exception
     {
-        final PVAClient pva = new PVAClient();
-        final PVAChannel channel = pva.getChannel("ramp");
-        channel.connect().get(5, TimeUnit.SECONDS);
-
-        // Subscribe for 10 seconds...
-        final AtomicInteger updates = new AtomicInteger();
-        final AutoCloseable subscription = channel.subscribe("", 4, (ch, changes, overruns, data) ->
+        // pipeline=10 fails with Base 7.0.2.2
+        for (int pipeline : new int[] { 0, 4 /*, 10*/ })
         {
-            System.out.println(data);
-            updates.incrementAndGet();
-        });
-        TimeUnit.SECONDS.sleep(10);
-        assertTrue(updates.get() > 0);
+            final PVAClient pva = new PVAClient();
+            final PVAChannel channel = pva.getChannel("ramp");
+            channel.connect().get(5, TimeUnit.SECONDS);
 
-        // Unsubscribe, check that updates subside
-        subscription.close();
-        System.out.println("Subscription closed");
-        updates.set(0);
-        TimeUnit.SECONDS.sleep(3);
-        assertThat(updates.get(), equalTo(0));
+            // Subscribe for 10 seconds...
+            final AtomicInteger updates = new AtomicInteger();
+            final AutoCloseable subscription = channel.subscribe("", pipeline, (ch, changes, overruns, data) ->
+            {
+                System.out.println(data);
+                updates.incrementAndGet();
+            });
+            TimeUnit.SECONDS.sleep(10);
+            System.out.println("Updates with pipeline=" + pipeline + ": " + updates.get());
+            // 10 seconds should get 10 updates.
+            // Expect at least 5.
+            assertTrue(updates.get() > 5);
 
-        channel.close();
-        pva.close();
+            // Unsubscribe, check that updates subside
+            subscription.close();
+            System.out.println("Subscription closed");
+            updates.set(0);
+            TimeUnit.SECONDS.sleep(3);
+            assertThat(updates.get(), equalTo(0));
+
+            channel.close();
+            pva.close();
+        }
     }
+
 
     @Test
     public void testConnection() throws Exception

--- a/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
@@ -37,6 +37,10 @@ public class SpamDemo
 
     public static void main(final String[] args) throws Exception
     {
+        // * base-7.0.2.2
+        //   pipeline= 2 (ack every 1):    OK, > 60000 updates/sec
+        //   pipeline= 4 (ack every 2):    OK, >100000 updates/sec
+        //   pipeline=10 (ack every 5):    Stops after 4 updates
         int pipeline = 4;
         if (args.length == 1)
             pipeline = Integer.parseInt(args[0]);
@@ -56,7 +60,7 @@ public class SpamDemo
         {
             TimeUnit.SECONDS.sleep(10);
             final int got = updates.getAndSet(0);
-            System.err.println(got + " updates in 10 seconds");
+            System.err.println("pipeline=" + pipeline + " got " + got + " updates in 10 seconds, " + got/10 + " per sec");
         }
 
 //        subscription.close();

--- a/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.client;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.LogManager;
+
+import org.epics.pva.PVASettings;
+
+/** Monitor the PV served by
+ *    epics7/modules/pvAccess/examples/O.linux-x86_64/spamme
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class SpamDemo
+{
+    static
+    {
+        try
+        {
+            LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
+            // Logger.getLogger("").setLevel(Level.CONFIG);
+        }
+        catch (Exception ex)
+        {
+            ex.printStackTrace();
+        }
+    }
+
+    public static void main(final String[] args) throws Exception
+    {
+        int pipeline = 4;
+        if (args.length == 1)
+            pipeline = Integer.parseInt(args[0]);
+
+        final PVAClient pva = new PVAClient();
+        final PVAChannel channel = pva.getChannel("spam");
+        channel.connect().get(5, TimeUnit.SECONDS);
+
+        final AutoCloseable subscription = channel.subscribe("", pipeline, (ch, changes, overruns, data) ->
+        {
+            System.out.println(data);
+        });
+
+        TimeUnit.HOURS.sleep(1);
+
+        subscription.close();
+        channel.close();
+        pva.close();
+    }
+}

--- a/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/SpamDemo.java
@@ -8,7 +8,10 @@
 package org.epics.pva.client;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.epics.pva.PVASettings;
 
@@ -24,7 +27,7 @@ public class SpamDemo
         try
         {
             LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
-            // Logger.getLogger("").setLevel(Level.CONFIG);
+            Logger.getLogger("").setLevel(Level.CONFIG);
         }
         catch (Exception ex)
         {
@@ -42,15 +45,22 @@ public class SpamDemo
         final PVAChannel channel = pva.getChannel("spam");
         channel.connect().get(5, TimeUnit.SECONDS);
 
+        AtomicInteger updates = new AtomicInteger();
         final AutoCloseable subscription = channel.subscribe("", pipeline, (ch, changes, overruns, data) ->
         {
-            System.out.println(data);
+            updates.incrementAndGet();
+            // System.out.println(data);
         });
 
-        TimeUnit.HOURS.sleep(1);
+        while (true)
+        {
+            TimeUnit.SECONDS.sleep(10);
+            final int got = updates.getAndSet(0);
+            System.err.println(got + " updates in 10 seconds");
+        }
 
-        subscription.close();
-        channel.close();
-        pva.close();
+//        subscription.close();
+//        channel.close();
+//        pva.close();
     }
 }

--- a/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
+++ b/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
@@ -123,15 +123,9 @@ public class TestFieldRequest
     @Test
     public void testPipeline() throws Exception
     {
-        FieldRequest request = new FieldRequest(true, "field(value)");
+        FieldRequest request = new FieldRequest(10, "field(value)");
         System.out.println(request);
-
-        final ByteBuffer buffer = ByteBuffer.allocate(100);
-        buffer.order(ByteOrder.LITTLE_ENDIAN);
-        request.encodeType(buffer);
-        request.encode(buffer);
-        buffer.flip();
-
+        ByteBuffer buffer = encode(request);
         System.out.println(Hexdump.toHexdump(buffer));
     }
 
@@ -140,6 +134,7 @@ public class TestFieldRequest
         final ByteBuffer buffer = ByteBuffer.allocate(100);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         request.encodeType(buffer);
+        request.encode(buffer);
         buffer.flip();
         return buffer;
     }

--- a/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
+++ b/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
@@ -63,8 +63,27 @@ public class TestFieldRequest
      *         "pixel": ONLY_ID_TYPE_CODE 3
      *         "timeStamp": FULL_WITH_ID_TYPE_CODE 4 struct named '', 1 element,
      *               "userTag": ONLY_ID_TYPE_CODE 3
+     *
+     *
+     * pvmonitor  -r "record[pipeline:1]field(value)" demo
+     * CA 02 80 0D 00 00 00 56 00 00 00 01 00 00 00 01 - .......V........
+     * 88 FD 00 02 80 00 02 06 72 65 63 6F 72 64 FD 00 - ........record..
+     * 03 80 00 01 08 5F 6F 70 74 69 6F 6E 73 FD 00 04 - ....._options...
+     * 80 00 01 08 70 69 70 65 6C 69 6E 65 60 05 66 69 - ....pipeline`.fi
+     * 65 6C 64 FD 00 05 80 00 01 05 76 61 6C 75 65 FD - eld.......value.
+     * 00 06 80 00 00 04 74 72 75 65 00 00 00 02       - ......true....
+     *
+     * Monitor (0D) SID 1, Request 1,
+     * Sub 0x88 (init 08 + pipeline 80),
+     * FULL_WITH_ID_TYPE_CODE 2, struct named '', 2 elements,
+     *   Element 'record': Type 3, struct named '', 1 element,
+     *     Element '_options': Type 4, struct named '', 1 element,
+     *       Element 'pipeline': String
+     *   Element 'field': Type 5, struct named '', 1 element,
+     *     Element 'value': Type 6, struct named '', 0(!) elements
+     * Request data: String "true"
+     * int nfree: 2
      */
-
     @Test
     public void testEmpty() throws Exception
     {
@@ -99,6 +118,21 @@ public class TestFieldRequest
         PVATypeRegistry registry = new PVATypeRegistry();
         final PVAData decoded = registry.decodeType("", buffer);
         System.out.println(decoded.formatType());
+    }
+
+    @Test
+    public void testPipeline() throws Exception
+    {
+        FieldRequest request = new FieldRequest(true, "field(value)");
+        System.out.println(request);
+
+        final ByteBuffer buffer = ByteBuffer.allocate(100);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        request.encodeType(buffer);
+        request.encode(buffer);
+        buffer.flip();
+
+        System.out.println(Hexdump.toHexdump(buffer));
     }
 
     private ByteBuffer encode(final FieldRequest request) throws Exception


### PR DESCRIPTION
Pipeline mode isn't used much, and details of the protocol might still change, but this supports the current qsrv and pvAccess 'spamme' test server.