### PR TITLE
PVAClient: Start with CID 2, clarify CID vs. SID

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -165,9 +165,9 @@ class ChannelSearch
      */
     public void register(final PVAChannel channel, final boolean now)
     {
-        logger.log(Level.FINE, () -> "Register search for " + channel.getName() + " " + channel.getId());
+        logger.log(Level.FINE, () -> "Register search for " + channel.getName() + " " + channel.getCID());
         channel.setState(ClientChannelState.SEARCHING);
-        searched_channels.computeIfAbsent(channel.getId(), id -> new SearchedChannel(channel));
+        searched_channels.computeIfAbsent(channel.getCID(), id -> new SearchedChannel(channel));
         // Issue immediate search request?
         if (now)
             search(channel);
@@ -254,7 +254,7 @@ class ChannelSearch
         {
             final int payload_start = send_buffer.position() + PVAHeader.HEADER_SIZE;
             final int seq = search_sequence.incrementAndGet();
-            SearchRequest.encode(true, seq, channel.getId(), channel.getName(), udp.getResponseAddress(), send_buffer);
+            SearchRequest.encode(true, seq, channel.getCID(), channel.getName(), udp.getResponseAddress(), send_buffer);
             send_buffer.flip();
             logger.log(Level.FINE, "Search Request #" + seq + " for " + channel);
             sendSearch(payload_start);

--- a/core/pva/src/main/java/org/epics/pva/client/CreateChannelRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/CreateChannelRequest.java
@@ -34,7 +34,7 @@ class CreateChannelRequest implements RequestEncoder
         PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_CREATE_CHANNEL, 2+4+PVAString.getEncodedSize(channel.getName()));
         // Not using PVASize, and only '1' is supported
         buffer.putShort((short)1);
-        buffer.putInt(channel.getId());
+        buffer.putInt(channel.getCID());
         PVAString.encodeString(channel.getName(), buffer);
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/client/DestroyChannelRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/DestroyChannelRequest.java
@@ -33,7 +33,7 @@ class DestroyChannelRequest implements RequestEncoder
         PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_DESTROY_CHANNEL, 4+4);
         // Protocol description claims CID followed by SID,
         // but as of May 2019 both the C++ and Java server expect SID, CID
-        buffer.putInt(channel.sid);
-        buffer.putInt(channel.getId());
+        buffer.putInt(channel.getSID());
+        buffer.putInt(channel.getCID());
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
@@ -74,7 +74,7 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_GET, 4+4+1+6);
             final int payload_start = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
@@ -89,7 +89,7 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
         {
             logger.log(Level.FINE, () -> "Sending get GET request #" + request_id + " for " + channel);
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_GET, 4+4+1);
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_DESTROY);
         }

--- a/core/pva/src/main/java/org/epics/pva/client/GetTypeRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetTypeRequest.java
@@ -62,7 +62,7 @@ class GetTypeRequest extends CompletableFuture<PVAStructure> implements RequestE
         logger.log(Level.FINE, () -> "Sending Get-Type request #" + request_id + " for " + channel + ", sub field '" + subfield + "'");
 
         PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_GET_TYPE, 4+4+PVAString.getEncodedSize(subfield));
-        buffer.putInt(channel.sid);
+        buffer.putInt(channel.getSID());
         buffer.putInt(request_id);
         PVAString.encodeString(subfield, buffer);
     }

--- a/core/pva/src/main/java/org/epics/pva/client/MonitorRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/MonitorRequest.java
@@ -88,7 +88,7 @@ class MonitorRequest implements AutoCloseable, RequestEncoder, ResponseHandler
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_MONITOR, 4+4+1+6);
             final int payload_start = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
 
             if (pipeline > 0)
@@ -110,7 +110,7 @@ class MonitorRequest implements AutoCloseable, RequestEncoder, ResponseHandler
             final int ack = received_updates.getAndSet(0);
             logger.log(Level.FINE, () -> "Sending monitor pipeline ack of " + ack + " updates, request #" + request_id + " for " + channel);
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_MONITOR, 4+4+1+4);
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_PIPELINE);
             buffer.putInt(ack);
@@ -126,7 +126,7 @@ class MonitorRequest implements AutoCloseable, RequestEncoder, ResponseHandler
             else
                 throw new Exception("Cannot handle monitor state " + state);
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_MONITOR, 4+4+1);
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(state);
         }

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -42,13 +42,20 @@ import org.epics.pva.data.PVAStructure;
 @SuppressWarnings("nls")
 public class PVAChannel
 {
-    private static final AtomicInteger IDs = new AtomicInteger();
+    /** Provider for the 'next' client channel ID
+     *
+     *  <p>Starts at 1, i.e. the first channel will use CID 2.
+     *  Since the server tends to start at 1, this makes it
+     *  more obvious in tests which ID is the SID
+     *  and which is the CID.
+     */
+    private static final AtomicInteger CID_Provider = new AtomicInteger(1);
 
     private final PVAClient client;
     private final String name;
     private final ClientChannelListener listener;
-    private final int id = IDs.incrementAndGet();
-    int sid = -1;
+    private final int cid = CID_Provider.incrementAndGet();
+    private volatile int sid = -1;
 
     /** State
      *
@@ -83,10 +90,17 @@ public class PVAChannel
     }
 
     /** @return Client channel ID */
-    int getId()
+    int getCID()
     {
-        return id;
+        return cid;
     }
+
+    /** @return Server channel ID */
+    int getSID()
+    {
+        return sid;
+    }
+
 
     /** @return Channel name */
     public String getName()
@@ -302,7 +316,7 @@ public class PVAChannel
     public void close()
     {
         // In case channel is still being searched, stop
-        client.search.unregister(getId());
+        client.search.unregister(getCID());
 
         // Indicate that channel is closing
         final ClientChannelState old_state = setState(ClientChannelState.CLOSING);
@@ -329,6 +343,6 @@ public class PVAChannel
     @Override
     public String toString()
     {
-        return "'" + name + "' [CID " + id + ", SID " + sid + " " + state.get() + "]";
+        return "'" + name + "' [CID " + cid + ", SID " + sid + " " + state.get() + "]";
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -135,7 +135,7 @@ public class PVAClient
     public PVAChannel getChannel(final String channel_name, final ClientChannelListener listener)
     {
         final PVAChannel channel = new PVAChannel(this, channel_name, listener);
-        channels_by_id.putIfAbsent(channel.getId(), channel);
+        channels_by_id.putIfAbsent(channel.getCID(), channel);
         search.register(channel, true);
         return channel;
     }
@@ -159,7 +159,7 @@ public class PVAClient
      */
     void forgetChannel(final PVAChannel channel)
     {
-        channels_by_id.remove(channel.getId());
+        channels_by_id.remove(channel.getCID());
 
         // Did channel have a connection?
         final ClientTCPHandler tcp = channel.tcp.get();

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -77,7 +77,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_PUT, 4+4+1+6);
             final int payload_start = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
@@ -96,7 +96,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_PUT, 4+4+1+1);
             final int pos = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_DESTROY);
 

--- a/core/pva/src/main/java/org/epics/pva/client/RPCRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/RPCRequest.java
@@ -74,7 +74,7 @@ class RPCRequest extends CompletableFuture<PVAStructure> implements RequestEncod
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_RPC, 4+4+1+2);
             final int payload_start = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
@@ -99,7 +99,7 @@ class RPCRequest extends CompletableFuture<PVAStructure> implements RequestEncod
             final int size_offset = buffer.position() + PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE;
             PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_RPC, 4+4+1);
             final int payload_start = buffer.position();
-            buffer.putInt(channel.sid);
+            buffer.putInt(channel.getSID());
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_DESTROY);
 


### PR DESCRIPTION
When debugging server/client communication, both server and client starting with ID 1 means you can't tell which one is the server and which is the client ID.

By client starting at 2, this is easier to tell apart.

Inside code, call client's ID 'CID' instead of just ID.