### PR TITLE
sys://time; javadoc

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
@@ -29,6 +29,8 @@ public class PVProposalService extends ProposalService
             providers.add(LocProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_sim_pv_proposals"))
             providers.add(SimProposalProvider.INSTANCE);
+        if (prefs.getBoolean("enable_sys_pv_proposals"))
+            providers.add(SysProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_pva_pv_proposals"))
             providers.add(PvaProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_mqtt_pv_proposals"))

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/SysProposalProvider.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/SysProposalProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.autocomplete;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.phoebus.framework.spi.PVProposalProvider;
+
+/** Provider of "sys://" PVs proposals
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class SysProposalProvider implements PVProposalProvider
+{
+    public static final SysProposalProvider INSTANCE = new SysProposalProvider();
+
+    private static final List<Proposal> generic = List.of(
+        new Proposal("sys://name"));
+
+    /** All the system PVs */
+    private static final List<Proposal> all_proposals = List.of(
+        new Proposal("sys://time"));
+
+    private SysProposalProvider()
+    {
+        // Singleton
+    }
+
+    @Override
+    public String getName()
+    {
+        return "System PV";
+    }
+
+    /** Get proposals
+     *
+     *  @param text Text entered by user
+     *  @return {@link Proposal}s that could be applied to the text
+     */
+    @Override
+    public List<Proposal> lookup(final String text)
+    {
+        // When nothing has been entered, suggest a generic system PV
+        if (text.isEmpty())
+            return generic;
+
+        // Search 'all' proposals for match
+        final List<Proposal> result = new ArrayList<>();
+
+        for (Proposal proposal : all_proposals)
+            if (proposal.getValue().contains(text))
+                result.add(proposal);
+
+        return result;
+    }
+}

--- a/core/framework/src/main/resources/autocomplete_preferences.properties
+++ b/core/framework/src/main/resources/autocomplete_preferences.properties
@@ -5,6 +5,7 @@
 # Enable the built-in PV proposal providers?
 enable_loc_pv_proposals=true
 enable_sim_pv_proposals=true
+enable_sys_pv_proposals=true
 enable_pva_pv_proposals=true
 enable_mqtt_pv_proposals=false
 

--- a/core/pv/.classpath
+++ b/core/pv/.classpath
@@ -8,6 +8,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pva"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-formula"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry exported="true" kind="lib" path="/phoebus-target/target/lib/epics-util-1.0.1-SNAPSHOT.jar"/>
 	<classpathentry exported="true" kind="lib" path="/phoebus-target/target/lib/vtype-1.0.1-SNAPSHOT.jar"/>

--- a/core/pv/pom.xml
+++ b/core/pv/pom.xml
@@ -56,6 +56,11 @@
       <version>4.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-util</artifactId>
+      <version>4.6.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
         <groupId>org.eclipse.paho</groupId>
         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         <version>1.2.0</version>

--- a/core/pv/src/main/java/org/phoebus/pv/sys/SysPVFactory.java
+++ b/core/pv/src/main/java/org/phoebus/pv/sys/SysPVFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.pv.sys;
+
+import org.phoebus.pv.PV;
+import org.phoebus.pv.PVFactory;
+
+/** PV Factory for system PVs
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class SysPVFactory implements PVFactory
+{
+    final public static String TYPE = "sys";
+
+    @Override
+    public String getType()
+    {
+        return TYPE;
+    }
+
+    @Override
+    public PV createPV(final String name, final String base_name) throws Exception
+    {
+        if (base_name.equals("time"))
+            return new TimePV(name);
+        else
+            throw new Exception("Unknown system PV " + base_name);
+    }
+}

--- a/core/pv/src/main/java/org/phoebus/pv/sys/TimePV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/sys/TimePV.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.pv.sys;
+
+import java.time.Instant;
+
+import org.phoebus.pv.sim.SimulatedStringPV;
+import org.phoebus.util.time.TimestampFormats;
+
+/** System "time" PV
+ *  @author Kay Kasemir, based on similar code in diirt
+ */
+public class TimePV extends SimulatedStringPV
+{
+    public TimePV(final String name)
+    {
+        super(name);
+        start(1);
+    }
+
+    @Override
+    public String compute()
+    {
+        return TimestampFormats.SECONDS_FORMAT.format(Instant.now());
+    }
+}

--- a/core/pv/src/main/resources/META-INF/services/org.phoebus.pv.PVFactory
+++ b/core/pv/src/main/resources/META-INF/services/org.phoebus.pv.PVFactory
@@ -1,5 +1,6 @@
 org.phoebus.pv.ca.JCA_PVFactory
 org.phoebus.pv.sim.SimPVFactory
+org.phoebus.pv.sys.SysPVFactory
 org.phoebus.pv.loc.LocalPVFactory
 org.phoebus.pv.pva.PVA_PVFactory
 org.phoebus.pv.opva.PVA_PVFactory

--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -22,7 +22,14 @@ Build
 Both Ant and Maven are supported:
 
     ant clean core-pva
-    mvn clean install
+    mvn clean install javadoc:javadoc
+    
+
+API Documentation
+-----------------
+
+Both Ant and Maven generate javadoc in target.
+... is in pva/target/site/apidocs/index.html
 
 Configuration
 -------------

--- a/core/pva/build.xml
+++ b/core/pva/build.xml
@@ -1,7 +1,14 @@
 <project default="core-pva">
     <import file="../../dependencies/ant_settings.xml"/>
 
-    <target name="core-pva">
+    <target name="javadoc">
+    	<javadoc sourcepath="src/main/java"
+    		     destdir="target/site/apidocs"
+    		     author="no">
+    	</javadoc>
+    </target>
+	
+    <target name="core-pva" depends="javadoc">
         <mkdir dir="${classes}"/>
         <javac destdir="${classes}" debug="${debug}">
             <src path="${src}"/>

--- a/core/pva/pom.xml
+++ b/core/pva/pom.xml
@@ -25,6 +25,17 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Javadoc, run via mvn javadoc:javadoc -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <author>false</author>
+          <!-- Avoid 'module' error -->
+          <source>8</source>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- Build executable JAR -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/core/pva/src/main/java/org/epics/pva/client/ClientChannelListener.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientChannelListener.java
@@ -18,15 +18,15 @@ public interface ClientChannelListener
      *  <p>Will be called as soon as possible, i.e. within
      *  the thread that handles the network communication.
      *
-     *  <p>Client code may invoke {@link PVAChannel#read()}
-     *  or {@link PVAChannel#subscribe()} to initiate
+     *  <p>Client code may invoke {@link PVAChannel#read(String)}
+     *  or {@link PVAChannel#subscribe(String, MonitorListener)} to initiate
      *  reading data or to start a subscription, but
      *  client code <b>must not</b> block,
-     *  i.e. awaiting the result of {@link PVAChannel#read()}
+     *  i.e. awaiting the result of a `read`
      *  is not permitted within this call.
      *
-     *  @param channel
-     *  @param state
+     *  @param channel Channel which changed state
+     *  @param state   Current state of that channel
      */
     public void channelStateChanged(PVAChannel channel, ClientChannelState state);
 }

--- a/core/pva/src/main/java/org/epics/pva/client/ClientChannelState.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientChannelState.java
@@ -30,7 +30,8 @@ public enum ClientChannelState
     /** Channel closing was confirmed by server, cannot be used again */
     CLOSED;
 
-    /** @return <code>true</code> if state is searching, connected, ..,
+    /** @param state State to check
+     *  @return <code>true</code> if state is searching, connected, ..,
      *          <code>false</code> if CLOSING or CLOSED and thus done.
      */
     public static boolean isActive(final ClientChannelState state)

--- a/core/pva/src/main/java/org/epics/pva/client/CreateChannelHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/CreateChannelHandler.java
@@ -20,7 +20,7 @@ import org.epics.pva.data.PVAStatus;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class CreateChannelHandler implements CommandHandler<ClientTCPHandler>
+class CreateChannelHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/DestroyChannelHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/DestroyChannelHandler.java
@@ -19,7 +19,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class DestroyChannelHandler implements CommandHandler<ClientTCPHandler>
+class DestroyChannelHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/EchoHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/EchoHandler.java
@@ -21,7 +21,7 @@ import org.epics.pva.data.Hexdump;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class EchoHandler implements CommandHandler<ClientTCPHandler>
+class EchoHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/GetHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetHandler.java
@@ -16,7 +16,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class GetHandler implements CommandHandler<ClientTCPHandler>
+class GetHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/GetTypeHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetTypeHandler.java
@@ -16,7 +16,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class GetTypeHandler implements CommandHandler<ClientTCPHandler>
+class GetTypeHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/MonitorHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/MonitorHandler.java
@@ -16,7 +16,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class MonitorHandler implements CommandHandler<ClientTCPHandler>
+class MonitorHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/MonitorListener.java
+++ b/core/pva/src/main/java/org/epics/pva/client/MonitorListener.java
@@ -11,7 +11,7 @@ import java.util.BitSet;
 
 import org.epics.pva.data.PVAStructure;
 
-/** Listener to {@link MonitorRequest}
+/** Listener to subscription updates of a {@link PVAChannel}
  *  @author Kay Kasemir
  */
 @FunctionalInterface

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -22,14 +22,20 @@ import org.epics.pva.data.PVAStructure;
 
 /** Client channel
  *
- *  <p>Obtained via {@link PVAClient#getChannel()}.
+ *  <p>Obtained via {@link PVAClient#getChannel(String)}.
  *  Allows reading and writing a channel's data.
  *
  *  <p>Channel 'connects' automatically.
- *  A listener will be informed when connection state changes,
- *  with helpers to await connection or check current connection state.
+ *  When obtaining the channel from the {@link PVAClient},
+ *  a listener can be provided to receive connection state updates.
+ *  In addition, {@link PVAChannel#connect()} can be used to await
+ *  connection, or {@link PVAChannel#isConnected()} can be used to check
+ *  the current state.
  *
- *  <p>Once connected, channel can read or write data.
+ *  <p>Once connected, a channel can {@link #read(String)} or {@link #write(String, Object)} data,
+ *  {@link #subscribe(String, MonitorListener)} to value updates, or {@link #invoke(PVAStructure)} RPC calls.
+ *
+ *  <p>When no longer in use, the channel should be {@link #close()}d.
  *
  *  @author Kay Kasemir
  */
@@ -213,11 +219,11 @@ public class PVAChannel
      *  and the value to write must be accepted by that field.
      *
      *  <p>For example, when "field(value)" addresses a double field,
-     *  {@link PVADouble#setValue()} will be called, so <code>new_value</code>
+     *  {@link PVADouble#setValue(Object)} will be called, so <code>new_value</code>
      *  may be a {@link Number}.
      *
      *  <p>When "field(value)" addresses a text field,
-     *  {@link PVAString#setValue()} will be called,
+     *  {@link PVAString#setValue(Object)} will be called,
      *  which accepts any object by converting it to a string.
      *
      *  <p>When writing an enumerated field, its <code>int index</code>

--- a/core/pva/src/main/java/org/epics/pva/client/PutHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutHandler.java
@@ -16,7 +16,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PutHandler implements CommandHandler<ClientTCPHandler>
+class PutHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/RPCHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/RPCHandler.java
@@ -16,7 +16,7 @@ import org.epics.pva.common.PVAHeader;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class RPCHandler implements CommandHandler<ClientTCPHandler>
+class RPCHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/ServerInfo.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ServerInfo.java
@@ -16,7 +16,8 @@ import org.epics.pva.server.Guid;
 
 /** Info for a server
  *
- *  <p>Obtained via {@link PVAClient#list()}
+ *  <p>Obtained via {@link PVAClient#list(java.util.concurrent.TimeUnit, long)}
+ *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")

--- a/core/pva/src/main/java/org/epics/pva/client/ValidatedHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ValidatedHandler.java
@@ -20,7 +20,7 @@ import org.epics.pva.data.PVAStatus;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ValidatedHandler implements CommandHandler<ClientTCPHandler>
+class ValidatedHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/ValidationHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ValidationHandler.java
@@ -22,7 +22,7 @@ import org.epics.pva.data.PVAString;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ValidationHandler implements CommandHandler<ClientTCPHandler>
+class ValidationHandler implements CommandHandler<ClientTCPHandler>
 {
     @Override
     public byte getCommand()

--- a/core/pva/src/main/java/org/epics/pva/client/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/client/package-info.java
@@ -1,0 +1,5 @@
+/** PV Access Client API
+ *
+ *  <p>Main API for client code is {@link org.epics.pva.client.PVAClient}.
+ */
+package org.epics.pva.client;

--- a/core/pva/src/main/java/org/epics/pva/common/Network.java
+++ b/core/pva/src/main/java/org/epics/pva/common/Network.java
@@ -126,8 +126,8 @@ public class Network
      *
      *  @param broadcast Support broadcast?
      *  @param port Port to use or 0 to auto-assign
-     *  @return
-     *  @throws Exception
+     *  @return UDP channel
+     *  @throws Exception on error
      */
     public static DatagramChannel createUDP(boolean broadcast, int port) throws Exception
     {
@@ -142,6 +142,7 @@ public class Network
     }
 
     /** Try to listen to multicast messages
+     *  @param udp UDP channel that should listen to multicast messages
      *  @return Local multicast address, or <code>null</code> if no multicast support
      */
     public static InetSocketAddress configureMulticast(final DatagramChannel udp)

--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -104,7 +104,7 @@ abstract public class TCPHandler
      *
      *  @param socket Socket to read/write
      *  @param client_mode Is this the client, expecting to receive messages from server?
-     *  @see {@link #startSender()}
+     *  @see #startSender()
      */
     public TCPHandler(final SocketChannel socket, final boolean client_mode)
     {

--- a/core/pva/src/main/java/org/epics/pva/common/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/common/package-info.java
@@ -1,0 +1,3 @@
+/** Common code internal to the server and client
+ */
+package org.epics.pva.common;

--- a/core/pva/src/main/java/org/epics/pva/data/PVAData.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAData.java
@@ -41,7 +41,7 @@ public abstract class PVAData
      *  This method allows setting the value from
      *  generic {@link Object}.
      *
-     *  @param new_value
+     *  @param new_value New value for this data item
      *  @throws Exception on error, including incompatible data type
      */
     public abstract void setValue(Object new_value) throws Exception;

--- a/core/pva/src/main/java/org/epics/pva/data/PVAString.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAString.java
@@ -19,7 +19,9 @@ public class PVAString extends PVAData
 {
     public static final byte FIELD_DESC_TYPE = (byte)0b01100000;
 
-    /** @return Encoded size of string in bytes */
+    /** @param string Text
+     *  @return Encoded size of string in bytes
+     */
     public static int getEncodedSize(final String string)
     {
         final int len = string.length();

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
@@ -21,14 +21,19 @@ public class PVAStringArray extends PVAData implements PVAArray
 {
     private volatile String[] value = new String[0];
 
-    /** Construct variable-size string array */
+    /** Construct variable-size string array
+     *  @param name Data item name
+     *  @param value Initial value
+     */
     public PVAStringArray(final String name, final String[] value)
     {
         super(name);
         this.value = value;
     }
 
-    /** Construct variable-size string array */
+    /** Construct variable-size string array
+     *  @param name Data item name
+     */
     public PVAStringArray(final String name)
     {
         this(name, new String[0]);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
@@ -25,11 +25,33 @@ import java.util.logging.Level;
  *  <p>Holds one or more {@link PVAData} elements.
  *  Often named as for example a normative type.
  *
+ *  <p>Usage example:
+ *  <pre>
+ *  PVAChannel channel = ...;
+ *  PVAStructure data = channel.read("").get();
+ *
+ *  // To debug, dump complete structure
+ *  System.out.println(data);
+ *
+ *  // Introspect
+ *  System.out.println("Structure of type " + data.getStructureName());
+ *  for (PVAData element : data.get())
+ *      System.out.println(element);*
+ *
+ *  // For known structure, get elements by name
+ *  PVAString value = data.get("value");
+ *  System.out.println("value = " + value.get());
+ *  </pre>
+ *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class PVAStructure extends PVADataWithID
 {
+    static
+    {
+    }
+
     static PVAStructure decodeType(final PVATypeRegistry types, final String name, final ByteBuffer buffer) throws Exception
     {
         final String struct_name = PVAString.decodeString(buffer);
@@ -274,6 +296,7 @@ public class PVAStructure extends PVADataWithID
      *
      *  @param element_name Name of structure element
      *  @return Located element or <code>null</code>
+     *  @param <PVA> PVAData or subclass
      */
     @SuppressWarnings("unchecked")
     public <PVA extends PVAData> PVA get(final String element_name)
@@ -308,6 +331,7 @@ public class PVAStructure extends PVADataWithID
      *
      *  @param index Element index
      *  @return Located element or <code>null</code>
+     *  @param <PVA> PVAData or subclass
      */
     @SuppressWarnings("unchecked")
     public <PVA extends PVAData> PVA get(final int index)

--- a/core/pva/src/main/java/org/epics/pva/data/PVAUnion.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAUnion.java
@@ -71,7 +71,9 @@ public class PVAUnion extends PVADataWithID
         this.elements = Collections.unmodifiableList(elements);
     }
 
-    /** @return Selected element of the union, <code>null</code> if none */
+    /** @return Selected element of the union, <code>null</code> if none
+     *  @param <PVA> PVAData or subclass
+     */
     @SuppressWarnings("unchecked")
     public <PVA extends PVAData> PVA get()
     {

--- a/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
@@ -1,0 +1,5 @@
+/** PV Access Data API for normative types
+ *
+ *  <p>Helpers for dealing with commonly used {@link org.epics.pva.data.PVAStructure}s
+ */
+package org.epics.pva.data.nt;

--- a/core/pva/src/main/java/org/epics/pva/data/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/data/package-info.java
@@ -1,0 +1,6 @@
+/** PV Access Data API
+ *
+ *  <p>All PV Access data is based on {@link org.epics.pva.data.PVAData},
+ *  but most practical API starts with {@link org.epics.pva.data.PVAStructure}.
+ */
+package org.epics.pva.data;

--- a/core/pva/src/main/java/org/epics/pva/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/package-info.java
@@ -1,0 +1,7 @@
+/** PV Access Client and Server configuration
+ *
+ *  <p>Both the {@link org.epics.pva.client.PVAClient} and the {@link org.epics.pva.server.PVAServer}
+ *  are configured via environment variables or system properties
+ *  described in {@link org.epics.pva.PVASettings}
+ */
+package org.epics.pva;

--- a/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
+++ b/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
@@ -53,7 +53,9 @@ public class PVAServer
     /** Handlers for the TCP connections clients established to this server */
     private final KeySetView<ServerTCPHandler, Boolean> tcp_handlers = ConcurrentHashMap.newKeySet();
 
-    /** Create PVA Server */
+    /** Create PVA Server
+     *  @throws Exception on error
+     */
     public PVAServer() throws Exception
     {
         logger.log(Level.CONFIG, "PVA Server " + guid);
@@ -80,11 +82,8 @@ public class PVAServer
 
     /** Create a PV for an RPC service
      *
-     *  <p>Creates a thread-safe copy of the initial value.
-     *  To update the data, see {@link ServerPV#update(PVAStructure)}
-     *
      *  @param name PV Name
-     *  @param data Type definition and initial value
+     *  @param rpc {@link RPCService} that handles client invocations
      *  @return {@link ServerPV}
      */
     public ServerPV createPV(final String name, final RPCService rpc)

--- a/core/pva/src/main/java/org/epics/pva/server/RPCService.java
+++ b/core/pva/src/main/java/org/epics/pva/server/RPCService.java
@@ -18,6 +18,7 @@ public interface RPCService
      *
      *  @param parameters Service call parameters, i.e. arguments of the call
      *  @return Result
+     *  @throws Exception on error
      */
     public PVAStructure call(PVAStructure parameters) throws Exception;
 }

--- a/core/pva/src/main/java/org/epics/pva/server/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/server/package-info.java
@@ -1,0 +1,5 @@
+/** PV Access Server API
+ *
+ *  <p>Main API for server code is {@link org.epics.pva.server.PVAServer}.
+ */
+package org.epics.pva.server;

--- a/run_maven.sh
+++ b/run_maven.sh
@@ -5,7 +5,7 @@ mvn clean verify  -f dependencies/pom.xml
 # All but first run can use -o for offline
 #
 mvn -DskipTests clean install 
-(cd phoebus-product/target; java -jar product-0.0.1-SNAPSHOT.jar  --add-modules=ALL-SYSTEM )
+(cd phoebus-product/target; java -jar product-*-SNAPSHOT.jar  --add-modules=ALL-SYSTEM )
 
 # Or:
 # (cd scan-server-product/target; java -jar scan-server-product-0.0.1-SNAPSHOT.jar )


### PR DESCRIPTION
Turns out we have several legacy displays with 'sys://time' somewhere in the corner, so supporting that PV, i.e. adding general 'sys://' PV section with autocomplete etc., but for now only "time" in there.

Add javadoc to pva lib.

