### PR TITLE
String table: Cancel editing combo when loosing focus

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/StringTable.java
@@ -292,14 +292,28 @@ public class StringTable extends BorderPane
             super.startEdit();
             if (combo == null)
             {
+                // When edited the first time, instrument combo
                 combo = (ComboBox<String>) getGraphic();
                 combo.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKey);
+                combo.focusedProperty().addListener(prop -> handleFocus(combo.isFocused()));
+                // ComboBoxTableCell re-uses the same combo,
+                // so won't add same filters again
             }
 
             // By default, the combo is shown, but not 'active'.
             // requestFocus activates the text field of the combo
             TIMER.schedule(() -> Platform.runLater(() ->  combo.requestFocus()),
                 200, TimeUnit.MILLISECONDS);
+        }
+
+        private void handleFocus(final boolean have_focus)
+        {
+            // By default, loosing the focus,
+            // for example by clicking elsewhere,
+            // would accept the value and activate editing the row below.
+            // Instead, cancel editing.
+            if (! have_focus)
+                super.cancelEdit();
         }
 
         private void handleKey(final KeyEvent event)


### PR DESCRIPTION
Before this fix, when opening the combo box for a cell with options in the last row, then clicking somewhere else, would result in the table accepting that value, starting to edit the next row, i.e. adding a new row, activating the combo box in that row.

Now clicking outside the combo simply cancels the edit.