### PR TITLE
Add 'app-errlog' to the product .classpath

### DIFF
--- a/phoebus-product/.classpath
+++ b/phoebus-product/.classpath
@@ -38,6 +38,7 @@
     <classpathentry combineaccessrules="false" kind="src" path="/app-rtplot"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-pvtable"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-email"/>
+    <classpathentry combineaccessrules="false" kind="src" path="/app-errlog"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-log-configuration"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-pvtree"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-probe"/>


### PR DESCRIPTION
.. so it's by default included when starting the product in Eclipse