### PR TITLE
Ensure that the alarm services use UTC when recording alarm events

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmCommandMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmCommandMessage.java
@@ -1,6 +1,7 @@
 package org.phoebus.applications.alarm.messages;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class AlarmCommandMessage {
         map.put("user", getUser());
         map.put("host", getHost());
         map.put("command", getCommand());
-        map.put("message_time", formatter.format(getMessage_time()));
+        map.put("message_time", formatter.withZone(ZoneId.of("UTC")).format(getMessage_time()));
         return map;
     }
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
@@ -1,6 +1,7 @@
 package org.phoebus.applications.alarm.messages;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
@@ -205,7 +206,7 @@ public class AlarmConfigMessage {
         map.put("enabled", Boolean.toString(isEnabled()));
         map.put("latching", Boolean.toString(isLatching()));
         map.put("config_msg", toString());
-        map.put("message_time", formatter.format(getMessage_time()));
+        map.put("message_time", formatter.withZone(ZoneId.of("UTC")).format(getMessage_time()));
         return map;
     }
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmMessage.java
@@ -1,12 +1,9 @@
 package org.phoebus.applications.alarm.messages;
 
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.phoebus.util.time.TimestampFormats;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -327,9 +324,6 @@ public class AlarmMessage {
     static {
         objectConfigMapper.addMixIn(AlarmMessage.class, AlarmConfigJsonMessage.class);
     }
-
-    @JsonIgnore
-    private static DateTimeFormatter formatter = TimestampFormats.MILLI_FORMAT;
 
     /**
      * Returns the json string representation of this object

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmStateMessage.java
@@ -1,6 +1,7 @@
 package org.phoebus.applications.alarm.messages;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -152,8 +153,8 @@ public class AlarmStateMessage {
         map.put("latch", Boolean.toString(isLatch()));
         map.put("message", getMessage());
         map.put("value", getValue());
-        map.put("time", formatter.format(getInstant()));
-        map.put("message_time", formatter.format(getMessage_time()));
+        map.put("time", formatter.withZone(ZoneId.of("UTC")).format(getInstant()));
+        map.put("message_time", formatter.withZone(ZoneId.of("UTC")).format(getMessage_time()));
         map.put("current_severity", getCurrent_severity());
         map.put("current_message", getCurrent_message());
         map.put("mode", getMode());


### PR DESCRIPTION
fixes the alarm messages source map to always use UTC