### PR TITLE
Scripts: Access to display's dock item

### DIFF
--- a/app/display/model/src/main/resources/examples/script_util/close_other_tabs.py
+++ b/app/display/model/src/main/resources/examples/script_util/close_other_tabs.py
@@ -1,0 +1,26 @@
+# Close all other tabs within the same pane
+#
+# Can be attached to a display, triggered by "loc://init(0)"
+# to run when display is opened.
+#
+# Example for obtaining the DisplayRuntimeInstance and DockItem
+# of a display to then interact with them
+
+from java.lang import Runnable
+from javafx.application import Platform
+from org.csstudio.display.builder.runtime.app import DisplayRuntimeInstance
+
+display = widget.getTopDisplayModel()
+
+# Interactions with UI must run on the UI thread
+class CloseOther(Runnable):
+    def run(self):
+        # Get DockItem for this display
+        this_item = DisplayRuntimeInstance.ofDisplayModel(display).getDockItem()
+        # Close all _other_ items (tabs) within this pane
+        for item in this_item.getDockPane().getDockItems():
+            if item != this_item:
+                print "CLOSE " + str(item)
+                item.close()
+
+Platform.runLater(CloseOther())

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -11,12 +11,14 @@ import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.macros.DisplayMacroExpander;
 import org.csstudio.display.builder.model.persist.ModelLoader;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
@@ -84,6 +86,16 @@ public class DisplayRuntimeInstance implements AppInstance
     /** Toolbar button for navigation */
     private ButtonBase navigate_backward, navigate_forward;
 
+    /** Obtain the DisplayRuntimeInstance of a display
+     *  @param model {@link DisplayModel}
+     *  @return {@link DisplayRuntimeInstance}
+     */
+    public static DisplayRuntimeInstance ofDisplayModel(final DisplayModel model)
+    {
+        final Parent model_parent = Objects.requireNonNull(model.getUserData(Widget.USER_DATA_TOOLKIT_PARENT));
+        return (DisplayRuntimeInstance) model_parent.getProperties().get(DisplayRuntimeInstance.MODEL_PARENT_DISPLAY_RUNTIME);
+    }
+
     DisplayRuntimeInstance(final AppDescriptor app)
     {
         this.app = app;
@@ -134,7 +146,7 @@ public class DisplayRuntimeInstance implements AppInstance
     }
 
     /** @return DockItem in which this display is contained */
-    DockItem getDockItem()
+    public DockItem getDockItem()
     {
         return dock_item;
     }


### PR DESCRIPTION
Simplify access to a display's DisplayRuntimeInstance and DockItem.
Allows implementing specialized cases where for example an opened display needs to close all other dock items (tabs) within a pane.

#896
