### PR TITLE
Add Gitlab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - build
+
+build:
+  stage: build
+  image: registry.esss.lu.se/ics-docker/maven:openjdk-11
+  tags:
+    - docker
+  script:
+    - mvn --batch-mode -DaltReleaseDeploymentRepository=${RELEASE_REPOSITORY} -DaltSnapshotDeploymentRepository=${SNAPSHOT_REPOSITORY} clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy
+    - mvn --batch-mode sonar:sonar


### PR DESCRIPTION
At ESS we would like to run continuous integration on Phoebus and deploy the binaries to artifactory.esss.lu.se. For this we require the pipeline configuration to be included in the source project.