### PR TITLE
Sniff feature to locate ES cluster nodes

### DIFF
--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -56,6 +56,11 @@
       <version>6.4.2</version>
     </dependency>
     <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+      <version>6.4.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-x-content</artifactId>
       <version>6.4.2</version>

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -50,6 +50,7 @@ public class AlarmLoggingService {
         System.out.println("-topics   Accelerator                    - Alarm topics to be logged, they can be defined as a comma separated list");
         System.out.println("-es_host  localhost                      - elastic server host");
         System.out.println("-es_port  9200                           - elastic server port");
+        System.out.println("-es_sniff  false                         - elastic server sniff feature");
         System.out.println("-bootstrap.servers localhost:9092        - Kafka server address");
         System.out.println("-properties /opt/alarm_logger.propertier - Properties file to be used (instead of command line arguments)");
         System.out.println("-date_span_units M                       - Date units for the time based index to span.");
@@ -127,6 +128,12 @@ public class AlarmLoggingService {
                         throw new Exception("Missing -es_port port number");
                     iter.remove();
                     properties.put("es_port",iter.next());
+                    iter.remove();
+                } else if (cmd.equals("-es_sniff")) {
+                    if (!iter.hasNext())
+                        throw new Exception("Missing -es_sniff sniff feature true/false");
+                    iter.remove();
+                    properties.put("es_sniff",iter.next());
                     iter.remove();
                 } else if (cmd.equals("-bootstrap.servers")) {
                     if (!iter.hasNext())

--- a/services/alarm-logger/src/main/resources/alarm_logging_service.properties
+++ b/services/alarm-logger/src/main/resources/alarm_logging_service.properties
@@ -6,6 +6,8 @@ es_host=localhost
 es_port=9200
 # max default size for es queries
 es_max_size=1000
+# set to 'true' if sniffing to be enabled to discover other cluster nodes
+es_sniff=false
 
 # Kafka server location
 bootstrap.servers=localhost:9092


### PR DESCRIPTION
This pull request is for enabling the ES sniff feature for alarm logger when an elasticsearch cluster is used. Sniff feature is used for loadbalancing and failovers within the ES cluster. This is an optional feature which can be set using param 'es_sniff' from alarm_logger properties file.