### PR TITLE
ca:// PV: Handle alarm when data carries none, as when reading RTYP 

### DIFF
--- a/app/pvtree/src/main/resources/pv_tree_preferences.properties
+++ b/app/pvtree/src/main/resources/pv_tree_preferences.properties
@@ -28,7 +28,7 @@ read_long_fields=true
 #
 # alarm record has INP1-10. 1-9 handled by pattern, INP10 listed
 
-fields=aai(INP);ai(INP);bi(INP);compress(INP);longin(INP);mbbi(INP);mbbiDirect(INP);mbboDirect(INP);stringin(INP);subArray(INP);waveform(INP);aao(DOL);ao(DOL);bo(DOL);fanout(DOL);longout(DOL);mbbo(DOL);stringout(DOL);sub(INPA-L);genSub(INPA-L);calc(INPA-L);calcout(INPA-L);aSub(INPA-U);seq(SELN);bigASub(INP001-128);scalcout(INPA-L,INAA,INBB,INCC,INDD,INEE,INFF,INGG,INHH,INII,INJJ,INKK,INLL);alarm(INP1-9,INP10)
+fields=aai(INP);ai(INP);bi(INP);compress(INP);longin(INP);mbbi(INP);mbbiDirect(INP);mbboDirect(INP);stringin(INP);lsi(INP);subArray(INP);waveform(INP);aao(DOL);ao(DOL);bo(DOL);fanout(DOL);longout(DOL);mbbo(DOL);stringout(DOL);sub(INPA-L);genSub(INPA-L);calc(INPA-L);calcout(INPA-L);aSub(INPA-U);seq(SELN);bigASub(INP001-128);scalcout(INPA-L,INAA,INBB,INCC,INDD,INEE,INFF,INGG,INHH,INII,INJJ,INKK,INLL);alarm(INP1-9,INP10)
 
 
 # Max update period in seconds

--- a/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
@@ -109,8 +109,18 @@ public class DBRHelper
 
     private static Alarm convertAlarm(final DBR dbr)
     {
-        if (! (dbr instanceof STS))
+        if (dbr == null)
+        {
+            // Not expected, but null indicates
+            // that there is no value, i.e. disconnected.
             return Alarm.disconnected();
+        }
+        else if (! (dbr instanceof STS))
+        {
+            // Called with a valid DBR that carries no alarm information: OK.
+            // Example scenario is reading record.RTYP, which sends plain DBR_STRING.
+            return Alarm.none();
+        }
 
         final STS sts = (STS) dbr;
 


### PR DESCRIPTION
Fixes #950

Also add comparably new 'lsi' record type to PV Tree, a tool that reads RTYP. 