### PR TITLE
ContextMenuEntry: Cleanup, document

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuNodeAlarmHistory.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuNodeAlarmHistory.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTable;
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTableApp;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
-import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.workbench.ApplicationService;
@@ -21,14 +20,14 @@ import javafx.scene.image.Image;
  * A headless context menu entry for creating log entries from adaptable
  * selections. TODO this temporary headless action needs to removed once the
  * create log entry dialog is complete.
- * 
+ *
  * @author Tanvi Ashwarya
  *
  */
 @SuppressWarnings("rawtypes")
 public class ContextMenuNodeAlarmHistory implements ContextMenuEntry {
 
-    private static final List<Class> supportedTypes = List.of(AlarmTreeItem.class);
+    private static final List<Class<?>> supportedTypes = List.of(AlarmTreeItem.class);
     private static final String NAME = "Alarm History";
 
     @Override
@@ -38,21 +37,19 @@ public class ContextMenuNodeAlarmHistory implements ContextMenuEntry {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object callWithSelection(Selection selection) throws URISyntaxException {
+    public void callWithSelection(Selection selection) throws URISyntaxException {
 
-        List<AlarmTreeItem> selectedNodes = new ArrayList<AlarmTreeItem>();
+        List<AlarmTreeItem> selectedNodes = new ArrayList<>();
         selection.getSelections().stream().forEach(s -> {
             AdapterService.adapt(s, AlarmTreeItem.class).ifPresent(selectedNodes::add);
         });
         AlarmLogTable table = ApplicationService.createInstance(AlarmLogTableApp.NAME);
         URI uri = new URI(AlarmLogTableApp.SUPPORTED_SCHEMA, "", "", "node="+selectedNodes.stream().map(AlarmTreeItem::getName).collect(Collectors.joining(",")), "");
         table.setNodeResource(uri);
-        
-        return null;
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
 

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuPVAlarmHistory.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuPVAlarmHistory.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTable;
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTableApp;
-import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.selection.Selection;
@@ -21,14 +20,13 @@ import javafx.scene.image.Image;
  * A headless context menu entry for creating log entries from adaptable
  * selections. TODO this temporary headless action needs to removed once the
  * create log entry dialog is complete.
- * 
+ *
  * @author Kunal Shroff
  *
  */
-@SuppressWarnings("rawtypes")
 public class ContextMenuPVAlarmHistory implements ContextMenuEntry {
 
-    private static final List<Class> supportedTypes = List.of(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
     private static final String NAME = "Alarm History";
 
     @Override
@@ -38,21 +36,19 @@ public class ContextMenuPVAlarmHistory implements ContextMenuEntry {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object callWithSelection(Selection selection) throws URISyntaxException {
+    public void callWithSelection(Selection selection) throws URISyntaxException {
 
-        List<ProcessVariable> selectedPvs = new ArrayList<ProcessVariable>();
+        List<ProcessVariable> selectedPvs = new ArrayList<>();
         selection.getSelections().stream().forEach(s -> {
             AdapterService.adapt(s, ProcessVariable.class).ifPresent(selectedPvs::add);
         });
         AlarmLogTable table = ApplicationService.createInstance(AlarmLogTableApp.NAME);
         URI uri = new URI(AlarmLogTableApp.SUPPORTED_SCHEMA, "", "", "pv="+selectedPvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(",")), "");
         table.setPVResource(uri);
-        
-        return null;
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ContextMenuDataBrowserLauncher.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ContextMenuDataBrowserLauncher.java
@@ -21,10 +21,10 @@ import javafx.scene.image.Image;
 /** Entry for context menus that starts Data Browser for selected ProcessVariable
  *  @author Kay Kasemir
  */
-@SuppressWarnings({ "rawtypes", "nls" })
-public class ContextMenuDataBrowserLauncher implements ContextMenuEntry<ProcessVariable>
+@SuppressWarnings("nls")
+public class ContextMenuDataBrowserLauncher implements ContextMenuEntry
 {
-    private static final List<Class> supportedTypes = List.of(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
 
     @Override
     public String getName()
@@ -39,13 +39,13 @@ public class ContextMenuDataBrowserLauncher implements ContextMenuEntry<ProcessV
     }
 
     @Override
-    public List<Class> getSupportedTypes()
+    public List<Class<?>> getSupportedTypes()
     {
         return supportedTypes;
     }
 
     @Override
-    public ProcessVariable callWithSelection(final Selection selection) throws Exception
+    public void callWithSelection(final Selection selection) throws Exception
     {
         final DataBrowserInstance instance = ApplicationService.createInstance(DataBrowserApp.NAME);
         final List<ProcessVariable> pvs = selection.getSelections();
@@ -58,6 +58,5 @@ public class ContextMenuDataBrowserLauncher implements ContextMenuEntry<ProcessV
                 item.useDefaultArchiveDataSources();
             instance.getModel().addItem(item);
         }
-        return null;
     }
 }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ProbeDisplayContextMenuEntry.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ProbeDisplayContextMenuEntry.java
@@ -30,9 +30,9 @@ import javafx.scene.image.Image;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ProbeDisplayContextMenuEntry implements ContextMenuEntry<Void>
+public class ProbeDisplayContextMenuEntry implements ContextMenuEntry
 {
-    private static final List<Class> types;
+    private static final List<Class<?>> types;
 
     static
     {
@@ -49,7 +49,7 @@ public class ProbeDisplayContextMenuEntry implements ContextMenuEntry<Void>
     }
 
     @Override
-    public List<Class> getSupportedTypes()
+    public List<Class<?>> getSupportedTypes()
     {
         return types;
     }
@@ -61,7 +61,7 @@ public class ProbeDisplayContextMenuEntry implements ContextMenuEntry<Void>
     }
 
     @Override
-    public Void callWithSelection(final Selection selection) throws Exception
+    public void callWithSelection(final Selection selection) throws Exception
     {
         final List<ProcessVariable> pvs = selection.getSelections();
         for (ProcessVariable pv : pvs)
@@ -74,6 +74,5 @@ public class ProbeDisplayContextMenuEntry implements ContextMenuEntry<Void>
                 resource = URI.create(Preferences.probe_display + "?PV=" + pv.getName());
             ApplicationService.createInstance(DisplayRuntimeApplication.NAME, resource);
         }
-        return null;
     }
 }

--- a/app/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
+++ b/app/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
@@ -16,7 +16,7 @@ import org.phoebus.ui.spi.ContextMenuEntry;
  */
 public class ContextCreateEmail implements ContextMenuEntry {
 
-    private static final List<Class> supportedTypes = Arrays.asList(String.class);
+    private static final List<Class<?>> supportedTypes = Arrays.asList(String.class);
 
     @Override
     public String getName() {
@@ -24,14 +24,12 @@ public class ContextCreateEmail implements ContextMenuEntry {
     }
 
     @Override
-    public Object callWithSelection(Selection selection) {
+    public void callWithSelection(Selection selection) {
         ApplicationService.createInstance(EmailApp.NAME);
-        return null;
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
-
 }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/ContextMenuLogging.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/ContextMenuLogging.java
@@ -12,7 +12,7 @@ import org.phoebus.ui.spi.ContextMenuEntry;
 
 /**
  * A headless context menu entry for creating log entries from adaptable selections.
- * TODO this temporary headless action needs to removed once the create log entry dialog is complete. 
+ * TODO this temporary headless action needs to removed once the create log entry dialog is complete.
  * @author Kunal Shroff
  *
  */
@@ -20,7 +20,7 @@ import org.phoebus.ui.spi.ContextMenuEntry;
 public class ContextMenuLogging implements ContextMenuEntry {
 
     private static final String NAME = "Create Log";
-    private static final List<Class> supportedTypes = Arrays.asList(LogEntry.class);
+    private static final List<Class<?>> supportedTypes = Arrays.asList(LogEntry.class);
 
     @Override
     public String getName() {
@@ -29,20 +29,19 @@ public class ContextMenuLogging implements ContextMenuEntry {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object callWithSelection(Selection selection) {
+    public void callWithSelection(Selection selection) {
 
-        List<LogEntry> adaptedSelections = new ArrayList<LogEntry>();
+        List<LogEntry> adaptedSelections = new ArrayList<>();
         selection.getSelections().stream().forEach(s -> {
             AdapterService.adapt(s, LogEntry.class).ifPresent(adapted -> {
-                adaptedSelections.add((LogEntry) adapted);
+                adaptedSelections.add(adapted);
             });
         });
         LogService.getInstance().createLogEntry(adaptedSelections, null);
-        return null;
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
 

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
@@ -17,10 +17,10 @@ import javafx.scene.image.Image;
  * @author Kunal Shroff
  *
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings("nls")
 public class ContextLaunchProbe implements ContextMenuEntry {
 
-    private static final List<Class> supportedTypes = Arrays.asList(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = Arrays.asList(ProcessVariable.class);
 
     @Override
     public String getName() {
@@ -34,10 +34,9 @@ public class ContextLaunchProbe implements ContextMenuEntry {
     }
 
     @Override
-    public Object callWithSelection(Selection selection) {
+    public void callWithSelection(Selection selection) {
         List<ProcessVariable> pvs = selection.getSelections();
         LaunchProbe(pvs);
-        return null;
     }
 
     private void LaunchProbe(List<ProcessVariable> pvs) {
@@ -54,7 +53,7 @@ public class ContextLaunchProbe implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
 

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
@@ -27,10 +27,10 @@ import javafx.scene.input.ClipboardContent;
 /** Context menu entry for PV that copies PV name to clipboard
  *  @author Kay Kasemir
  */
-@SuppressWarnings({ "rawtypes", "nls" })
-public class ContextMenuPvToClipboard implements ContextMenuEntry<ProcessVariable>
+@SuppressWarnings("nls")
+public class ContextMenuPvToClipboard implements ContextMenuEntry
 {
-    private static final List<Class> supportedTypes = Arrays.asList(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = Arrays.asList(ProcessVariable.class);
 
     private static final Image icon = ImageCache.getImage(ImageCache.class, "/icons/copy.png");
 
@@ -47,14 +47,13 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry<ProcessVariabl
     }
 
     @Override
-    public List<Class> getSupportedTypes()
+    public List<Class<?>> getSupportedTypes()
     {
         return supportedTypes;
     }
 
     @Override
-    public ProcessVariable callWithSelection(final Selection selection)
-            throws Exception
+    public void callWithSelection(final Selection selection) throws Exception
     {
         final List<ProcessVariable> pvs = selection.getSelections();
 
@@ -62,7 +61,5 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry<ProcessVariabl
         final ClipboardContent content = new ClipboardContent();
         content.putString(pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(" ")));
         clipboard.setContent(content);
-        return null;
     }
-
 }

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
@@ -20,10 +20,10 @@ import javafx.scene.image.Image;
 /** Entry for context menus that starts PV Table for selected ProcessVariable
  *  @author Kay Kasemir
  */
-@SuppressWarnings({ "rawtypes", "nls" })
-public class ContextMenuPVTableLauncher implements ContextMenuEntry<ProcessVariable>
+@SuppressWarnings("nls")
+public class ContextMenuPVTableLauncher implements ContextMenuEntry
 {
-    private static final List<Class> supportedTypes = List.of(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
 
     static final Image icon = ImageCache.getImage(PVTableApplication.class, "/icons/pvtable.png");
 
@@ -40,18 +40,17 @@ public class ContextMenuPVTableLauncher implements ContextMenuEntry<ProcessVaria
     }
 
     @Override
-    public List<Class> getSupportedTypes()
+    public List<Class<?>> getSupportedTypes()
     {
         return supportedTypes;
     }
 
     @Override
-    public ProcessVariable callWithSelection(final Selection selection) throws Exception
+    public void callWithSelection(final Selection selection) throws Exception
     {
         final PVTableInstance instance = ApplicationService.createInstance(PVTableApplication.NAME);
         final List<ProcessVariable> pvs = selection.getSelections();
         for (ProcessVariable pv : pvs)
             instance.getModel().addItem(pv.getName());
-        return null;
     }
 }

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
@@ -21,10 +21,10 @@ import javafx.scene.image.Image;
  *
  *  @author Kay Kasemir
  */
-@SuppressWarnings({ "nls", "rawtypes" })
-public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariable>
+@SuppressWarnings("nls")
+public class ContextMenuPVTreeLauncher implements ContextMenuEntry
 {
-    private static final List<Class> supportedTypes = List.of(ProcessVariable.class);
+    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
 
     private static final Image icon = ImageCache.getImage(ContextMenuPVTreeLauncher.class, "/icons/pvtree.png");
 
@@ -41,13 +41,13 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariab
     }
 
     @Override
-    public List<Class> getSupportedTypes()
+    public List<Class<?>> getSupportedTypes()
     {
         return supportedTypes;
     }
 
     @Override
-    public ProcessVariable callWithSelection(final Selection selection) throws Exception
+    public void callWithSelection(final Selection selection) throws Exception
     {
         final List<ProcessVariable> pvs = selection.getSelections();
         for (ProcessVariable pv : pvs)
@@ -55,7 +55,5 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry<ProcessVariab
             final PVTree tree = ApplicationService.createInstance(PVTreeApplication.NAME);
             tree.setPVName(pv.getName());
         }
-
-        return null;
     }
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/actions/contextMenuLogging.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/actions/contextMenuLogging.java
@@ -7,22 +7,20 @@ import java.util.List;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.logbook.LogEntry;
-import org.phoebus.logbook.LogService;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
 /**
  * A headless context menu entry for creating log entries from adaptable
  * selections. TODO this temporary headless action needs to removed once the
  * create log entry dialog is complete.
- * 
+ *
  * @author Kunal Shroff
  *
  */
-@SuppressWarnings("rawtypes")
 public class contextMenuLogging implements ContextMenuEntry {
 
     private static final String NAME = "Create Log";
-    private static final List<Class> supportedTypes = Arrays.asList(LogEntry.class);
+    private static final List<Class<?>> supportedTypes = Arrays.asList(LogEntry.class);
 
     @Override
     public String getName() {
@@ -31,21 +29,20 @@ public class contextMenuLogging implements ContextMenuEntry {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object callWithSelection(Selection selection) {
+    public void callWithSelection(Selection selection) {
 
-        List<LogEntry> adaptedSelections = new ArrayList<LogEntry>();
+        List<LogEntry> adaptedSelections = new ArrayList<>();
         selection.getSelections().stream().forEach(s -> {
             AdapterService.adapt(s, LogEntry.class).ifPresent(adapted -> {
-                adaptedSelections.add((LogEntry) adapted);
+                adaptedSelections.add(adapted);
             });
         });
         // TODO open the create log entry dialog
         // LogService.getInstance().createLogEntry(adaptedSelections, null);
-        return null;
     }
 
     @Override
-    public List<Class> getSupportedTypes() {
+    public List<Class<?>> getSupportedTypes() {
         return supportedTypes;
     }
 

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -57,8 +57,8 @@ public class ContextMenuHelper
         final List<ContextMenuEntry> entries = ContextMenuService.getInstance().listSupportedContextMenuEntries();
         if (entries.isEmpty())
             return false;
-        
-        for (ContextMenuEntry<?> entry : entries)
+
+        for (ContextMenuEntry entry : entries)
         {
             final MenuItem item = new MenuItem(entry.getName());
 
@@ -78,7 +78,7 @@ public class ContextMenuHelper
             });
             menu.getItems().add(item);
         }
-        
+
         return true;
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/spi/ContextMenuEntry.java
+++ b/core/ui/src/main/java/org/phoebus/ui/spi/ContextMenuEntry.java
@@ -3,17 +3,24 @@ package org.phoebus.ui.spi;
 import java.util.List;
 
 import org.phoebus.framework.selection.Selection;
+import org.phoebus.ui.application.ContextMenuHelper;
 
 import javafx.scene.image.Image;
 
 /**
  * Context menu entry service interface
  *
- * @author Kunal Shroff
- * @param <V>
+ * <p>Applications can use this to register context menu
+ * entries that are applicable to certain types found
+ * in the current selection.
  *
+ * <p>Applications with context menus to their UI
+ * should use the {@link ContextMenuHelper} to add
+ * SPI-provided additions to the menu.
+ *
+ * @author Kunal Shroff
  */
-public interface ContextMenuEntry<V> {
+public interface ContextMenuEntry {
 
     /**
      * The display name of the context menu entry
@@ -39,14 +46,13 @@ public interface ContextMenuEntry<V> {
     /**
      * @return Selection types for which this entry should be displayed
      */
-    public List<Class> getSupportedTypes();
+    public List<Class<?>> getSupportedTypes();
 
     /**
      * Invoke the context menu
      *
-     * @param (TODO replace with the use of selectionService.getCurrentSelection(); ) selection Current selection
-     * @return (TODO What does it return?? )
+     * @param selection Current selection
      * @throws Exception on error
      */
-    public V callWithSelection(Selection selection) throws Exception;
+    public void callWithSelection(Selection selection) throws Exception;
 }


### PR DESCRIPTION
Removes the unused `<V>` type parameter.
Adds `Class<?>` to avoid `rawtypes` warning.
Documents how to contribute and how to use context menu entries.

#917