### PR TITLE
TimeParser.parseTemporalAmount handles floats

### DIFF
--- a/core/util/src/main/java/org/phoebus/util/time/TimeParser.java
+++ b/core/util/src/main/java/org/phoebus/util/time/TimeParser.java
@@ -193,9 +193,10 @@ public class TimeParser {
             {
                 timeQuantities.put(YEARS, full);
                 if (fraction > 0)
-                    timeQuantities.compute(MONTHS, (u, prev) -> prev == null
-                                                                ? (int) (fraction * 12)
-                                                                : (int) (prev + fraction*12));
+                {
+                    final int next = (int) (fraction * 12);
+                    timeQuantities.compute(MONTHS, (u, prev) -> prev == null ? next : prev + next);
+                }
                 use_period = true;
             }
             else if (unit.startsWith("mo"))

--- a/core/util/src/main/java/org/phoebus/util/time/TimeParser.java
+++ b/core/util/src/main/java/org/phoebus/util/time/TimeParser.java
@@ -41,10 +41,12 @@ public class TimeParser {
     static final Pattern durationTimeQunatityUnitsPattern = Pattern
             .compile("\\s*(\\d*)\\s*(ms|milli|sec|secs|min|mins|hour|hours|day|days)\\s*", Pattern.CASE_INSENSITIVE);
 
+    // SPACE*  (NUMBER?) SPACE*  (UNIT),
+    // with NUMBER being positive floating point
     // Patterns need to be listed longest-first.
     // Otherwise "days" would match just the "d"
     static final Pattern timeQuantityUnitsPattern = Pattern.compile(
-            "\\s*(\\d*)\\s*(millis|ms|seconds|second|secs|sec|s|minutes|minute|mins|min|hours|hour|h|days|day|d|weeks|week|w|months|month|mon|mo|years|year|y)\\s*",
+            "\\s*([0-9]?\\.?[0-9]*)\\s*(millis|ms|seconds|second|secs|sec|s|minutes|minute|mins|min|hours|hour|h|days|day|d|weeks|week|w|months|month|mon|mo|years|year|y)\\s*",
             Pattern.CASE_INSENSITIVE);
 
     /**
@@ -105,7 +107,7 @@ public class TimeParser {
         int quantity = 0;
         String unit = "";
         Matcher timeQunatityUnitsMatcher = durationTimeQunatityUnitsPattern.matcher(string);
-        Map<ChronoUnit, Integer> timeQuantities = new HashMap<ChronoUnit, Integer>();
+        Map<ChronoUnit, Integer> timeQuantities = new HashMap<>();
         while (timeQunatityUnitsMatcher.find()) {
             quantity = "".equals(timeQunatityUnitsMatcher.group(1)) ? 1
                     : Integer.valueOf(timeQunatityUnitsMatcher.group(1));
@@ -170,44 +172,91 @@ public class TimeParser {
     {
         if (NOW.equalsIgnoreCase(string))
             return Duration.ZERO;
-        int quantity = 0;
-        String unit = "";
-        Matcher timeQuantityUnitsMatcher = timeQuantityUnitsPattern.matcher(string);
-        Map<ChronoUnit, Integer> timeQuantities = new HashMap<ChronoUnit, Integer>();
+        final Matcher timeQuantityUnitsMatcher = timeQuantityUnitsPattern.matcher(string);
+        final Map<ChronoUnit, Integer> timeQuantities = new HashMap<>();
 
         boolean use_period = false;
         while (timeQuantityUnitsMatcher.find())
         {
-            quantity = "".equals(timeQuantityUnitsMatcher.group(1))
-                    ? 1
-                    : Integer.valueOf(timeQuantityUnitsMatcher.group(1));
-            unit = timeQuantityUnitsMatcher.group(2).toLowerCase();
+            final double quantity = "".equals(timeQuantityUnitsMatcher.group(1))
+                    ? 1.0
+                    : Double.valueOf(timeQuantityUnitsMatcher.group(1));
+            final int full = (int) quantity;
+            final double fraction = quantity - full;
+            final String unit = timeQuantityUnitsMatcher.group(2).toLowerCase();
+            // Collect the YEARS, .., DAYS, .., MINUTES, .. as used by Period or Duration.
+            // Problem 1: Need to eventually pick either Period or Duration.
+            //            -> We go up to Period when WEEKS or larger are involved.
+            // Problem 2: They only take full amounts.
+            //            -> We place fractional amounts in the next finer unit.
             if (unit.startsWith("y"))
             {
-                timeQuantities.put(YEARS, quantity);
+                timeQuantities.put(YEARS, full);
+                if (fraction > 0)
+                    timeQuantities.compute(MONTHS, (u, prev) -> prev == null
+                                                                ? (int) (fraction * 12)
+                                                                : (int) (prev + fraction*12));
                 use_period = true;
             }
             else if (unit.startsWith("mo"))
             {
-                timeQuantities.put(MONTHS, quantity);
+                timeQuantities.compute(MONTHS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 4*7);
+                    timeQuantities.compute(DAYS,  (u, prev) -> prev == null ? next : prev + next);
+                }
                 use_period = true;
             }
             else if (unit.startsWith("w"))
             {
-                timeQuantities.put(WEEKS, quantity);
+                timeQuantities.compute(WEEKS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 7);
+                    timeQuantities.compute(DAYS, (u, prev) -> prev == null ? next : prev + next);
+                }
                 use_period = true;
             }
             else if (unit.startsWith("mi"))
-                timeQuantities.put(MINUTES, quantity);
+            {
+                timeQuantities.compute(MINUTES, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 60);
+                    timeQuantities.compute(SECONDS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
             else if (unit.startsWith("h"))
-                timeQuantities.put(HOURS, quantity);
+            {
+                timeQuantities.compute(HOURS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 60);
+                    timeQuantities.compute(MINUTES, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
             else if (unit.startsWith("d"))
-                timeQuantities.put(DAYS, quantity);
+            {
+                timeQuantities.compute(DAYS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 24);
+                    timeQuantities.compute(HOURS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
             else if (unit.startsWith("s"))
-                timeQuantities.put(SECONDS, quantity);
+            {
+                timeQuantities.compute(SECONDS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 1000);
+                    timeQuantities.compute(MILLIS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
             else if (unit.startsWith("mi")  ||
                      unit.equals("ms"))
-                timeQuantities.put(MILLIS, quantity);
+                timeQuantities.compute(MILLIS, (u, prev) -> prev == null ? full : prev + full);
         }
 
         if (use_period)

--- a/core/util/src/test/java/org/phoebus/util/time/TimeParserTest.java
+++ b/core/util/src/test/java/org/phoebus/util/time/TimeParserTest.java
@@ -144,12 +144,74 @@ public class TimeParserTest {
         amount = TimeParser.parseTemporalAmount("1 mo");
         assertEquals(amount, Period.of(0, 1, 0));
 
+        // Just the unit name implies "1 xxx"
+        amount = TimeParser.parseTemporalAmount("month");
+        assertEquals(amount, Period.of(0, 1, 0));
+
         // 60 days span more than a month,
         // but since "month" is not mentioned,
         // it's considered 60 exact days
         // (implying 24 hour days)
         amount = TimeParser.parseTemporalAmount("60 days");
         assertEquals(amount, Duration.ofDays(60));
+    }
+
+    @Test
+    public void testParseFactionalTemporalAmount()
+    {
+        // Just having ".0" used to be an error before fractions were supported
+        TemporalAmount amount = TimeParser.parseTemporalAmount("1.000 hour");
+        System.out.println(TimeParser.format(amount));
+        Instant instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(60*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 hour");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((60+30)*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 hour 6.5 minutes");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((60+30+6)*60+30, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("6.5 minutes");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(6*60+30, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("3.5 seconds");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(3, instant.getEpochSecond());
+        assertEquals(500000000, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 days");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((24+12)*60*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        // As soon as the time span enters "weeks", it's handled
+        // as a 'Period' which is only good down to days.
+        // So 1.5 weeks = 7 + 3.5 days is rounded down to 10 days, not 10.5
+        amount = TimeParser.parseTemporalAmount("1.5 weeks");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(0,  0,  10), amount);
+
+        // 1.5 month = 1 month, 2 weeks=14days
+        amount = TimeParser.parseTemporalAmount("1.5 months");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(0,  1,  14), amount);
+
+        // 1.5 years = 1 year, 6 months (not divving up further into days)
+        amount = TimeParser.parseTemporalAmount("1.5 years");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(1,  6,  0), amount);
     }
 
     @Test


### PR DESCRIPTION
@shroffk, this is part of #755 .
`TimeParser.parseTemporalAmount` now handles fractional amounts, i.e. OK to enter "1.5 hours", which turns into 1 hour, 30 minutes. Existing `TimeParserTest` still passes.
Please merge unless you find problems.
Then I'll be able to simplify the data browser code that for now had to patch strings to work around the integer-only limitation in the TimeParser.