### PR TITLE
PV Tree: Detect "13SIM:cam1:.." as PV but still take "13" as constant

### DIFF
--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 public class PVNameFilter
 {
     // Number, optional exponent
-    final private static Pattern number = Pattern.compile("^-?[0-9]+[+.0-9eE-]+");
+    final private static Pattern number = Pattern.compile("^-?[0-9]+[+.0-9eE-]*$");
 
     /** @param pvname Possible PV name as received from a link
      *  @return <code>true</code> if it looks like a valid PV name

--- a/app/pvtree/src/test/java/org/phoebus/applications/pvtree/PVNameFilterTest.java
+++ b/app/pvtree/src/test/java/org/phoebus/applications/pvtree/PVNameFilterTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.applications.pvtree;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.phoebus.applications.pvtree.model.PVNameFilter;
+
+/** {@link PVNameFilter} test
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVNameFilterTest
+{
+    @Test
+    public void testPVNames()
+    {
+        // 'Normal' PV
+        assertTrue(PVNameFilter.isPvName("SomePV"));
+        assertTrue(PVNameFilter.isPvName("SomePV:WithNumber2"));
+
+        // Starts with number, as used by AreaDetector
+        assertTrue(PVNameFilter.isPvName("13SIM:cam1:whatever42"));
+
+        // 'Hardware' links
+        assertFalse(PVNameFilter.isPvName("@plc2"));
+        assertFalse(PVNameFilter.isPvName("#2 S3"));
+    }
+
+    @Test
+    public void testConstants()
+    {
+        // Numbers
+        assertFalse(PVNameFilter.isPvName("2"));
+        assertFalse(PVNameFilter.isPvName("3.14"));
+        assertFalse(PVNameFilter.isPvName("1.9E-31"));
+    }
+}


### PR DESCRIPTION
#883 added support for area detector PVs like "13SIM:.." that start with a number, but that fix then caused actual numbers to no longer be recognized as constants.
Fixed, and adding test.