### PR TITLE
Medm converter fixes

### DIFF
--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
@@ -79,7 +79,8 @@ public abstract class AbstractADL2Model<WM extends Widget>
      * @param widgetModel
      */
     protected void setADLObjectProps(ADLAbstractWidget adlWidget, Widget widgetModel) {
-        widgetModel.propName().setValue(adlWidget.getName());
+        widgetModel.propName().setValue(adlWidget.getName() + " #" + adlWidget.getObjectNr());
+
         if (adlWidget.hasADLObject()) {
             ADLObject adlObj = adlWidget.getAdlObject();
             widgetModel.propX().setValue(adlObj.getX());
@@ -210,71 +211,28 @@ public abstract class AbstractADL2Model<WM extends Widget>
      *        B = pv1
      *        C = pv2
      *        D = PV3
-     * 3. Only basic desion maiking is hapenning
+     * 3. Only basic decision making is happening
      *    ()+-/*=<># were used.  No use of math
      *    functions like ABS, SIN, ...
      * 4. The characters = and # are replaced by
-     *    == and != respecively.
+     *    == and != respectively.
      * @param adlExpr
      * @return
      */
     private String translateExpression(String adlExpr) {
-        String opiExpr = adlExpr;
-        opiExpr = replaceChannel("A", "pv0", opiExpr);
-        opiExpr = replaceChannel("B", "pv1", opiExpr);
-        opiExpr = replaceChannel("C", "pv2", opiExpr);
-        opiExpr = replaceChannel("D", "pv3", opiExpr);
-        opiExpr = replaceString("=", "==", opiExpr);
-        opiExpr = replaceString("#", "!=", opiExpr);
+        String opiExpr = adlExpr.replace("A", "pv0")
+                                .replace("B", "pv1")
+                                .replace("C", "pv2")
+                                .replace("D", "pv3")
+                                .replace("=", "==")
+                                .replace("#", "!=");
 
-        // The above can result in "pv0====7".
-        // Patch that back into a plain "pv0==7"
+        // The above can result in "pv0====7" or "pv1 !== 8"
+        // when exiting "==" or "!=" gets replaced.
+        // Patch that back into a plain "==" resp. "!="
         opiExpr = opiExpr.replaceAll("==+", "==");
-        return opiExpr.toString();
-    }
 
-    /**
-     *
-     * @param adlChanName
-     * @param opiChanName
-     * @param opiExpr
-     * @return
-     */
-    private String replaceChannel(String adlChanName, String opiChanName,
-            String opiExpr) {
-        opiExpr = replaceString(adlChanName, opiChanName, opiExpr);
-        opiExpr = replaceString(adlChanName.toLowerCase(), opiChanName, opiExpr);
         return opiExpr;
-    }
-
-    private String replaceString(String inName, String outName, String expr) {
-        String retExpr = expr;
-        if (retExpr.contains(inName)){
-            StringBuffer tempExpr = new StringBuffer();
-            String[] parts = retExpr.split(inName);
-            tempExpr.append(parts[0]);
-            for (int occur = 0; occur<(parts.length-1); occur++){
-                if (!inName.equals("=")) {
-                    if (inName.equals("=")
-                            && (tempExpr.toString().endsWith(">") ||
-                                    tempExpr.toString().endsWith("<") ))
-
-                    {
-                        tempExpr.append("=");
-                        tempExpr.append(parts[occur + 1]);
-                    } else {
-                        tempExpr.append(outName);
-                        tempExpr.append(parts[occur + 1]);
-                    }
-                }
-                else {
-                    tempExpr.append(outName);
-                    tempExpr.append(parts[occur + 1]);
-                }
-            }
-            retExpr = tempExpr.toString();
-        }
-        return retExpr;
     }
 
     /**

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgets/ADLAbstractWidget.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgets/ADLAbstractWidget.java
@@ -39,8 +39,14 @@ public abstract class ADLAbstractWidget {
 
     protected String name = new String();
 
-    public ADLAbstractWidget(final ADLWidget adlWidget){
+    private final int _objectNr;
 
+    public ADLAbstractWidget(final ADLWidget adlWidget){
+        _objectNr = adlWidget.getObjectNr();
+    }
+
+    public final int getObjectNr() {
+        return _objectNr;
     }
 
     public final String getName(){

--- a/app/display/convert-medm/src/test/java/org/csstudio/display/converter/medm/ConverterTest.java
+++ b/app/display/convert-medm/src/test/java/org/csstudio/display/converter/medm/ConverterTest.java
@@ -1,12 +1,22 @@
 package org.csstudio.display.converter.medm;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
+import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.rules.RuleInfo;
+import org.csstudio.display.builder.model.rules.RuleInfo.ExpressionInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +35,7 @@ public class ConverterTest
     @Test
     public void testConverter() throws Exception
     {
+        // Convert into tmp file
         final String filename = ConverterTest.class.getResource("/Main_XXXX.adl").getFile();
         if (filename.isEmpty())
             throw new Exception("Cannot obtain test file");
@@ -33,8 +44,44 @@ public class ConverterTest
         output.deleteOnExit();
         new Converter(new File(filename), output);
 
+        // Dump the resulting *.bob file
         final BufferedReader dump = new BufferedReader(new FileReader(output));
         dump.lines().forEach(System.out::println);
         dump.close();
+
+        // Read into model
+        final ModelReader reader = new ModelReader(new FileInputStream(output));
+        final DisplayModel model = reader.readModel();
+
+        // Perform some tests
+        testCalcRule(model);
+    }
+
+    private void testCalcRule(final DisplayModel model)
+    {
+        for (Widget widget : model.runtimeChildren().getValue())
+        {
+            if (! widget.getName().equals("composite #351"))
+                continue;
+
+            final List<RuleInfo> rules = widget.propRules().getValue();
+            System.out.println(rules);
+            assertEquals(rules.size(), 1);
+
+            assertEquals("visible", rules.get(0).getPropID());
+
+            final List<String> pvs = rules.get(0)
+                                          .getPVs()
+                                          .stream()
+                                          .map(pv -> pv.getName())
+                                          .collect(Collectors.toList());
+            assertEquals(List.of("$(xx):A_SHUTTER_CLOSEDBI", "$(xx):A_BEAM_PRESENTBI", "$(xx):B_SHUTTER_CLOSEDBI", "$(xx):B_BEAM_PRESENTBI"),
+                         pvs);
+
+            // Bug used to turn "A&&B&&C&&D" into "pv0&&pv1&&pv2&&", dropping "...pv3"
+            final List<ExpressionInfo<?>> expressions = rules.get(0).getExpressions();
+            assertEquals(expressions.size(), 1);
+            assertEquals("!(pv0&&pv1&&pv2&&pv3)", expressions.get(0).getBoolExp());
+        }
     }
 }

--- a/phoebus-product/.classpath
+++ b/phoebus-product/.classpath
@@ -1,48 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-types"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-email"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-logbook"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-formula"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/core-security"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-3d-viewer"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-alarm-ui"/>
+    <classpathentry kind="src" output="target/classes" path="src/main/java"/>
+    <classpathentry kind="src" path="src/main/resources"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <attributes>
+            <attribute name="module" value="true"/>
+        </attributes>
+    </classpathentry>
+    <classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-types"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-email"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-logbook"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-formula"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/core-security"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-3d-viewer"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-alarm-ui"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-alarm-logging-ui"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-alarm-model"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-scan-ui"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-scan-model"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-scan-client"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-channel-utility"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-channel-channelfinder"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-channel-views"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-display-editor"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-display-runtime"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-display-representation-javafx"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-display-representation"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-display-model"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-databrowser"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-rtplot"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-pvtable"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-email"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-log-configuration"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-pvtree"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-probe"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-logbook-ui"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-filebrowser"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-perfmon"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/app-pace"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-alarm-model"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-scan-ui"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-scan-model"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-scan-client"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-channel-utility"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-channel-channelfinder"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-channel-views"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-editor"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-runtime"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-representation-javafx"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-representation"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-model"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-display-convert-medm"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-databrowser"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-rtplot"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-pvtable"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-email"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-log-configuration"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-pvtree"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-probe"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-logbook-ui"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-filebrowser"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-perfmon"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-pace"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-diag"/>
-	<classpathentry kind="output" path="target/classes"/>
+    <classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Simplify conversion of visibility CALC expression into rules.
Bug used to turn "A&&B&&C&&D" into "pv0&&pv1&&pv2&&", dropping "...pv3".

Adding ADL object number to widget name to simplify finding a specific converted widget.