### PR TITLE
Errlog: Remove `\r`

### DIFF
--- a/app/errlog/src/main/java/org/phoebus/applications/errlog/LineDetectingOutputInterpose.java
+++ b/app/errlog/src/main/java/org/phoebus/applications/errlog/LineDetectingOutputInterpose.java
@@ -71,8 +71,9 @@ public class LineDetectingOutputInterpose extends OutputStream
             line_handler.accept(new String(linebuf, 0, count));
             count = 0;
         }
-        else
+        else if (b != '\r')
         {
+            // Skip Windows line feed, but add other text to line
             ensureCapacity(count + 1);
             linebuf[count] = (byte) b;
             count += 1;


### PR DESCRIPTION
Windows adds line feed `\r` to output, and when that's placed in the error log table, it changes the row height

#947