### PR TITLE
Faster XY Plot

### DIFF
--- a/app/display/model/src/main/resources/examples/plots/xy_speed.bob
+++ b/app/display/model/src/main/resources/examples/plots/xy_speed.bob
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display version="2.0.0">
+  <name>XY Plot</name>
+  <macros>
+    <PV>sim://noisewave(0, 10, 0.01)</PV>
+  </macros>
+  <width>810</width>
+  <height>1020</height>
+  <widget type="xyplot" version="2.0.0">
+    <name>RightPlot</name>
+    <x>40</x>
+    <y>20</y>
+    <width>360</width>
+    <height>340</height>
+    <show_legend>false</show_legend>
+    <x_axis>
+      <title>X</title>
+      <autoscale>false</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>10.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>true</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>120.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>Counts</name>
+        <x_pv></x_pv>
+        <y_pv>$(PV)</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>3</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>3</line_width>
+        <point_type>2</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>RightPlot_1</name>
+    <x>420</x>
+    <y>20</y>
+    <width>360</width>
+    <height>340</height>
+    <show_legend>false</show_legend>
+    <x_axis>
+      <title>X</title>
+      <autoscale>false</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>10.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>true</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>120.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>Counts</name>
+        <x_pv></x_pv>
+        <y_pv>$(PV)</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>3</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>3</line_width>
+        <point_type>2</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>RightPlot_2</name>
+    <x>40</x>
+    <y>380</y>
+    <width>360</width>
+    <height>340</height>
+    <show_legend>false</show_legend>
+    <x_axis>
+      <title>X</title>
+      <autoscale>false</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>10.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>true</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>120.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>Counts</name>
+        <x_pv></x_pv>
+        <y_pv>$(PV)</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>3</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>3</line_width>
+        <point_type>2</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>RightPlot_3</name>
+    <x>420</x>
+    <y>380</y>
+    <width>360</width>
+    <height>340</height>
+    <show_legend>false</show_legend>
+    <x_axis>
+      <title>X</title>
+      <autoscale>false</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>10.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>true</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>120.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>Counts</name>
+        <x_pv></x_pv>
+        <y_pv>$(PV)</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>3</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>3</line_width>
+        <point_type>2</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>All plots show the same PV, configured as a macro on the display:
+PV: $(PV).
+
+With the default settings, updates are throttled to 4Hz.
+
+With these settings, should get up to 100Hz updates:
+
+org.csstudio.display.builder.runtime/update_throttle=1
+org.csstudio.display.builder.representation/update_accumulation_time = 1
+org.csstudio.display.builder.representation/update_delay = 1
+org.csstudio.display.builder.representation/plot_update_delay = 1
+org.csstudio.display.builder.representation/image_update_delay = 1
+
+To see updates, start with Java property
+ -Dorg.csstudio.javafx.rtplot.update_counter=true</text>
+    <x>30</x>
+    <y>730</y>
+    <width>670</width>
+    <height>270</height>
+  </widget>
+</display>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -29,12 +29,12 @@ import org.csstudio.display.builder.model.widgets.plots.XYPlotWidget.MarkerPrope
 import org.csstudio.display.builder.representation.Preferences;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.csstudio.display.builder.representation.javafx.widgets.RegionBaseRepresentation;
+import org.csstudio.javafx.rtplot.Activator;
 import org.csstudio.javafx.rtplot.Axis;
 import org.csstudio.javafx.rtplot.AxisRange;
 import org.csstudio.javafx.rtplot.LineStyle;
 import org.csstudio.javafx.rtplot.PlotMarker;
 import org.csstudio.javafx.rtplot.PointType;
-import org.csstudio.javafx.rtplot.RTPlot;
 import org.csstudio.javafx.rtplot.RTPlotListener;
 import org.csstudio.javafx.rtplot.RTValuePlot;
 import org.csstudio.javafx.rtplot.Trace;
@@ -208,7 +208,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
                                                     value_listener = this::valueChanged;
         private final Trace<Double> trace;
         // Throttle this trace's x, y, error value changes
-        private final UpdateThrottle throttle = new UpdateThrottle(Preferences.plot_update_delay, TimeUnit.MILLISECONDS, this::computeTrace, RTPlot.UPDATE_TIMER);
+        private final UpdateThrottle throttle = new UpdateThrottle(Preferences.plot_update_delay, TimeUnit.MILLISECONDS, this::computeTrace,  Activator.thread_pool);
 
         TraceHandler(final TraceWidgetProperty model_trace)
         {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -34,6 +34,7 @@ import org.csstudio.javafx.rtplot.AxisRange;
 import org.csstudio.javafx.rtplot.LineStyle;
 import org.csstudio.javafx.rtplot.PlotMarker;
 import org.csstudio.javafx.rtplot.PointType;
+import org.csstudio.javafx.rtplot.RTPlot;
 import org.csstudio.javafx.rtplot.RTPlotListener;
 import org.csstudio.javafx.rtplot.RTValuePlot;
 import org.csstudio.javafx.rtplot.Trace;
@@ -207,7 +208,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
                                                     value_listener = this::valueChanged;
         private final Trace<Double> trace;
         // Throttle this trace's x, y, error value changes
-        private final UpdateThrottle throttle = new UpdateThrottle(Preferences.plot_update_delay, TimeUnit.MILLISECONDS, this::computeTrace);
+        private final UpdateThrottle throttle = new UpdateThrottle(Preferences.plot_update_delay, TimeUnit.MILLISECONDS, this::computeTrace, RTPlot.UPDATE_TIMER);
 
         TraceHandler(final TraceWidgetProperty model_trace)
         {

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Activator.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Activator.java
@@ -10,8 +10,6 @@ package org.csstudio.javafx.rtplot;
 import java.awt.Color;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.phoebus.framework.jobs.NamedThreadFactory;
@@ -31,17 +29,14 @@ public class Activator
     public static final Color shady_future;
 
     /** Thread pool for scrolling, throttling updates
-     *  <p>No upper limit for threads.
-     *  Removes all threads after 10 seconds
+     * 
+     *  <p>One per CPU core allows that many plots to run updateImageBuffer in parallel.
      */
-    public static final ScheduledExecutorService thread_pool;
+    public static final ScheduledExecutorService thread_pool
+        =  Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new NamedThreadFactory("RTPlot"));
 
     static
     {
-        // After 10 seconds, delete all idle threads
-        thread_pool = Executors.newScheduledThreadPool(0, new NamedThreadFactory("RTPlot"));
-        ((ThreadPoolExecutor)thread_pool).setKeepAliveTime(10, TimeUnit.SECONDS);
-
         final PreferencesReader prefs = new PreferencesReader(Activator.class, "/rt_plot_preferences.properties");
         final String[] rgba = prefs.get("shady_future").split("\\s*,\\s*");
         shady_future = new Color(Integer.parseInt(rgba[0]),Integer.parseInt(rgba[1]), Integer.parseInt(rgba[2]), Integer.parseInt(rgba[3]));

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.javafx.rtplot.data.PlotDataItem;
@@ -28,6 +30,7 @@ import org.csstudio.javafx.rtplot.internal.TraceImpl;
 import org.csstudio.javafx.rtplot.internal.YAxisImpl;
 import org.csstudio.javafx.rtplot.internal.undo.ChangeAxisRanges;
 import org.csstudio.javafx.rtplot.internal.util.GraphicsUtils;
+import org.phoebus.framework.jobs.NamedThreadFactory;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
@@ -58,6 +61,12 @@ import javafx.stage.Stage;
 @SuppressWarnings("nls")
 public class RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
 {
+    /** Timer for scheduling plot updates, for example with plot-related UpdateThrottle
+     *  <p>One per CPU core allows that many plots to run updateImageBuffer in parallel.
+     */
+    public static final ScheduledExecutorService UPDATE_TIMER =
+        Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new NamedThreadFactory("RTPlotUpdateThrottle"));
+
     final protected Plot<XTYPE> plot;
     final protected ToolbarHandler<XTYPE> toolbar;
     private boolean handle_keys = false;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
@@ -14,8 +14,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.javafx.rtplot.data.PlotDataItem;
@@ -30,7 +28,6 @@ import org.csstudio.javafx.rtplot.internal.TraceImpl;
 import org.csstudio.javafx.rtplot.internal.YAxisImpl;
 import org.csstudio.javafx.rtplot.internal.undo.ChangeAxisRanges;
 import org.csstudio.javafx.rtplot.internal.util.GraphicsUtils;
-import org.phoebus.framework.jobs.NamedThreadFactory;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
@@ -61,12 +58,6 @@ import javafx.stage.Stage;
 @SuppressWarnings("nls")
 public class RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
 {
-    /** Timer for scheduling plot updates, for example with plot-related UpdateThrottle
-     *  <p>One per CPU core allows that many plots to run updateImageBuffer in parallel.
-     */
-    public static final ScheduledExecutorService UPDATE_TIMER =
-        Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new NamedThreadFactory("RTPlotUpdateThrottle"));
-
     final protected Plot<XTYPE> plot;
     final protected ToolbarHandler<XTYPE> toolbar;
     private boolean handle_keys = false;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.csstudio.javafx.rtplot.RTPlot;
+import org.csstudio.javafx.rtplot.Activator;
 import org.phoebus.ui.javafx.BufferUtil;
 import org.phoebus.ui.javafx.DoubleBuffer;
 import org.phoebus.ui.javafx.UpdateThrottle;
@@ -214,7 +214,7 @@ abstract class PlotCanvasBase extends ImageView
             }
             if (!pending_redraw.getAndSet(true))
                 Platform.runLater(redraw_runnable);
-        }, RTPlot.UPDATE_TIMER);
+        }, Activator.thread_pool);
 
         if (active)
         {

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotCanvasBase.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.csstudio.javafx.rtplot.RTPlot;
 import org.phoebus.ui.javafx.BufferUtil;
 import org.phoebus.ui.javafx.DoubleBuffer;
 import org.phoebus.ui.javafx.UpdateThrottle;
@@ -165,7 +166,7 @@ abstract class PlotCanvasBase extends ImageView
                 if (now > next_rate_update)
                 {
                     final long diff = update_counter - last_counter;
-                    update_rate = (update_rate * 9.0 + diff) / 10.0;
+                    update_rate = (update_rate * 5.0 + diff) / 6.0;
                     last_counter = update_counter;
                     next_rate_update = now + 1000;
                 }
@@ -213,7 +214,7 @@ abstract class PlotCanvasBase extends ImageView
             }
             if (!pending_redraw.getAndSet(true))
                 Platform.runLater(redraw_runnable);
-        });
+        }, RTPlot.UPDATE_TIMER);
 
         if (active)
         {

--- a/core/pv/src/main/java/org/phoebus/pv/sim/SimulatedPV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/sim/SimulatedPV.java
@@ -47,7 +47,8 @@ abstract public class SimulatedPV extends PV
      */
     protected void start(final double update_seconds)
     {
-        final long milli = Math.round(Math.max(update_seconds, 0.1) * 1000);
+        // Limit rate to 100 Hz
+        final long milli = Math.round(Math.max(update_seconds, 0.01) * 1000);
         task = executor.scheduleAtFixedRate(this::update, milli, milli, TimeUnit.MILLISECONDS);
     }
 


### PR DESCRIPTION
Michael noticed that XYPlot updates result in sequenced redraws, i.e. one plot updates, then the next.
That happened because the throttling of plot updates used one shared thread.
Now using a thread pool.
With default settings, plot display updates are still throttled to 4Hz, but when reducing the throttle delays, it can now display a 100Hz PV four times, each plot updating at 100Hz.

![plot2](https://user-images.githubusercontent.com/1932421/62972584-5ce0b680-bde2-11e9-9f45-7579a545eb34.png)
