### PR TITLE
Gitlab pipeline: Reference external pipeline configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,2 @@
-stages:
-  - build
-
-build:
-  stage: build
-  image: registry.esss.lu.se/ics-docker/maven:openjdk-11
-  tags:
-    - docker
-  script:
-    - mvn --batch-mode -DaltReleaseDeploymentRepository=${RELEASE_REPOSITORY} -DaltSnapshotDeploymentRepository=${SNAPSHOT_REPOSITORY} clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy
-    - mvn --batch-mode sonar:sonar
+---
+include: 'https://gitlab.esss.lu.se/ics-software/phoebus-build/raw/master/phoebus.gitlab-ci.yml'


### PR DESCRIPTION
I decided that it's better to keep the pipeline configuration in an ESS Gitlab repo and just reference it from the .gitlab-ci.yml in the Phoebus repo.
This is to avoid further PRs for changes on the Gitlab pipeline.