### PR TITLE
Display fixes

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -230,6 +230,7 @@ public class PropertyPanelSection extends GridPane
         {
             final FontWidgetProperty font_prop = (FontWidgetProperty) property;
             final Button font_field = new Button();
+            font_field.setMnemonicParsing(false);
             font_field.setMaxWidth(Double.MAX_VALUE);
             final WidgetFontPropertyBinding binding = new WidgetFontPropertyBinding(undo, font_field, font_prop, other);
             bindings.add(binding);
@@ -328,6 +329,7 @@ public class PropertyPanelSection extends GridPane
         {
             final ColorMapWidgetProperty colormap_prop = (ColorMapWidgetProperty) property;
             final Button map_button = new Button();
+            map_button.setMnemonicParsing(false);
             map_button.setMaxWidth(Double.MAX_VALUE);
             final ColorMapPropertyBinding binding = new ColorMapPropertyBinding(undo, map_button, colormap_prop, other);
             bindings.add(binding);
@@ -508,6 +510,7 @@ public class PropertyPanelSection extends GridPane
         {
             final MacrosWidgetProperty macros_prop = (MacrosWidgetProperty) property;
             final Button macros_field = new Button();
+            macros_field.setMnemonicParsing(false);
             macros_field.setMaxWidth(Double.MAX_VALUE);
             final MacrosPropertyBinding binding = new MacrosPropertyBinding(undo, macros_field, macros_prop, other);
             bindings.add(binding);
@@ -518,6 +521,7 @@ public class PropertyPanelSection extends GridPane
         {
             final ActionsWidgetProperty actions_prop = (ActionsWidgetProperty) property;
             final Button actions_field = new Button();
+            actions_field.setMnemonicParsing(false);
             actions_field.setMaxWidth(Double.MAX_VALUE);
             final ActionsPropertyBinding binding = new ActionsPropertyBinding(undo, actions_field, actions_prop, other);
             bindings.add(binding);
@@ -528,6 +532,7 @@ public class PropertyPanelSection extends GridPane
         {
             final ScriptsWidgetProperty scripts_prop = (ScriptsWidgetProperty) property;
             final Button scripts_field = new Button();
+            scripts_field.setMnemonicParsing(false);
             scripts_field.setMaxWidth(Double.MAX_VALUE);
             final ScriptsPropertyBinding binding = new ScriptsPropertyBinding(undo, scripts_field, scripts_prop, other);
             bindings.add(binding);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetColorPropertyField.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetColorPropertyField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,9 @@ public class WidgetColorPropertyField extends HBox
 
     public WidgetColorPropertyField()
     {
+        // Button with label "Button_Background" for color name
+        // must not react to Alt-B (used to move widgets for/back in order)
+        button.setMnemonicParsing(false);
         button.setMaxWidth(Double.MAX_VALUE);
 
         HBox.setMargin(blob, new Insets(5, 5, 5, 0));

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
@@ -76,6 +76,14 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
 
     public static final String FONT_FAMILY = "Liberation Sans";
 
+    /** When background is 100% transparent (alpha=0),
+     *  the plot will no longer capture any mouse events,
+     *  it's invisible to the mouse.
+     *  Patching that color with an almost transparent one
+     *  avoids the issue.
+     */
+    private static final Color ALMOST_TRANSPARENT = new Color(0, 0, 0, 1);
+
     /** Font to use for, well, title */
     private volatile Font title_font = new Font(FONT_FAMILY, Font.BOLD, 18);
 
@@ -185,7 +193,10 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
     /** @param color Background color */
     public void setBackground(final Color color)
     {
-        background = color;
+        if (color.getAlpha() <= 0)
+            background = ALMOST_TRANSPARENT;
+        else
+            background = color;
     }
 
     /** Opacity (0 .. 100 %) of 'area' */


### PR DESCRIPTION
"Alt-B" in editor, instead of moving widget back, tended to open the color editor for a widget with "Button_Background" color because that was mnemoniced as "Button&Background".

XYPlot with fully transparent background no longer got mouse events, hence cannot zoom/pan #760