### PR TITLE
Display: Fix freeze when closing display with blank 'write' action PV

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -220,7 +220,7 @@ public class ActionUtil
         }
         catch (final Exception ex)
         {
-            final String message = "Cannot write " + pv_name + " = " + value;
+            final String message = "Cannot write '" + pv_name + "' = " + value;
             logger.log(Level.WARNING, message, ex);
             ScriptUtil.showErrorDialog(source_widget, message + ".\n\nSee log for details.");
         }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/WidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/WidgetRuntime.java
@@ -194,9 +194,11 @@ public class WidgetRuntime<MW extends Widget>
     }
 
     /** Start: Connect to PVs, start scripts
-     *  @throws Exception on error
+     *
+     *  <p>Errors will be logged, but the start will "succeed"
+     *  and in the end count down `started`.
      */
-    public void start() throws Exception
+    public void start()
     {
         // Update "value" property from primary PV, if defined
         final Optional<WidgetProperty<String>> name = widget.checkProperty(propPVName);
@@ -215,10 +217,17 @@ public class WidgetRuntime<MW extends Widget>
                 if (action instanceof WritePVActionInfo)
                 {
                     final String pv_name = ((WritePVActionInfo) action).getPV();
-                    final String expanded = MacroHandler.replace(widget.getMacrosOrProperties(), pv_name);
-                    final RuntimePV pv = PVFactory.getPV(expanded);
-                    action_pvs.add(pv);
-                    addPV(pv, true);
+                    try
+                    {
+                        final String expanded = MacroHandler.replace(widget.getMacrosOrProperties(), pv_name);
+                        final RuntimePV pv = PVFactory.getPV(expanded);
+                        action_pvs.add(pv);
+                        addPV(pv, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.log(Level.WARNING, widget + " cannot start action to write PV '" + pv_name + "'", ex);
+                    }
                 }
             }
             if (action_pvs.size() > 0)

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/ArrayWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/ArrayWidgetRuntime.java
@@ -31,7 +31,7 @@ import org.csstudio.display.builder.runtime.pv.RuntimePV;
 public class ArrayWidgetRuntime extends WidgetRuntime<ArrayWidget>
 {
     private ArrayPVDispatcher dispatcher;
-    private CopyOnWriteArrayList<String> pvnames = new CopyOnWriteArrayList<String>();
+    private CopyOnWriteArrayList<String> pvnames = new CopyOnWriteArrayList<>();
     private String pvid;
 
     private final ArrayPVDispatcher.Listener assign_pv_names = new ArrayPVDispatcher.Listener()
@@ -42,7 +42,7 @@ public class ArrayWidgetRuntime extends WidgetRuntime<ArrayWidget>
             pvnames.clear();
             for (RuntimePV pv : element_pvs)
                 pvnames.add(pv.getName());
-            setPVNames(0, new ArrayList<Widget>(widget.runtimeChildren().getValue()));
+            setPVNames(0, new ArrayList<>(widget.runtimeChildren().getValue()));
         }
     };
 
@@ -81,7 +81,7 @@ public class ArrayWidgetRuntime extends WidgetRuntime<ArrayWidget>
     }
 
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         RuntimePV pv = getPrimaryPV().orElse(null);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/DataBrowserWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/DataBrowserWidgetRuntime.java
@@ -69,14 +69,22 @@ public class DataBrowserWidgetRuntime  extends WidgetRuntime<DataBrowserWidget>
     }
 
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
 
+        // Write selection (VTable) to PV?
         final String pv_name = widget.propSelectionValuePVName().getValue();
-        if (pv_name.length() > 0)
+        if (!pv_name.isBlank())
         {
-            selection_pv = PVPool.getPV(pv_name);
+            try
+            {
+                selection_pv = PVPool.getPV(pv_name);
+            }
+            catch (Exception ex)
+            {
+                logger.log(Level.WARNING, widget + " cannot create selection PV '" + pv_name + "'");
+            }
             listener = (p, o, value) ->
             {
                 try

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/DisplayRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/DisplayRuntime.java
@@ -21,7 +21,7 @@ import org.csstudio.display.builder.runtime.WidgetRuntime;
 public class DisplayRuntime extends WidgetRuntime<DisplayModel>
 {
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         RuntimeUtil.startChildRuntimes(widget.runtimeChildren());

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/EmbeddedDisplayRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/EmbeddedDisplayRuntime.java
@@ -33,11 +33,9 @@ public class EmbeddedDisplayRuntime extends WidgetRuntime<EmbeddedDisplayWidget>
             RuntimeUtil.startRuntime(new_model);
     };
 
-    /** Start: Connect to PVs, ..., then monitor the embedded model to start/stop it
-     *  @throws Exception on error
-     */
+    /** Start: Connect to PVs, ..., then monitor the embedded model to start/stop it */
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         widget.runtimePropEmbeddedModel().addPropertyListener(model_listener);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/GroupWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/GroupWidgetRuntime.java
@@ -20,7 +20,7 @@ import org.csstudio.display.builder.runtime.WidgetRuntime;
 public class GroupWidgetRuntime extends WidgetRuntime<GroupWidget>
 {
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         RuntimeUtil.startChildRuntimes(widget.runtimeChildren());

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/ImageWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/ImageWidgetRuntime.java
@@ -173,7 +173,7 @@ public class ImageWidgetRuntime extends WidgetRuntime<ImageWidget>
     }
 
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/KnobWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/KnobWidgetRuntime.java
@@ -26,12 +26,10 @@ public class KnobWidgetRuntime extends WidgetRuntime<KnobWidget> {
     private final List<PVNameToValueBinding> bindings = new ArrayList<>();
 
     @Override
-    public void start ( ) throws Exception {
-
+    public void start()
+    {
         super.start();
-
         bindings.add(new PVNameToValueBinding(this, widget.propReadbackPVName(), widget.propReadbackPVValue()));
-
     }
 
     @Override

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/NavigationTabsRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/NavigationTabsRuntime.java
@@ -23,11 +23,9 @@ import org.csstudio.display.builder.runtime.WidgetRuntime;
  */
 public class NavigationTabsRuntime extends WidgetRuntime<NavigationTabsWidget>
 {
-    /** Start: Connect to PVs, ..., then monitor the embedded model to start/stop it
-     *  @throws Exception on error
-     */
+    /** Start: Connect to PVs, ..., then monitor the embedded model to start/stop it */
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         widget.runtimePropEmbeddedModel().addPropertyListener(this::embeddedModelChanged);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/TableWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/TableWidgetRuntime.java
@@ -61,7 +61,7 @@ public class TableWidgetRuntime extends WidgetRuntime<TableWidget>
     }
 
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/TabsWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/TabsWidgetRuntime.java
@@ -21,7 +21,7 @@ import org.csstudio.display.builder.runtime.WidgetRuntime;
 public class TabsWidgetRuntime extends WidgetRuntime<TabsWidget>
 {
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
         for (TabItemProperty tab : widget.propTabs().getValue())

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/XYPlotWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/XYPlotWidgetRuntime.java
@@ -66,7 +66,7 @@ public class XYPlotWidgetRuntime  extends WidgetRuntime<XYPlotWidget>
     }
 
     @Override
-    public void start() throws Exception
+    public void start()
     {
         super.start();
 

--- a/core/pv/src/main/java/org/phoebus/pv/PVPool.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PVPool.java
@@ -116,6 +116,8 @@ public class PVPool
      */
     public static PV getPV(final String name) throws Exception
     {
+        if (name.isBlank())
+            throw new Exception("Empty PV name");
         final String[] prefix_base = analyzeName(name);
         final PVFactory factory = factories.get(prefix_base[0]);
         if (factory == null)


### PR DESCRIPTION
Runtime.start() must always succeed, even when some PVs can't start.
Log errors, but finish start() so that we don't get stuck later when
shutting down and awaiting the start() to complete.

Fixes #824