### PR TITLE
Slider: Preference to select behavior

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.representation.javafx;
+
+import org.phoebus.framework.preferences.PreferencesReader;
+
+/** Preference settings
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class JFXPreferences
+{
+    public static boolean inc_dec_slider;
+
+    static
+    {
+        final PreferencesReader prefs = new PreferencesReader(JFXPreferences.class, "/jfx_repr_preferences.properties");
+        inc_dec_slider = prefs.getBoolean("inc_dec_slider");
+    }
+}

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -19,6 +19,7 @@ import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ScaledSliderWidget;
+import org.csstudio.display.builder.representation.javafx.JFXPreferences;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.Display;
 import org.epics.vtype.VType;
@@ -69,8 +70,16 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
     private volatile boolean active = false;
     private volatile boolean enabled = false;
 
-    private final Slider slider = new TrackClickSlider();
-    private final SliderMarkers markers = new SliderMarkers(slider);
+    private final Slider slider;
+    private final SliderMarkers markers;
+
+    public ScaledSliderRepresentation()
+    {
+        slider = JFXPreferences.inc_dec_slider
+               ? new TrackClickSlider()
+               : new Slider();
+       markers = new SliderMarkers(slider);
+    }
 
     @Override
     protected GridPane createJFXNode() throws Exception

--- a/app/display/representation-javafx/src/main/resources/jfx_repr_preferences.properties
+++ b/app/display/representation-javafx/src/main/resources/jfx_repr_preferences.properties
@@ -1,0 +1,9 @@
+# ----------------------------------------------------------
+# Package org.csstudio.display.builder.representation.javafx
+# ----------------------------------------------------------
+
+# When clicking on the 'slider' widget 'track',
+# should the value increment/decrement,
+# matching the behavior of EDM, BOY, ...?
+# Otherwise, jump to the clicked value right away. 
+inc_dec_slider=true


### PR DESCRIPTION
The inc/dec behavior that's compatible with EDM, BOY is the default, because it avoids large value jumps from accidental clicks on the slider, for example to activate it for keyboard tweaks.
Jump-to-clicked-value is available via a preference setting for sites which prefer that behavior.