### PR TITLE
Probe handling of large arrays

### DIFF
--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -281,8 +281,9 @@ public class ProbeController {
     private void updateValueUI()
     {
         final FormattedValue fmt = update_value.getAndSet(null);
-        if (fmt.text.length() > 100)
-            txtValue.setText(fmt.text.substring(0, 100) + "...");
+        // Hard limit for amount of text to show for value
+        if (fmt.text.length() > 2000)
+            txtValue.setText(fmt.text.substring(0, 2000) + "...");
         else
             txtValue.setText(fmt.text);
         setTime(Time.timeOf(fmt.value));

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Oak Ridge National Laboratory.
+ * Copyright (c) 2013-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,8 @@ import java.util.regex.Pattern;
 @SuppressWarnings("nls")
 public class PVNameFilter
 {
-    final private static Pattern number = Pattern.compile("^-?[0-9]+.*");
+    // Number, optional exponent
+    final private static Pattern number = Pattern.compile("^-?[0-9]+[+.0-9eE-]+");
 
     /** @param pvname Possible PV name as received from a link
      *  @return <code>true</code> if it looks like a valid PV name

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/VTypeHelper.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/VTypeHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,17 +7,12 @@
  ******************************************************************************/
 package org.phoebus.applications.pvtree.model;
 
-import java.nio.charset.Charset;
-import java.text.NumberFormat;
-
-import org.epics.util.array.ListNumber;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.VByteArray;
-import org.epics.vtype.VEnum;
-import org.epics.vtype.VNumber;
-import org.epics.vtype.VString;
 import org.epics.vtype.VType;
+import org.phoebus.ui.vtype.FormatOption;
+import org.phoebus.ui.vtype.FormatOptionHandler;
 
 /** Helper for {@link VType} gymnastics
  *  @author Kay Kasemir
@@ -25,79 +20,12 @@ import org.epics.vtype.VType;
 @SuppressWarnings("nls")
 public class VTypeHelper
 {
-    /** [85, 84, 70, 45, 56] */
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     public static AlarmSeverity getSeverity(final VType value)
     {
         final Alarm alarm = Alarm.alarmOf(value);
         if (alarm == null)
             return AlarmSeverity.UNDEFINED;
         return alarm.getSeverity();
-    }
-
-    public static void appendValue(final StringBuilder buf, final VType value)
-    {
-        if (value == null)
-            buf.append("null");
-        else if (value instanceof VNumber)
-        {
-            final VNumber number = (VNumber) value;
-
-            final NumberFormat format = number.getDisplay().getFormat();
-            if (format == null)
-                buf.append(number.getValue());
-            else
-                buf.append(format.format(number.getValue()));
-
-            final String units = number.getDisplay().getUnit();
-            if (units != null  &&  !units.isEmpty())
-                buf.append(" ").append(units);
-        }
-        else if (value instanceof VString)
-        {
-            final VString text = (VString) value;
-            try
-            {
-                buf.append(text.getValue());
-            }
-            catch (NullPointerException ex)
-            {
-                buf.append("'null'");
-            }
-        }
-        else if (value instanceof VByteArray)
-        {
-            final ListNumber data = ((VByteArray) value).getData();
-            final byte[] bytes = new byte[data.size()];
-            // Copy bytes until end or '\0'
-            int len = 0;
-            while (len < bytes.length)
-            {
-                final byte b = data.getByte(len);
-                if (b == 0)
-                    break;
-                else
-                    bytes[len++] = b;
-            }
-            // Use actual 'len', not data.size()
-            buf.append(new String(bytes, 0, len, UTF8));
-        }
-        else if (value instanceof VEnum)
-        {
-            final VEnum item = (VEnum) value;
-            try
-            {
-                buf.append(item.getValue()).append(" ");
-            }
-            catch (ArrayIndexOutOfBoundsException ex)
-            {
-                // PVManager doesn't handle enums that have no label. Ignore
-            }
-            buf.append("(").append(item.getIndex()).append(")");
-        }
-        else
-            buf.append(value.toString());
     }
 
     public static void appendAlarm(final StringBuilder buf, final VType value)
@@ -113,15 +41,17 @@ public class VTypeHelper
 
     public static String formatValue(final VType value)
     {
-        final StringBuilder buf = new StringBuilder();
-        appendValue(buf, value);
-        return buf.toString();
+        if (value instanceof VByteArray)
+            return FormatOptionHandler.format(value, FormatOption.STRING, -1, true);
+        else
+            return FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true);
     }
 
     public static String format(final VType value)
     {
         final StringBuilder buf = new StringBuilder();
-        appendValue(buf, value);
+        buf.append(formatValue(value));
+
         // If there is no value, suppress the alarm.
         // TODO Check note in PVTreeItem#updateLinks():
         // If a link is empty, the record could still be in alarm.

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -77,6 +77,9 @@ public class PVASettings
      */
     public static int EPICS_CA_CONN_TMO = 30;
 
+    /** Maximum number of array elements shown when printing data */
+    public static int EPICS_PVA_MAX_ARRAY_FORMATTING = 256;
+
     static
     {
         EPICS_PVA_ADDR_LIST = set("EPICS_PVA_ADDR_LIST", EPICS_PVA_ADDR_LIST);
@@ -84,6 +87,7 @@ public class PVASettings
         EPICS_PVA_SERVER_PORT = set("EPICS_PVA_SERVER_PORT", EPICS_PVA_SERVER_PORT);
         EPICS_PVA_BROADCAST_PORT = set("EPICS_PVA_BROADCAST_PORT", EPICS_PVA_BROADCAST_PORT);
         EPICS_CA_CONN_TMO = set("EPICS_CA_CONN_TMO", EPICS_CA_CONN_TMO);
+        EPICS_PVA_MAX_ARRAY_FORMATTING = set("EPICS_PVA_MAX_ARRAY_FORMATTING", EPICS_PVA_MAX_ARRAY_FORMATTING);
         EPICS_PVA_SEND_BUFFER_SIZE = set("EPICS_PVA_SEND_BUFFER_SIZE", EPICS_PVA_SEND_BUFFER_SIZE);
     }
 

--- a/core/pva/src/main/java/org/epics/pva/data/PVABoolArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVABoolArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -138,12 +140,15 @@ public class PVABoolArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
                 buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVAByteArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAByteArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -150,7 +152,8 @@ public class PVAByteArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
@@ -159,6 +162,8 @@ public class PVAByteArray extends PVAData implements PVAArray
                 else
                     buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVADoubleArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVADoubleArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -141,12 +143,15 @@ public class PVADoubleArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
                 buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVAFloatArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAFloatArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -141,12 +143,15 @@ public class PVAFloatArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
                 buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVAIntArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAIntArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -151,7 +153,8 @@ public class PVAIntArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
@@ -160,6 +163,8 @@ public class PVAIntArray extends PVAData implements PVAArray
                 else
                     buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVALongArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVALongArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -151,7 +153,8 @@ public class PVALongArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
@@ -160,6 +163,8 @@ public class PVALongArray extends PVAData implements PVAArray
                 else
                     buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVAShortArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAShortArray.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -157,7 +159,8 @@ public class PVAShortArray extends PVAData implements PVAArray
             buffer.append("null");
         else
         {
-            for (int i=0; i<safe.length; ++i)
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
             {
                 if (i > 0)
                     buffer.append(", ");
@@ -166,6 +169,8 @@ public class PVAShortArray extends PVAData implements PVAArray
                 else
                     buffer.append(safe[i]);
             }
+            if (safe.length > show)
+                buffer.append(", ...");
         }
         buffer.append("]");
     }

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
@@ -13,6 +13,8 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 
+import org.epics.pva.PVASettings;
+
 /** 'Primitive' PV Access data type
  *   @author Kay Kasemir
  */
@@ -133,7 +135,22 @@ public class PVAStringArray extends PVAData implements PVAArray
     protected void format(final int level, final StringBuilder buffer)
     {
         formatType(level, buffer);
-        buffer.append(" ").append(Arrays.toString(value));
+        final String[] safe = value;
+        if (safe == null)
+            buffer.append("null");
+        else
+        {
+            final int show = Math.min(PVASettings.EPICS_PVA_MAX_ARRAY_FORMATTING, safe.length);
+            for (int i=0; i<show; ++i)
+            {
+                if (i > 0)
+                    buffer.append(", ");
+                buffer.append(safe[i]);
+            }
+            if (safe.length > show)
+                buffer.append(", ...");
+        }
+        buffer.append("]");
     }
 
     @Override

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -26,6 +26,7 @@ public class Preferences
     public static final String top_resources;
     public static final boolean splash;
     public static final String welcome;
+    public static final int max_array_formatting;
     public static final int ui_monitor_period;
     public static final String[] hide_spi_menu;
     public static final boolean status_show_user;
@@ -38,6 +39,7 @@ public class Preferences
         top_resources = prefs.get(TOP_RESOURCES);
         splash = prefs.getBoolean(SPLASH);
         welcome = prefs.get("welcome");
+        max_array_formatting = prefs.getInt("max_array_formatting");
         ui_monitor_period = prefs.getInt("ui_monitor_period");
         hide_spi_menu = prefs.get("hide_spi_menu").split("\\s*,\\s*");
         status_show_user = prefs.getBoolean("status_show_user");

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -43,5 +43,10 @@ public class Preferences
         ui_monitor_period = prefs.getInt("ui_monitor_period");
         hide_spi_menu = prefs.get("hide_spi_menu").split("\\s*,\\s*");
         status_show_user = prefs.getBoolean("status_show_user");
+
+        // In case PVA library is included, sync its array formatting
+        // (PVASettings cannot use Preferences.max_array_formatting
+        //  since the PVA library may be used standalone)
+        System.setProperty("EPICS_PVA_MAX_ARRAY_FORMATTING", Integer.toString(max_array_formatting));
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -30,6 +30,7 @@ import org.epics.vtype.VStringArray;
 import org.epics.vtype.VTable;
 import org.epics.vtype.VType;
 import org.phoebus.pv.LongString;
+import org.phoebus.ui.Preferences;
 
 /** Utility for formatting data as string.
  *  @author Kay Kasemir
@@ -111,11 +112,14 @@ public class FormatOptionHandler
                 return "[]";
             final StringBuilder buf = new StringBuilder("[");
             buf.append(formatNumber(data.getDouble(0), array.getDisplay(), option, precision));
-            for (int i=1; i<data.size(); ++i)
+            final int show = Math.min(data.size(), Preferences.max_array_formatting);
+            for (int i=1; i<show; ++i)
             {
                 buf.append(", ");
                 buf.append(formatNumber(data.getDouble(i), array.getDisplay(), option, precision));
             }
+            if (data.size() > show)
+                buf.append(", ...");
             buf.append("]");
             if (show_units  &&  !array.getDisplay().getUnit().isEmpty())
                 buf.append(" ").append(array.getDisplay().getUnit());

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -42,6 +42,9 @@ top_resources=examples:/01_main.bob?app=display_runtime,Example Display | pv://?
 # Home display file. "Home display" button will navigate to this display.
 home_display=examples:/01_main.bob?app=display_runtime,Example Display
 
+# How many array elements to show when formatting as text?
+max_array_formatting=256
+
 # UI Responsiveness Monitor Period
 # Period between tests [millisec],
 # i.e. the minimum detected UI freeze duration


### PR DESCRIPTION
Fixes #869:

Probe ran out of memory when displaying the array value of an image.
Simply formatting the array as a string takes time, and requests to update the UI queued up.

Fix:
 * Probe caches the last value and only schedules a UI update unless that's already pending
 * Format the value string off the UI thread
 * New preference to limit the number of displayed array elements when formatting array as string

While checking PVTree for similar issue, found it's already protected, but treats area detector PV like '13SIM1:cam1:..' as constant, so fixed that.