### PR TITLE
ArrayWidgetProp: Check if both element and value use macros ...

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -218,10 +218,14 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
             for (int i=0; i<N; ++i)
             {
                 final WPE element = getElement(i);
-                if (element instanceof MacroizedWidgetProperty<?>)
-                    ((MacroizedWidgetProperty<?>)element).setSpecification(((MacroizedWidgetProperty<?>) iter.next()).getSpecification());
+                final Object el_value = iter.next();
+                if (element  instanceof MacroizedWidgetProperty<?>  &&
+                    el_value instanceof MacroizedWidgetProperty<?>)
+                {
+                    ((MacroizedWidgetProperty<?>)element).setSpecification(((MacroizedWidgetProperty<?>) el_value).getSpecification());
+                }
                 else
-                    element.setValueFromObject(iter.next());
+                    element.setValueFromObject(el_value);
             }
 
             // Notify listeners of the whole array


### PR DESCRIPTION
.. when trying to set 'spec' instead of value.

Original symptom was in import of legacy *.opi with byte monitor widget and labels.
Setting the new labels property to a `List<String>` failed because it assumed a `List<StringWidgetProperty>`. Now handling both.