### PR TITLE
PVA: Handle segmented messages

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -3,17 +3,20 @@ PVA Client and Server
 
 PV Access client and server for Java, based on the 
 [PV Access Protocol Description](https://github.com/epics-base/pvAccessCPP/wiki/protocol),
-consulting the [Reference Implementation](https://github.com/epics-base/epicsCoreJava)
+consulting the
+[Reference Implementation](https://github.com/epics-base/epicsCoreJava)
 to clarify details.
-Purpose is to better understand the protocol
-and to implement it in pure Java, using concurrent classes
-from the standard library and taking advantage of for example
-functional interfaces because compatibility to the C++ implementation
-is not required.
+
+Original motivation was understanding the protocol and implementing it based on the standard Java library,
+taking advantage of for example functional interfaces and concurrency classes,
+instead of requiring API compatibility to the C++ implementation.
+
 Implementation is focused on the requirements of clients like CS-Studio,
 covering the majority of PV Access features but not all of them.
 Also includes a PVA Server implementation, which was mostly created
 to again better understand the protocol and to allow closed-loop tests.
+
+Network compatibility with all other PVA servers and clients is desired.
 
 Prerequisites
 -------------
@@ -116,6 +119,7 @@ PVA Client:
  * Put: Init, get structure, update field, write, destroy
  * RPC: Send request structure, get response structure
  * Decode data sent by IOC and 'image' demo
+ * Handle 'segmented' messages
  * Close (destroy) channel
  * Close client
  * Info/get/monitor/put command line tool

--- a/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
+++ b/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
@@ -39,6 +39,7 @@ public class PVAHeader
     public static final byte FLAG_CONTROL    = 1;
 
     /** Segmented message? Else: Single */
+    public static final byte FLAG_SEGMENT_MASK  = 3 << 4;
     public static final byte FLAG_FIRST      = 1 << 4;
     public static final byte FLAG_LAST       = 2 << 4;
     public static final byte FLAG_MIDDLE     = 3 << 4;
@@ -163,7 +164,7 @@ public class PVAHeader
 
         final byte magic = buffer.get(0);
         if (magic != PVAHeader.PVA_MAGIC)
-            throw new Exception("Message lacks magic");
+            throw new Exception(String.format("Message lacks magic 0x%02X, got 0x%02X", PVAHeader.PVA_MAGIC, magic));
 
         final byte version = buffer.get(1);
         if (version < PVAHeader.REQUIRED_PVA_PROTOCOL_REVISION)

--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -66,6 +66,12 @@ abstract public class TCPHandler
     /** Buffer used to receive data via {@link TCPHandler#receive_thread} */
     protected ByteBuffer receive_buffer = ByteBuffer.allocate(PVASettings.EPICS_PVA_RECEIVE_BUFFER_SIZE);
 
+    /** Buffer for assembling parts of segmented message
+     *
+     *  <p>Created and then grown as needed
+     */
+    private ByteBuffer segments = null;
+
     /** Buffer used to send data via {@link TCPHandler#send_thread} */
     protected final ByteBuffer send_buffer = ByteBuffer.allocate(PVASettings.EPICS_PVA_SEND_BUFFER_SIZE);
 
@@ -366,12 +372,6 @@ abstract public class TCPHandler
         }
     }
 
-    /** Buffer for assembling parts of segmented message
-     *
-     *  <p>Created and then grown as needed
-     */
-    private ByteBuffer segments = null;
-
     /** Handle a segmented message
      *
      *  <p>Assembles parts of a segmented message,
@@ -383,6 +383,10 @@ abstract public class TCPHandler
      */
     private void handleSegmentedMessage(final byte segmented, final ByteBuffer buffer) throws Exception
     {
+        // This implementation does copy data from the original receive buffer
+        // into the 'segmented' buffer where they are combined.
+        // Original Java implementation also copied received bytes,
+        // albeit within the same socketBuffer.
         if (segmented == PVAHeader.FLAG_FIRST)
         {
             if (segments == null)

--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -254,7 +254,7 @@ abstract public class TCPHandler
                 int message_size = PVAHeader.checkMessageAndGetSize(receive_buffer, client_mode);
                 while (receive_buffer.position() < message_size)
                 {
-                    checkReceiveBufferSize(message_size);
+                    receive_buffer = assertBufferSize(receive_buffer, message_size);
                     final int read = socket.read(receive_buffer);
                     if (read < 0)
                     {
@@ -312,25 +312,30 @@ abstract public class TCPHandler
         // NOP
     }
 
-    /** Check receive buffer size, grow if needed
+    /** Check buffer size, grow if needed
+     *
+     *  <p>When necessary, a new buffer is allocated,
+     *  existing data copied.
+     *
+     *  @param buffer Original buffer
      *  @param message_size Required receive buffer size
+     *  @return Original buffer, or larger buffer with copied data
      */
-    private void checkReceiveBufferSize(final int message_size)
+    private ByteBuffer assertBufferSize(final ByteBuffer buffer, final int size)
     {
-        if (receive_buffer.capacity() >= message_size)
-            return;
+        if (buffer.capacity() >= size)
+            return buffer;
 
-        final ByteBuffer new_buffer = ByteBuffer.allocate(message_size);
-        new_buffer.order(receive_buffer.order());
-        receive_buffer.flip();
-        new_buffer.put(receive_buffer);
+        final ByteBuffer new_buffer = ByteBuffer.allocate(size);
+        new_buffer.order(buffer.order());
+        buffer.flip();
+        new_buffer.put(buffer);
 
         logger.log(Level.INFO,
-                   Thread.currentThread().getName() + " extends receive buffer from " +
-                   receive_buffer.capacity() + " to " + new_buffer.capacity() +
+                   Thread.currentThread().getName() + " extends buffer from " +
+                   buffer.capacity() + " to " + new_buffer.capacity() +
                    ", copied " + new_buffer.position() + " bytes to new buffer");
-
-        receive_buffer = new_buffer;
+        return new_buffer;
     }
 
     /** Handle a received message
@@ -342,16 +347,104 @@ abstract public class TCPHandler
      *  @param buffer Buffer positioned at start of header
      *  @throws Exception on error
      */
-    protected void handleMessage(final ByteBuffer buffer) throws Exception
+    private void handleMessage(final ByteBuffer buffer) throws Exception
     {
-        final boolean control = (buffer.get(2) & PVAHeader.FLAG_CONTROL) != 0;
-        final byte command = buffer.get(3);
-        // Move to start of potential payload
-        buffer.position(8);
-        if (control)
-            handleControlMessage(command, buffer);
+        final byte flags = buffer.get(2);
+        final byte segemented = (byte) (flags & PVAHeader.FLAG_SEGMENT_MASK);
+        if (segemented != 0)
+            handleSegmentedMessage(segemented, buffer);
         else
-            handleApplicationMessage(command, buffer);
+        {
+            final boolean control = (flags & PVAHeader.FLAG_CONTROL) != 0;
+            final byte command = buffer.get(3);
+            // Move to start of potential payload
+            buffer.position(8);
+            if (control)
+                handleControlMessage(command, buffer);
+            else
+                handleApplicationMessage(command, buffer);
+        }
+    }
+
+    private ByteBuffer segments = null;
+
+    private void handleSegmentedMessage(final byte segemented, final ByteBuffer buffer) throws Exception
+    {
+        if (segemented == PVAHeader.FLAG_FIRST)
+        {
+            if (segments == null)
+            {
+                logger.log(Level.INFO,
+                           () -> Thread.currentThread().getName() + " allocates segmented message accumulator buffer for " + buffer.limit() + " bytes");
+                segments = ByteBuffer.allocate(buffer.limit());
+                segments.order(buffer.order());
+            }
+            else if (segments.position() > 0)
+                throw new Exception("Received first message segment while still handling previous one");
+
+            segments = assertBufferSize(segments, buffer.limit());
+            segments.put(buffer);
+            // Clear the 'segmented' flags in the accumulator buffer
+            segments.put(2, (byte) (buffer.get(2) & 0b11001111));
+
+            if (logger.isLoggable(Level.FINER))
+            {
+                final int pos = segments.position();
+                segments.flip();
+                logger.log(Level.FINER, "First message segment:\n" + Hexdump.toHexdump(segments));
+                segments.position(pos);
+            }
+        }
+        else
+        {
+            final boolean last = segemented == PVAHeader.FLAG_LAST;
+
+            if (segments == null  ||  segments.position() <= 0)
+                throw new Exception("Received " + (last ? "last" : "middle") + " message segment without first segment");
+            // Check if command matches the one in first segment
+            final byte seg_command = segments.get(3);
+            if (seg_command != buffer.get(3))
+                throw new Exception(String.format("Received " + (last ? "last" : "middle") +
+                                                  " message segment for command 0x%02X after first segment for command 0x%02X",
+                                                  buffer.get(3), seg_command));
+
+            // Size of segments accumulated so far..
+            final int seg_size = segments.getInt(PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE);
+            // Payload of segment to add
+            final int payload = buffer.getInt(PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE);
+            final int total = seg_size + payload;
+            segments = assertBufferSize(segments, PVAHeader.HEADER_SIZE + total);
+            // Skip header, add payload to segments
+            buffer.position(PVAHeader.HEADER_SIZE);
+            segments.put(buffer);
+            // Update total size
+            segments.putInt(PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE, total);
+
+            if (logger.isLoggable(Level.FINER))
+            {
+                final int pos = segments.position();
+                segments.flip();
+                logger.log(Level.FINER, (last ? "Last" : "Middle") + " message segment:\n" + Hexdump.toHexdump(segments));
+                segments.position(pos);
+            }
+
+            if (last)
+            {
+                try
+                {
+                    segments.flip();
+                    handleMessage(segments);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception("Error handling assembled segmented message", ex);
+                }
+                finally
+                {
+                    segments.clear();
+                }
+            }
+        }
     }
 
     /** Handle a received control message

--- a/core/pva/src/main/java/org/epics/pva/data/Hexdump.java
+++ b/core/pva/src/main/java/org/epics/pva/data/Hexdump.java
@@ -143,7 +143,6 @@ public class Hexdump
                 }
             }
         }
-        buffer.rewind();
     }
 
     /** @param bytes Any bytes

--- a/core/pva/src/main/java/org/epics/pva/data/PVAByteArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAByteArray.java
@@ -103,8 +103,7 @@ public class PVAByteArray extends PVAData implements PVAArray
         byte[] new_value = value;
         if (new_value == null  ||  new_value.length != size)
             new_value = new byte[size];
-        for (int i=0; i<size; ++i)
-            new_value[i] = buffer.get();
+        buffer.get(new_value);
         value = new_value;
     }
 

--- a/core/pva/src/main/java/org/epics/pva/data/PVAUnion.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAUnion.java
@@ -183,6 +183,11 @@ public class PVAUnion extends PVADataWithID
     public void decode(final PVATypeRegistry types, final ByteBuffer buffer) throws Exception
     {
         selected = PVASize.decodeSize(buffer);
+        if (selected < 0)
+        {   // -1 (we're treating any negative number like that) selects no value
+            logger.log(Level.FINER, () -> "Union element selector is " + selected + ", no value");
+            return;
+        }
         if (selected < 0  ||  selected >= elements.size())
             throw new Exception("Invalid union selector " + selected + " for " + formatType());
         final PVAData element = elements.get(selected);
@@ -244,7 +249,11 @@ public class PVAUnion extends PVADataWithID
             buffer.append(union_name).append(" ");
         buffer.append(name);
         if (selected < 0)
-            buffer.append("\n - nothing selected -\n");
+        {
+            buffer.append("\n");
+            indent(level+1, buffer);
+            buffer.append("- nothing selected -");
+        }
         else
         {
             buffer.append("\n");

--- a/core/pva/src/test/java/org/epics/pva/client/ImageDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ImageDemo.java
@@ -8,7 +8,9 @@
 package org.epics.pva.client;
 
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.epics.pva.PVASettings;
 import org.epics.pva.data.PVAByteArray;
@@ -38,7 +40,7 @@ import org.junit.Test;
 public class ImageDemo
 {
     // "IMAGE" for ntndarrayServer, "13SIM1:Pva1:Image" for Area Detector
-    private static final String PV_NAME = "13SIM1:Pva1:Image";
+    private static final String PV_NAME = "IMAGE"; // "13SIM1:Pva1:Image";
 
     static
     {
@@ -50,6 +52,8 @@ public class ImageDemo
         {
             ex.printStackTrace();
         }
+        final Logger root = Logger.getLogger("");
+        root.setLevel(Level.INFO);
     }
 
     @Test
@@ -63,8 +67,8 @@ public class ImageDemo
         final PVAChannel ch = pva.getChannel(PV_NAME, channel_listener);
         ch.connect().get(5, TimeUnit.SECONDS);
 
-        // Read value
-        System.out.println(ch.read("").get());
+        // Read value, show type (value could be too large)
+        System.out.println(ch.read("").get().formatType());
 
         // Monitor updates
         final MonitorListener monitor_listener = (channel, changed, overruns, data) ->


### PR DESCRIPTION
While looking into #869, the memory usage of CAJ when monitoring area detector images, checked PVA and found that PVA client needs to handle segmented messages as the image size grows.
Also fixing errors when pva:// image is empty.