### PR TITLE
Fix example screen links

### DIFF
--- a/app/display/model/src/main/resources/examples/screen_A.bob
+++ b/app/display/model/src/main/resources/examples/screen_A.bob
@@ -22,7 +22,7 @@
     <text>$(actions)</text>
     <actions>
       <action type="open_display">
-        <file>control_action_buttons.bob</file>
+        <file>controls_action_buttons.bob</file>
         <target>replace</target>
         <description>Back To Action Buttons Screen</description>
       </action>

--- a/app/display/model/src/main/resources/examples/screen_B.bob
+++ b/app/display/model/src/main/resources/examples/screen_B.bob
@@ -22,7 +22,7 @@
     <text>$(actions)</text>
     <actions>
       <action type="open_display">
-        <file>control_action_buttons.bob</file>
+        <file>controls_action_buttons.bob</file>
         <target>replace</target>
         <description>Back To Action Buttons Screen</description>
       </action>


### PR DESCRIPTION
.. that have been broken back when 'control(s)_...' example screens switched to common name.