### PR TITLE
Csstudio 1143

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
+++ b/core/framework/src/main/java/org/phoebus/framework/util/ResourceParser.java
@@ -209,7 +209,7 @@ public class ResourceParser
     {
         final int idx = item.indexOf("=");
         final String key = idx > 0 ? item.substring(0, idx) : item;
-        final String value = idx > 0 && item.length() > idx + 1 ? item.substring(idx + 1) : null;
+        final String value = idx > 0 && item.length() > idx + 1 ? item.substring(idx + 1) : "";
         return new SimpleImmutableEntry<String, String>(decode(key), decode(value));
     }
 

--- a/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/util/ResourceParserTest.java
@@ -194,7 +194,7 @@ public class ResourceParserTest
 
         List<String> values = items.get("Fred");
         assertThat(values.size(), equalTo(1));
-        assertThat(values.get(0), nullValue());
+        assertThat(values.get(0), equalTo(""));
 
         values = items.get("Y");
         assertThat(values.size(), equalTo(1));


### PR DESCRIPTION
This is a fix to allow a zero-length string as a macro value. This is possible in BOY, so suggestion is to  align in Display Builder.