### PR TITLE
ES sniff feature for logging-ui

### DIFF
--- a/app/alarm/logging-ui/pom.xml
+++ b/app/alarm/logging-ui/pom.xml
@@ -16,7 +16,12 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-high-level-client</artifactId>
-      <version>6.3.1</version>
+      <version>6.4.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+      <version>6.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableApp.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableApp.java
@@ -77,7 +77,9 @@ public class AlarmLogTableApp implements AppResourceDescriptor {
     public void stop() {
         if (client != null) {
             try {
-                sniffer.close();
+                if (sniffer != null) {
+                    sniffer.close();
+                }
                 client.close();
             } catch (IOException e) {
                 logger.log(Level.WARNING, "Failed to properly close the elastic rest client", e);

--- a/app/alarm/logging-ui/src/main/resources/alarm_logging_preferences.properties
+++ b/app/alarm/logging-ui/src/main/resources/alarm_logging_preferences.properties
@@ -7,3 +7,4 @@ es_host=130.199.219.152
 es_port=9200
 es_index=accelerator_alarms
 es_max_size=1000
+es_sniff=false


### PR DESCRIPTION
The change is similar to the one I made on alarm logger side. This is to enable ES sniff feature for logging-ui client so it can retrieve data from other cluster ES nodes in case of failover.