### PR TITLE
Plot: Fix cast error in plot config 'log' handling

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
@@ -109,10 +109,10 @@ public class ModelBasedPlot
             }
 
             @Override
-            public void changedLogarithmic(final YAxis<?> axis)
+            public void changedLogarithmic(final Axis<?> axis)
             {
                 final int index = plot.getYAxes().indexOf(axis);
-                listener.ifPresent(l -> l.logarithmicChanged(index, axis.isLogarithmic()));
+                listener.ifPresent(l -> l.logarithmicChanged(index, ((YAxis<?>)axis).isLogarithmic()));
             }
 
             @Override

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -145,11 +145,11 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
                 updateModelAxis(model_widget.propYAxes().getElement(index), y_axis);
         }
 
-        public void changedLogarithmic(final YAxis<?> y_axis)
+        public void changedLogarithmic(final Axis<?> y_axis)
         {
             final int index = plot.getYAxes().indexOf(y_axis);
             if (index >= 0  &&  index < model_widget.propYAxes().size())
-                model_widget.propYAxes().getElement(index).logscale().setValue(y_axis.isLogarithmic());
+                model_widget.propYAxes().getElement(index).logscale().setValue(((YAxis<?>)y_axis).isLogarithmic());
         };
 
         /** Invoked when auto scale is enabled or disabled by user interaction */

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlotListener.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlotListener.java
@@ -8,6 +8,7 @@
 package org.csstudio.javafx.rtplot;
 
 import org.csstudio.javafx.rtplot.data.PlotDataItem;
+import org.csstudio.javafx.rtplot.internal.HorizontalNumericAxis;
 
 /** Listener to changes in the plot
  *  @param <XTYPE> Data type used for the {@link PlotDataItem}
@@ -27,8 +28,10 @@ public interface RTPlotListener<XTYPE extends Comparable<XTYPE>>
     /** Invoked when grid is enabled/disabled by user interaction */
     default public void changedGrid(Axis<?> axis) {};
 
-    /** Invoked when logarithmic mode is enabled/disabled by user interaction */
-    default public void changedLogarithmic(YAxis<?> axis) {};
+    /** Invoked when logarithmic mode is enabled/disabled by user interaction
+     *  @param axis {@link YAxis} or {@link HorizontalNumericAxis} with changed log setting
+     */
+    default public void changedLogarithmic(Axis<?> axis) {};
 
     /** Invoked when a PlotMarker has been moved
      *  @param index Index 0, .. of the {@link PlotMarker}

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
@@ -65,7 +65,7 @@ public class LogTicks extends LinearTicks
         // Try major tick distance between __exponents__
         double exp_dist = (high_exp - low_exp) / num_that_fits;
 
-        if (exp_dist <= 0.0)
+        if (exp_dist < 1.0)
         {
             // All values have the same exponent, can't create a useful log scale.
             // Pick a format that shows significant detail for mantissa.
@@ -85,7 +85,7 @@ public class LogTicks extends LinearTicks
             for (int i=0; i<=4; ++i)
             {
                 double value = low + (high - low) * i / 4;
-                major_ticks.add(new MajorTick<Double>(value, format(value)));
+                major_ticks.add(new MajorTick<>(value, format(value)));
             }
         }
         else
@@ -93,6 +93,7 @@ public class LogTicks extends LinearTicks
             // System.out.println("\nExp dist: " + exp_dist + " for range "+ num_fmt.format(low) + " .. " + num_fmt.format(high));
             // Round up to a 'nice' step size
             exp_dist = selectNiceStep(exp_dist);
+            // System.out.println("-> Nice Exp dist: " + exp_dist);
 
             int minor_count;
             if (exp_dist < 1.0)
@@ -126,7 +127,7 @@ public class LogTicks extends LinearTicks
             while (value <= high*major_factor)
             {
                 if (value >= low  &&  value <= high)
-                    major_ticks.add(new MajorTick<Double>(value, format(value)));
+                    major_ticks.add(new MajorTick<>(value, format(value)));
 
                 if (minor_count > 0)
                 {   // Fill major tick marks with minor ticks
@@ -140,7 +141,7 @@ public class LogTicks extends LinearTicks
                         final double min_val = prev + i * minor_step;
                         if (min_val <= low || min_val >= high)
                             continue;
-                        minor_ticks.add(new MinorTick<Double>(min_val));
+                        minor_ticks.add(new MinorTick<>(min_val));
                     }
                 }
                 prev = value;
@@ -157,8 +158,8 @@ public class LogTicks extends LinearTicks
         {   // If the best-laid plans of mice and men fail
             // and we end up with just one or no tick,
             // add the low and high markers
-            major_ticks.add(0, new MajorTick<Double>(low, format(low)));
-            major_ticks.add(new MajorTick<Double>(high, format(high)));
+            major_ticks.add(0, new MajorTick<>(low, format(low)));
+            major_ticks.add(new MajorTick<>(high, format(high)));
         }
         this.major_ticks = major_ticks;
         this.minor_ticks = minor_ticks;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
@@ -1286,7 +1286,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
     }
 
     /** Notify listeners */
-    public void fireLogarithmicChange(final YAxis<?> axis)
+    public void fireLogarithmicChange(final Axis<?> axis)
     {
         for (RTPlotListener<?> listener : listeners)
             listener.changedLogarithmic(axis);

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotConfigDialog.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotConfigDialog.java
@@ -15,6 +15,7 @@ import org.csstudio.javafx.rtplot.Trace;
 import org.csstudio.javafx.rtplot.YAxis;
 import org.csstudio.javafx.rtplot.util.RGBFactory;
 
+import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Orientation;
@@ -114,6 +115,7 @@ public class PlotConfigDialog<XTYPE extends Comparable<XTYPE>>  extends Dialog<V
 
         final TextField title = new TextField(plot.getTitle());
         title.setOnAction(event -> plot.setTitle(title.getText()));
+        title.focusedProperty().addListener((prop, old, focus) -> { if (!focus) plot.setTitle(title.getText()); });
         layout.add(title, 1, row++, 2, 1);
 
         final CheckBox legend = new CheckBox(Messages.PlotConfigShowLegend);
@@ -167,6 +169,7 @@ public class PlotConfigDialog<XTYPE extends Comparable<XTYPE>>  extends Dialog<V
         layout.add(new Label(Messages.PlotConfigAxName), 0, row);
         final TextField axis_name = new TextField(axis.getName());
         axis_name.setOnAction(event -> axis.setName(axis_name.getText()));
+        axis_name.focusedProperty().addListener((prop, old, focus) -> { if (!focus) axis.setName(axis_name.getText());});
         layout.add(axis_name, 1, row++, 2, 1);
 
         // Don't support auto-scale for time axis
@@ -203,8 +206,15 @@ public class PlotConfigDialog<XTYPE extends Comparable<XTYPE>>  extends Dialog<V
                 else if (axis instanceof HorizontalNumericAxis)
                     plot.internalGetPlot().fireXAxisChange();
             };
+            final ChangeListener<? super Boolean> focus_listener = (prop, old, focus) ->
+            {
+                if (! focus)
+                    update_range.handle(null);
+            };
             start.setOnAction(update_range);
+            start.focusedProperty().addListener(focus_listener);
             end.setOnAction(update_range);
+            end.focusedProperty().addListener(focus_listener);
 
             final CheckBox autoscale = new CheckBox(Messages.PlotConfigAutoScale);
             if (axis.isAutoscale())

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotConfigDialog.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotConfigDialog.java
@@ -227,7 +227,7 @@ public class PlotConfigDialog<XTYPE extends Comparable<XTYPE>>  extends Dialog<V
             logscale.setOnAction(event ->
             {
                 num_axis.setLogarithmic(logscale.isSelected());
-                plot.internalGetPlot().fireLogarithmicChange((YAxis<?>)num_axis);
+                plot.internalGetPlot().fireLogarithmicChange(num_axis);
             });
             layout.add(logscale, 2, row++);
         }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/LogTicksTest.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/LogTicksTest.java
@@ -32,7 +32,7 @@ public class LogTicksTest extends TicksTestBase
         System.out.println("Ticks for " + start + " .. " + end + ":");
         String text = ticks2text(ticks);
         System.out.println(text);
-        assertThat(text, equalTo("'1E0' 2E0 3E0 4E0 5E0 6E0 7E0 8E0 9E0 '1E1' 1E1 2E1 3E1 4E1 5E1 6E1 7E1 8E1 9E1 '1E2' 1E2 2E2 3E2 4E2 5E2 6E2 7E2 8E2 9E2 '1E3' 1E3 2E3 3E3 4E3 5E3 6E3 7E3 8E3 9E3 '1E4' "));
+        assertThat(text, equalTo("'1E0' '3E3' '5E3' '8E3' '1E4' "));
 
         // Wider log scale with majors at 1E0, 1E2, 1E4, ..
         start = 1.0;  end = 1e8;


### PR DESCRIPTION
Both HorizontalNumericAxis and YAxis support log, they have common root
class, but HorizontalNumericAxis is not a sub-type of YAxis.

Resulted in this when opening the plot config dialog on an XYPlot and then selecting 'log' for the horizontal axis:
```
Exception in thread "JavaFX Application Thread" java.lang.ClassCastException:
class org.csstudio.javafx.rtplot.internal.HorizontalNumericAxis
cannot be cast to class org.csstudio.javafx.rtplot.YAxis
at
org.csstudio.javafx.rtplot.internal.PlotConfigDialog.lambda$addAxisContent$8
(PlotConfigDialog.java:230)
```
