### PR TITLE
Unify MenuEntry and ToolbarEntry to both use Callable<Void>

### DIFF
--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserToolbarEntry.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserToolbarEntry.java
@@ -20,9 +20,9 @@ public class FileBrowserToolbarEntry implements ToolbarEntry {
         return ImageCache.getImage(FileBrowserApp.class, "/icons/filebrowser.png");
     }
 
-
     @Override
-    public void call() throws Exception {
+    public Void call() throws Exception {
         ApplicationService.createInstance(FileBrowserApp.Name);
+        return null;
     }
 }

--- a/app/log-configuration/src/main/java/org/phoebus/applications/utility/LoggingConfigurationToolbarEntry.java
+++ b/app/log-configuration/src/main/java/org/phoebus/applications/utility/LoggingConfigurationToolbarEntry.java
@@ -24,7 +24,8 @@ public class LoggingConfigurationToolbarEntry implements ToolbarEntry {
     }
 
     @Override
-    public void call() throws Exception {
+    public Void call() throws Exception {
         ApplicationService.createInstance(LoggingConfigurationApplication.NAME);
+        return null;
     }
 }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ProbeToolbarEntry.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ProbeToolbarEntry.java
@@ -16,8 +16,8 @@ public class ProbeToolbarEntry implements ToolbarEntry {
     }
 
     @Override
-    public void call() throws Exception {
+    public Void call() throws Exception {
         ApplicationService.createInstance(Probe.NAME);
+        return null;
     }
-
 }

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeToolbarEntry.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/PVTreeToolbarEntry.java
@@ -22,8 +22,9 @@ public class PVTreeToolbarEntry implements ToolbarEntry
     }
 
     @Override
-    public void call() throws Exception
+    public Void call() throws Exception
     {
         ApplicationService.createInstance(PVTreeApplication.NAME);
+        return null;
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/spi/ToolbarEntry.java
+++ b/core/ui/src/main/java/org/phoebus/ui/spi/ToolbarEntry.java
@@ -1,14 +1,20 @@
 package org.phoebus.ui.spi;
 
+import java.util.concurrent.Callable;
+
+import org.phoebus.ui.application.ToolbarEntryService;
+
 import javafx.scene.image.Image;
 
 /**
  * An interface describing the contributions to the main toolbar.
  *
+ * <p>Used by the {@link ToolbarEntryService}
+ *
  * @author Kunal Shroff
  *
  */
-public interface ToolbarEntry {
+public interface ToolbarEntry extends Callable<Void> {
 
     /**
      * The name of the toolbar entry
@@ -25,12 +31,4 @@ public interface ToolbarEntry {
     {
         return null;
     }
-
-    /**
-     * Called by the UI framework to invoke the tool bar entry
-     *
-     * @throws Exception on error
-     */
-    public void call() throws Exception;
-
 }


### PR DESCRIPTION
@shroffk, this example would make both MenuEntry and ToolbarEntry use `Callable<Void>`, instead of ToolbarEntry defining its own very similar method.

Downside: Every implementation needs to return a Void, i.e. null.
Upside: Using existing interface.

We could also switch to Runnable instead of Callable<Void>, but I think it's nice for the implementation to allow exceptions which are then logged by the caller.
Having to add 'return null' is a lot simpler than having to catch & log exceptions.