### PR TITLE
Fix inconsistent poms

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -49,13 +49,14 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/kafka-streams-2.0.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/commons-codec-1.10.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/commons-logging-1.1.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-cli-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-core-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-high-level-client-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-secure-sm-6.3.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-x-content-6.3.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-cli-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-core-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-sniffer-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-high-level-client-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-secure-sm-6.4.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-x-content-6.4.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/HdrHistogram-2.1.9.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/hppc-0.7.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/httpasyncclient-4.1.2.jar"/>
@@ -123,32 +124,32 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2-win.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2-win.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2-win.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2-win.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2-win.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2-win.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2-win.jar"/>
 	-->
 	<!-- On Linux, need to add this:
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2-linux.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
-        <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2-linux.jar"/>
 	-->
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -253,7 +253,12 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-high-level-client</artifactId>
-      <version>6.3.1</version>
+      <version>6.4.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+      <version>6.4.2</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.jfxtras/jfxtras-controls -->
     <dependency>


### PR DESCRIPTION
@tanviash, the recent addition of the 'sniff' feature to the alarm logger, #864, broke my build.

We might need to better document this, for example by elaborating in the readme, but I thought when @shroffk  and I started the phoebus development one goal was to have a well defined and 100% known target platform. This goal was driven by the Eclipse RCP build issues where every manifest might have a need-package or require-bundle statement for arbitrary versions, and after adding tycho to the mix you no longer know what you'll get, and build errors became very hard to fix.

For phoebus the idea was, OK, some of us want to use Maven, but we put all the dependencies into dependencies/phoebus-target/pom.xml. Running `mvn clean verify  -f dependencies/pom.xml` fetches them into the lib/ folder. Alternatively, one could get a zipped-up copy of that lib folder. In any case, that's the target platform that one can use with ant, Eclipse, ...

OK to use maven for builing the rest as well, but the other pom.xml must only list dependencies that are already mentioned in the dependencies/phoebus-target/pom.xml, not introduce new/different onces. So the rest of the maven build won't have to download anything.

Well, dependencies/phoebus-target/pom.xml listed this for elastic:

    <dependency>
      <groupId>org.elasticsearch.client</groupId>
      <artifactId>elasticsearch-rest-high-level-client</artifactId>
      <version>6.3.1</version>
    </dependency>

Meanwhile, services/alarm-logger/pom.xml lists a different version:

    <dependency>
      <groupId>org.elasticsearch.client</groupId>
      <artifactId>elasticsearch-rest-high-level-client</artifactId>
      <version>6.4.2</version>
    </dependency>

.. and adds a new dependency:

    <dependency>
      <groupId>org.elasticsearch.client</groupId>
      <artifactId>elasticsearch-rest-client-sniffer</artifactId>
      <version>6.4.2</version>
    </dependency>

The ant-based build or the Eclipse .classpath files that use the content from the target platform thus fail.

This PR adds all the elastic dependencies used by the logger to the target platform.