### PR TITLE
Use ${jackson.version} 2.10.1

### DIFF
--- a/app/alarm/model/pom.xml
+++ b/app/alarm/model/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.4</version>
+        <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/app/channel/channelfinder/pom.xml
+++ b/app/channel/channelfinder/pom.xml
@@ -16,19 +16,19 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
         <groupId>com.sun.jersey</groupId>

--- a/app/logbook/olog-es/pom.xml
+++ b/app/logbook/olog-es/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.8.10</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
@@ -43,18 +43,18 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/app/logbook/olog-es/src/main/java/org/phoebus/olog/es/api/OlogClient.java
+++ b/app/logbook/olog-es/src/main/java/org/phoebus/olog/es/api/OlogClient.java
@@ -55,19 +55,19 @@ import com.sun.jersey.core.util.MultivaluedMapImpl;
 import com.sun.jersey.multipart.impl.MultiPartWriter;
 
 /**
- * 
- * 
+ *
+ *
  * @author Eric Berryman taken from shroffk
- * 
+ *
  */
 public class OlogClient implements LogClient {
     private final WebResource service;
 
     /**
      * Builder Class to help create a olog client.
-     * 
+     *
      * @author shroffk
-     * 
+     *
      */
     public static class OlogClientBuilder {
         // required
@@ -101,7 +101,7 @@ public class OlogClient implements LogClient {
         /**
          * Creates a {@link OlogClientBuilder} for a CF client to Default URL in the
          * channelfinder.properties.
-         * 
+         *
          * @return
          */
         public static OlogClientBuilder serviceURL() {
@@ -110,7 +110,7 @@ public class OlogClient implements LogClient {
 
         /**
          * Creates a {@link OlogClientBuilder} for a CF client to URI <tt>uri</tt>.
-         * 
+         *
          * @param uri
          * @return {@link OlogClientBuilder}
          */
@@ -121,7 +121,7 @@ public class OlogClient implements LogClient {
         /**
          * Creates a {@link OlogClientBuilder} for a CF client to {@link URI}
          * <tt>uri</tt>.
-         * 
+         *
          * @param uri
          * @return {@link OlogClientBuilder}
          */
@@ -131,7 +131,7 @@ public class OlogClient implements LogClient {
 
         /**
          * Enable of Disable the HTTP authentication on the client connection.
-         * 
+         *
          * @param withHTTPAuthentication
          * @return {@link OlogClientBuilder}
          */
@@ -142,7 +142,7 @@ public class OlogClient implements LogClient {
 
         /**
          * Set the username to be used for HTTP Authentication.
-         * 
+         *
          * @param username
          * @return {@link OlogClientBuilder}
          */
@@ -153,7 +153,7 @@ public class OlogClient implements LogClient {
 
         /**
          * Set the password to be used for the HTTP Authentication.
-         * 
+         *
          * @param password
          * @return {@link OlogClientBuilder}
          */
@@ -165,7 +165,7 @@ public class OlogClient implements LogClient {
         /**
          * set the {@link ClientConfig} to be used while creating the channelfinder
          * client connection.
-         * 
+         *
          * @param clientConfig
          * @return {@link OlogClientBuilder}
          */
@@ -182,7 +182,7 @@ public class OlogClient implements LogClient {
 
         /**
          * Set the trustManager that should be used for authentication.
-         * 
+         *
          * @param trustManager
          * @return {@link OlogClientBuilder}
          */
@@ -443,7 +443,7 @@ public class OlogClient implements LogClient {
                     .post(ClientResponse.class, str);
             if (clientResponse.getStatus() < 300) {
                 // XmlLogs responseLogs = clientResponse.getEntity(XmlLogs.class);
-                Collection<LogEntry> returnLogs = new HashSet<LogEntry>();
+                Collection<LogEntry> returnLogs = new HashSet<>();
                 // for (XmlLog xmllog : responseLogs.getLogs()) {
                 // returnLogs.add(xmllog);
                 // }
@@ -496,15 +496,18 @@ public class OlogClient implements LogClient {
     }
 
     private List<LogEntry> findLogs(MultivaluedMap<String, String> mMap) {
-        List<LogEntry> logs = new ArrayList<LogEntry>();
+        List<LogEntry> logs = new ArrayList<>();
         if (!mMap.containsKey("limit")) {
             mMap.putSingle("limit", "100");
         }
         try {
-            logs = logEntryMapper.readValue(
+            // Convert List<XmlLog> into List<LogEntry>
+            final List<XmlLog> xmls = logEntryMapper.readValue(
                     service.path("logs").queryParams(mMap).accept(MediaType.APPLICATION_JSON).get(String.class),
                     new TypeReference<List<XmlLog>>() {
                     });
+            for (XmlLog xml : xmls)
+                logs.add(xml);
             logs.forEach(log -> {
                 // fetch attachment??
                 // This surely can be done better, move the fetch into a job and only invoke it when the client is trying to render the image
@@ -557,7 +560,7 @@ public class OlogClient implements LogClient {
 
     @Override
     public List<LogEntry> findLogsByProperty(String propertyName, String attributeName, String attributeValue) {
-        HashMap<String, String> map = new HashMap<String, String>();
+        HashMap<String, String> map = new HashMap<>();
         map.put(propertyName + "." + attributeName, attributeValue);
         return findLogs(map);
     }
@@ -580,7 +583,7 @@ public class OlogClient implements LogClient {
 
     @Override
     public Collection<Attachment> listAttachments(Long logId) {
-        Collection<Attachment> allAttachments = new HashSet<Attachment>();
+        Collection<Attachment> allAttachments = new HashSet<>();
         XmlAttachments allXmlAttachments = service.path("attachments").path(logId.toString())
                 .accept(MediaType.APPLICATION_XML).get(XmlAttachments.class);
         for (XmlAttachment xmlAttachment : allXmlAttachments.getAttachments()) {
@@ -613,7 +616,7 @@ public class OlogClient implements LogClient {
         // XmlLogs xmlLogs =
         // service.path("logs").accept(MediaType.APPLICATION_XML).accept(MediaType.APPLICATION_JSON)
         // .get(XmlLogs.class);
-        List<LogEntry> logEntries = new ArrayList<LogEntry>();
+        List<LogEntry> logEntries = new ArrayList<>();
         // logEntries.addAll(xmlLogs.getLogs());
         return logEntries;
     }

--- a/app/logbook/olog/pom.xml
+++ b/app/logbook/olog/pom.xml
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
         <groupId>com.sun.jersey</groupId>

--- a/app/save-and-restore/model/pom.xml
+++ b/app/save-and-restore/model/pom.xml
@@ -44,14 +44,14 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.7</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.7</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->

--- a/app/save-and-restore/ui/pom.xml
+++ b/app/save-and-restore/ui/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-json-provider</artifactId>
-			<version>2.9.8</version>
+			<version>${jackson.version}</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
 		<dependency>

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -38,9 +38,15 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/jersey-server-1.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/jsr311-api-1.1.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/mimepull-1.9.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-annotations-2.9.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-core-2.9.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-databind-2.9.4.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-annotations-2.10.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-core-2.10.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-databind-2.10.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-cbor-2.8.10.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-smile-2.8.10.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-yaml-2.8.10.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jdk8-2.9.6.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jsr310-2.10.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/jackson-module-parameter-names-2.9.6.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/kafka-clients-2.0.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/slf4j-api-1.7.25.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/reactive-streams-1.0.2.jar"/>
@@ -63,10 +69,6 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/httpclient-4.5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/httpcore-4.4.5.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/httpcore-nio-4.4.5.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-cbor-2.8.10.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-smile-2.8.10.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-dataformat-yaml-2.8.10.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jsr310-2.8.10.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/jna-4.5.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/joda-time-2.10.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/jopt-simple-5.0.2.jar"/>
@@ -95,8 +97,6 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/protobuf-java-2.4.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/pbrawclient-0.0.8.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/org.eclipse.jgit-5.0.3.201809091024-r.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jdk8-2.9.6.jar"/>
-	<classpathentry exported="true" kind="lib" path="target/lib/jackson-module-parameter-names-2.9.6.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javax.annotation-api-1.3.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/validation-api-2.0.1.Final.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/spring-aop-5.0.9.RELEASE.jar"/>
@@ -150,6 +150,6 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1-linux.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1-linux.jar"/>
-	-->
 	<classpathentry kind="output" path="target/classes"/>
+	-->
 </classpath>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -187,22 +187,22 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.8.10</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <!-- Jetty, web server used by scan server, archive engine, .. For versions check http://central.maven.org/maven2/org/eclipse/jetty/jetty-maven-plugin/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <epics.version>7.0.4</epics.version>
     <vtype.version>1.0.1</vtype.version>
     <openjfx.version>13.0.1</openjfx.version>
+    <jackson.version>2.10.1</jackson.version>
     <!--<maven.repo.local>${project.build.directory}/.m2</maven.repo.local>-->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Don't merge, but maybe check/explain...

@shroffk, based on those odd PRs #930, #931, #932 and #933 which suggest that jackson needs to be updated from 2.9.4 to  2.9.10.1, I introduced a variable `${jackson.version}` and set that to 2.10.1, which is the latest release in maven central.

Builds and runs with ant.
Builds and runs with Eclipse.

I don't know why the overall dependencies drag in older versions of other jackson packages:
```
jackson-dataformat-cbor-2.8.10.jar
jackson-dataformat-smile-2.8.10.jar
jackson-dataformat-yaml-2.8.10.jar
jackson-datatype-jdk8-2.9.6.jar
jackson-module-parameter-names-2.9.6.jar
```

Finally, maven fails with this error:
```
[ERROR] /home/ky9/git/phoebus/app/logbook/olog-es/src/main/java/org/phoebus/olog/es/api/OlogClient.java:[504,44] incompatible types: inference variable T has incompatible bounds
    equality constraints: java.util.List<org.phoebus.olog.es.api.XmlLog>
    lower bounds: java.util.List<org.phoebus.logbook.LogEntry>,java.lang.Object
[INFO] 1 error
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] phoebus (parent) ................................... SUCCESS [  0.395 s]
[INFO] dependencies ....................................... SUCCESS [  0.018 s]
[INFO] install-jars ....................................... SUCCESS [  0.537 s]
[INFO] phoebus-target ..................................... SUCCESS [  0.951 s]
..
[INFO] app-logbook-olog ................................... SUCCESS [  0.212 s]
[INFO] app-logbook-olog-es ................................ FAILURE [  0.149 s]
[INFO] app-rtplot ......................................... SKIPPED
[INFO] app-databrowser .................................... SKIPPED
```