### PR TITLE
Check if folder already exist

### DIFF
--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
@@ -287,7 +287,7 @@ public class AlarmConfigLogger implements Runnable {
     private synchronized void writeAlarmModel() {
         // Output the model to the restore-able scripts folder.
         File node = Paths.get(root.getPath(), ".restore-script").toFile();
-        if (!node.mkdirs()) {
+        if (!node.mkdirs() && !node.exists()) {
             logger.log(Level.WARNING, "Alarm config logging failed to create .restore-script folder");
         }
         File node_info = new File(node, "config.xml");


### PR DESCRIPTION
```
2019-09-17 13:33:40.610  WARN 2415 --- [-StreamThread-1] org.phoebus.applications.alarm           : Alarm config logging failed to create .restore-script folder
2019-09-17 13:33:50.672  INFO 2415 --- [-StreamThread-1] org.phoebus.applications.alarm           : processing message:state:/Accelerator:{"severity":"OK"}
2019-09-17 13:33:50.673  WARN 2415 --- [-StreamThread-1] org.phoebus.applications.alarm           : Alarm config logging failed to create .restore-script folder
```

This Warning is printed in loop, because ".restore-script" directory exist on second pass and "node.mkdirs()" returns false. Maybe check if exists already?