### PR TITLE
JavaFX12

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ http://phoebus-doc.readthedocs.io
 
 
 ## Requirements
- - [JDK11 or later, suggested is OpenJDK](http://jdk.java.net/11).
-   (For the time being, Phoebus still builds with Oracle JDK 9 and 10,
-    but it must be a JDK that includes JavaFX).
+ - [JDK11 or later, suggested is OpenJDK](http://jdk.java.net/12).
  - [maven 2.x](https://maven.apache.org/) or [ant](http://ant.apache.org/)
 
 
@@ -99,7 +97,7 @@ Select the phoebus root directory, and check the option to "Seach for nested pro
 
 By default, all projects should be selected ('dependencies', 'core-framework', .., 'product').
 
-When using Java 11, the file `dependencies/phoebus-target/.classpath`
+The file `dependencies/phoebus-target/.classpath`
 needs to be edited to list all the `phoebus-target/target/lib/javafx*.jar` files.
 
 Invoke `Run As/Java Application` on the `Launcher` in the product.

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -27,17 +27,17 @@
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-web</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-swing</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-fxml</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
 
     <dependency>

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -119,17 +119,33 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/spring-webmvc-5.0.9.RELEASE.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/hibernate-validator-6.0.12.Final.jar"/>
 	<!-- On Windows, need to add this:
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-11.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-11.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-11.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-11.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-11.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-11.0.2-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.1-win.jar"/>
+	-->
+	<!-- On Linux, need to add this:
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.1-linux.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.1.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.1-linux.jar"/>
 	-->
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -60,22 +60,22 @@
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-web</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-swing</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-fxml</artifactId>
-      <version>11.0.2</version>
+      <version>${openjfx.version}</version>
     </dependency>
 
     <!--  Includes

--- a/phoebus-product/src/main/resources/logging.properties
+++ b/phoebus-product/src/main/resources/logging.properties
@@ -24,6 +24,7 @@ java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$
 # Core java and general 3rd party libs
 sun.awt.X11.level = WARNING
 sun.net.www.protocol.http.HttpURLConnection.level = CONFIG
+jdk.event.security.level = WARNING
 javafx.scene.control.level = WARNING
 javafx.css.level = WARNING
 javafx.scene.focus.level = WARNING

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <epics.version>7.0.3-SNAPSHOT</epics.version>
     <vtype.version>1.0.1-SNAPSHOT</vtype.version>
+    <openjfx.version>12.0.1</openjfx.version>
     <!--<maven.repo.local>${project.build.directory}/.m2</maven.repo.local>-->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Updates openjfx from 11 to 12.

@shroffk there is at this time no desperate need to update JFX.
There is no new API on which we depend.
JFX11 has a bug, #704, but there's a workaround.
https://github.com/javafxports/openjdk-jfx/blob/jfx-12/doc-files/release-notes-12.md#release-notes-for-javafx-12 mentions a fix for blurry fonts on Ubuntu and Debian which I cannot check.

This pull request is mostly to verify that everything still builds and runs with JDK12 and JFX12, check that we don't get behind.
The JFX12 description states that it required JDK11 or 12, and I've verified that it runs with both on Linux.
I found that the code also still runs with Oracle JDK 10, but then it uses the JFX 10 included in the JDK, ignoring the JFX12 jars.
