### PR TITLE
File browser: Use "path" instead of "base"

### DIFF
--- a/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
+++ b/app/filebrowser/src/main/resources/org/phoebus/applications/filebrowser/messages.properties
@@ -1,6 +1,6 @@
-BaseDirectorySelTT=Select a base directory
-BaseDirectoryTT=Enter a base directory
-BrowserRootTitle=Select Browser Root
+BaseDirectorySelTT=Select a File Browser path
+BaseDirectoryTT=Enter File Browser path
+BrowserRootTitle=Select File Browser Path
 CopyPathClp=Copy Path to Clipboard
 CreateDirectoryErr=Cannot create new folder 
 CreateDirectoryHdr=Enter name for new folder under 
@@ -41,4 +41,4 @@ Refresh=Refresh
 Rename=Rename
 RenameHdr=Enter new name:
 RenameJobName=Rename 
-SetBaseDirectory=Set as Base Directory
+SetBaseDirectory=Set as File Browser Path


### PR DESCRIPTION
Recently had a 30 minute discussion at beamline because users saw "base directory" mentioned in file browser, and assumed that for example selecting "/some/path/Experiment124" as the "base" directory in the file browser would automatically activate tasks related to that experiment, like select devices which are used for that experiment.

Linux (gnome) file browser uses "path" for the corresponding section at the top, so trying that. 