### PR TITLE
Display: Add display name and path to email & logbook text suggestion

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.runtime.app;
 import java.util.List;
 import java.util.Optional;
 
+import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.ActionInfo;
@@ -35,6 +36,8 @@ import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
+
+import com.google.common.base.Objects;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
@@ -170,8 +173,24 @@ class ContextMenuSupport
         items.add(new PrintAction(model_parent));
 
         items.add(new SaveSnapshotAction(model_parent));
-        items.add(new SendEmailAction(model_parent, "Display Screenshot", "See attached display", () ->  Screenshot.imageFromNode(model_parent)));
-        items.add(new SendLogbookAction(model_parent, "Display Screenshot", "See attached display", () ->  Screenshot.imageFromNode(model_parent)));
+
+        String display_info;
+        try
+        {
+            final DisplayModel model = widget.getDisplayModel();
+            final String name = model.getDisplayName();
+            final String input =  model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
+            if (Objects.equal(name, input))
+                display_info = "Display '" + name + "'";
+            else
+                display_info = "Display '" + name + "' (" + input + ")";
+        }
+        catch (Exception ex)
+        {
+            display_info = "See attached display";
+        }
+        items.add(new SendEmailAction(model_parent, "Display Screenshot", display_info, () ->  Screenshot.imageFromNode(model_parent)));
+        items.add(new SendLogbookAction(model_parent, "Display Screenshot", display_info, () ->  Screenshot.imageFromNode(model_parent)));
         items.add(new SeparatorMenuItem());
 
         items.add(new DisplayToolbarAction(instance));

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.runtime.app;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.csstudio.display.builder.model.DisplayModel;
@@ -36,8 +37,6 @@ import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
-
-import com.google.common.base.Objects;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
@@ -180,7 +179,7 @@ class ContextMenuSupport
             final DisplayModel model = widget.getDisplayModel();
             final String name = model.getDisplayName();
             final String input =  model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
-            if (Objects.equal(name, input))
+            if (Objects.equals(name, input))
                 display_info = "Display '" + name + "'";
             else
                 display_info = "Display '" + name + "' (" + input + ")";


### PR DESCRIPTION
I tend to get many emails with a screenshot, the default "See attached display" and some comment, but then wonder what display that is.
Now the default text mentions the display name and input file/path.