### PR TITLE
JavaFX 13.0.1

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -120,36 +120,36 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/spring-webmvc-5.0.9.RELEASE.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/hibernate-validator-6.0.12.Final.jar"/>
 	<!-- On Windows, need to add this:
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2-win.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1-win.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1-win.jar"/>
 	-->
 	<!-- On Linux, need to add this:
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-12.0.2-linux.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-12.0.2-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1-linux.jar"/>
 	-->
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <epics.version>7.0.4</epics.version>
     <vtype.version>1.0.1</vtype.version>
-    <openjfx.version>12.0.2</openjfx.version>
+    <openjfx.version>13.0.1</openjfx.version>
     <!--<maven.repo.local>${project.build.directory}/.m2</maven.repo.local>-->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Updates JavaFX libraries to the current one, 13.0.1.

Requires JDK 11 or later, i.e. no change from JFX 12.

Big news: On Linux, this fixes the GTK3 drag-and-drop problems, #367, where tabs could not be moved, widgets not be dragged in the display editor, unless one ran with `-Djdk.gtk.version=2`.
Now both GTK2 and GTK3 seem to support drag & drop.
https://bugs.openjdk.java.net/browse/JDK-8211302

Otherwise found no API changes, everything still compiles.

https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-13.md
 

