### PR TITLE
Preferences: Listing, option to import in UI

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/preferences/PropertyPreferenceWriter.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/PropertyPreferenceWriter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.preferences;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.prefs.Preferences;
+
+/** Write preferences in property file format
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PropertyPreferenceWriter
+{
+    /** Save preferences in property file format
+     *
+     *  <p>Properties have the name "package/setting",
+     *  where the package name in dot notation
+     *  is used to locate the preference node.
+     *
+     *  <p>Value is the corresponding preference setting.
+     *
+     *  @param stream Stream for property file
+     *  @throws Exception on error
+     */
+    public static void save(final OutputStream stream) throws Exception
+    {
+        try
+        (
+            final OutputStreamWriter out = new OutputStreamWriter(stream);
+        )
+        {
+            out.append("# Preference settings\n");
+            out.append("# Format:\n");
+            out.append("# the.package.name/key=value\n");
+            listSettings(out, Preferences.userRoot());
+            out.append("# End.\n");
+            out.flush();
+        }
+    }
+
+    private static void listSettings(final Writer out, final Preferences node) throws Exception
+    {
+        for (String key : node.keys())
+            formatSetting(out, node, key);
+        for (String child : node.childrenNames())
+            listSettings(out, node.node(child));
+    }
+
+    private static void formatSetting(final Writer out, final Preferences node, final String key) throws Exception
+    {
+        final String path = node.absolutePath();
+        out.append(path.substring(1).replace('/', '.'))
+           .append('/')
+           .append(key)
+           .append('=')
+           .append(node.get(key, ""))
+           .append('\n');
+    }
+}

--- a/core/framework/src/test/java/org/phoebus/framework/preferences/PreferencesReaderTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/preferences/PreferencesReaderTest.java
@@ -10,6 +10,8 @@ package org.phoebus.framework.preferences;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import java.io.ByteArrayOutputStream;
+
 import org.junit.Test;
 
 /** JUnit test of the PreferencesReader
@@ -32,5 +34,19 @@ public class PreferencesReaderTest
 
         // Replace one property
         assertThat(PreferencesReader.replaceProperties("This is $(test)"), equalTo("This is OK"));
+    }
+
+    @Test
+    public void testListSettings() throws Exception
+    {
+        try
+        (
+            final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        )
+        {
+            PropertyPreferenceWriter.save(buf);
+            System.out.print(buf.toString());
+        }
+        System.out.println("Done");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -43,7 +43,6 @@ public class Messages
     public static String Help;
     public static String HelpAbout;
     public static String HelpAboutAppFea;
-    public static String HelpAboutAppUnd;
     public static String HelpAboutHdr;
     public static String HelpAboutColName;
     public static String HelpAboutColValue;
@@ -51,8 +50,8 @@ public class Messages
     public static String HelpAboutJava;
     public static String HelpAboutJfx;
     public static String HelpAboutMenuPath;
+    public static String HelpAboutPrefs;
     public static String HelpAboutSysFea;
-    public static String HelpAboutSysUnd;
     public static String HelpAboutTitle;
     public static String HelpAboutUser;
     public static String HelpContentMenuPath;

--- a/core/ui/src/main/java/org/phoebus/ui/dialog/DialogHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/dialog/DialogHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.control.Dialog;
 import javafx.stage.Screen;
+import javafx.stage.Stage;
 
 /** Helper for dialogs
  *  @author Kay Kasemir
@@ -34,6 +35,14 @@ public class DialogHelper
     private DialogHelper()
     {
     }
+
+    /** @param dialog Dialog that should be on top of other windows */
+    public static void forceToFront(final Dialog<?> dialog)
+    {
+        final Stage stage  = (Stage)  dialog.getDialogPane().getScene().getWindow();
+        stage.toFront();
+    }
+
 
     /** Position dialog relative to another widget
      *
@@ -62,13 +71,13 @@ public class DialogHelper
                 }
                 final double nodeX = pos.getMinX();
                 final double nodeY = pos.getMinY();
-                
+
                 double newX = nodeX + pos.getWidth()/2 + x_offset;
                 double newY = nodeY + pos.getHeight()/2 + y_offset;
-                
+
                 final double dw = dialog.getWidth();
                 final double dh = dialog.getHeight();
-                
+
                 List<Screen> scr = Screen.getScreensForRectangle(nodeX, nodeY, pos.getWidth(), pos.getHeight());
                 if (scr == null || scr.size() == 0)
                 {
@@ -77,15 +86,18 @@ public class DialogHelper
                 }
                 // Take the first available screen
                 Rectangle2D sb = scr.get(0).getVisualBounds();
-                
+
                 newX = newX < sb.getMinX() ? sb.getMinX() : newX;
                 newX = newX + dw > sb.getMaxX() ? sb.getMaxX() - dw : newX;
 
                 newY = newY < sb.getMinY() ? sb.getMinY() : newY;
                 newY = newY + dh > sb.getMaxY() ? sb.getMaxY() - dh : newY;
-                        
+
                 dialog.setX(newX);
                 dialog.setY(newY);
+
+                // Force to front
+                forceToFront(dialog);
             }
         });
     }

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -46,10 +46,10 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.image.Image;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser.ExtensionFilter;
-import jfxtras.scene.layout.HBox;
 
 /** Menu entry to open 'about'
  *  @author Kay Kasemir

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -11,27 +11,34 @@ import static org.phoebus.ui.application.PhoebusApplication.logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.framework.preferences.PropertyPreferenceLoader;
 import org.phoebus.framework.preferences.PropertyPreferenceWriter;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.framework.workbench.Locations;
 import org.phoebus.ui.application.Messages;
 import org.phoebus.ui.dialog.DialogHelper;
+import org.phoebus.ui.dialog.OpenFileDialog;
 import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.ReadOnlyTextCell;
 import org.phoebus.ui.spi.MenuEntry;
 
+import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TableCell;
@@ -39,6 +46,10 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.image.Image;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser.ExtensionFilter;
+import jfxtras.scene.layout.HBox;
 
 /** Menu entry to open 'about'
  *  @author Kay Kasemir
@@ -176,9 +187,45 @@ public class OpenAbout implements MenuEntry
 
         area = new TextArea(prefs_buf.toString());
         area.setEditable(false);
-        final Tab prefs = new Tab(Messages.HelpAboutPrefs, area);
+
+        final Button import_prefs = new Button("Import Preferences");
+        import_prefs.setOnAction(event -> import_preferences());
+        final HBox bottom_row = new HBox(import_prefs);
+        bottom_row.setAlignment(Pos.BASELINE_RIGHT);
+
+        VBox.setVgrow(area, Priority.ALWAYS);
+
+        final Tab prefs = new Tab(Messages.HelpAboutPrefs, new VBox(5, area, bottom_row));
 
         final TabPane tabs = new TabPane(apps, props, prefs);
         return tabs;
+    }
+
+    /** Prompt for settings.ini to import, then offer restart */
+    private void import_preferences()
+    {
+        final DockPane parent = DockPane.getActiveDockPane();
+
+        final ExtensionFilter[] ini = new ExtensionFilter[] { new ExtensionFilter("Preference settings.ini", List.of("*.ini")) };
+        final File file = new OpenFileDialog().promptForFile(parent.getScene().getWindow(), Messages.Open, null, ini);
+        if (file == null)
+            return;
+
+        JobManager.schedule("Load preferences", monitor ->
+        {
+            PropertyPreferenceLoader.load(new FileInputStream(file));
+            Platform.runLater(() ->
+            {
+                final Alert restart = new Alert(AlertType.CONFIRMATION);
+                restart.setHeaderText("Restart to activate loaded settings");
+                restart.setContentText("For performance reasons, preference settings are only loaded once on startup.\n" +
+                                       "Exit application so you can then start it again?");
+                restart.getDialogPane().setPrefSize(500, 300);
+                restart.setResizable(true);
+                DialogHelper.positionDialog(restart, parent, -400, -300);
+                if (restart.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK)
+                    System.exit(0);
+            });
+        });
     }
 }

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -28,8 +28,7 @@ FileExists=File \"{0}\" already exists. Do you want to overwite it?
 FixedTitle=Phoebus
 Help=Help
 HelpAbout=About
-HelpAboutAppFea=Application Features\n
-HelpAboutAppUnd=====================\n
+HelpAboutAppFea=Application Features
 HelpAboutColName=Name
 HelpAboutColValue=Value
 HelpAboutHdr=Phoebus Installation Information
@@ -37,8 +36,8 @@ HelpAboutInst=Installation Location
 HelpAboutJava=Java Version
 HelpAboutJfx=JavaFX Version
 HelpAboutMenuPath=Help/About
-HelpAboutSysFea=System Properties\n
-HelpAboutSysUnd==================\n
+HelpAboutPrefs=Preference Settings
+HelpAboutSysFea=System Properties
 HelpAboutTitle=About Phoebus
 HelpAboutUser=User Settings Location
 HelpContentMenuPath=Help/Content


### PR DESCRIPTION
Preferences are meant to be configured by 'experts', i.e. those who set phoebus up for end users.

Still, sometimes it's helpful to be able to see the current values for all preferences in the UI.
==> This adds a "Preference Settings" tab to the Help/About dialog that lists all the current settings.

Finally, in case an end user ever needs to change preferences, especially windows users have a hard time running the launcher with '-settings /path/to/settings.ini'.
==> This adds an "Import Preferences" button to that same location.

Since imported settings are stored in the phoebus.user location, such imported settings remain in effect until user deletes the user location, or imports new settings via UI or `-settings`

![prefs](https://user-images.githubusercontent.com/1932421/63105035-01cbd280-bf4e-11e9-9f3e-e962f0065da1.png)
