### PR TITLE
Databrowser fixes: Formula, legacy configs

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/FormulaItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/FormulaItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -238,6 +238,7 @@ public class FormulaItem extends ModelItem
                         variables[i].setValue(val[i]);
                     // Evaluate formula for these inputs
                     final double res_val = VTypeHelper.toDouble(formula.eval());
+                    final Time timestamp = Time.of(time);
                     final VType value;
 
                     if (have_min_max)
@@ -249,14 +250,15 @@ public class FormulaItem extends ModelItem
                         for (int i = 0; i < values.length; i++)
                             variables[i].setValue(max[i]);
                         final double res_max = VTypeHelper.toDouble(formula.eval());
-                        value = VStatistics.of(res_val, 0.0, res_min, res_max, 1, OK_FORMULA, Time.now(), display);
+                        // Use min, max, average(=res_val)
+                        value = VStatistics.of(res_val, 0.0, res_min, res_max, 1, OK_FORMULA, timestamp, display);
                     }
                     else
                     {   // No min/max.
                         if (Double.isNaN(res_val))
-                            value = VDouble.of(res_val, INVALID_FORMULA, Time.of(time), display);
+                            value = VDouble.of(res_val, INVALID_FORMULA, timestamp, display);
                         else
-                            value = VDouble.of(res_val, OK_FORMULA, Time.of(time), display);
+                            value = VDouble.of(res_val, OK_FORMULA, timestamp, display);
                     }
                     result.add(new PlotSample(Messages.Formula, value));
                 }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/FormulaItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/FormulaItem.java
@@ -234,21 +234,21 @@ public class FormulaItem extends ModelItem
                     }
 
                     // Set variables[] from val to get res_val
+                    final Time timestamp = Time.of(time);
                     for (int i = 0; i < values.length; i++)
-                        variables[i].setValue(val[i]);
+                        variables[i].setValue(VDouble.of(val[i], OK_FORMULA, timestamp, display));
                     // Evaluate formula for these inputs
                     final double res_val = VTypeHelper.toDouble(formula.eval());
-                    final Time timestamp = Time.of(time);
                     final VType value;
 
                     if (have_min_max)
                     {   // Set variables[] from min
                         for (int i = 0; i < values.length; i++)
-                            variables[i].setValue(min[i]);
+                            variables[i].setValue(VDouble.of(min[i], OK_FORMULA, timestamp, display));
                         final double res_min = VTypeHelper.toDouble(formula.eval());
                         // Set variables[] from max
                         for (int i = 0; i < values.length; i++)
-                            variables[i].setValue(max[i]);
+                            variables[i].setValue(VDouble.of(max[i], OK_FORMULA, timestamp, display));
                         final double res_max = VTypeHelper.toDouble(formula.eval());
                         // Use min, max, average(=res_val)
                         value = VStatistics.of(res_val, 0.0, res_min, res_max, 1, OK_FORMULA, timestamp, display);

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -956,7 +956,10 @@ public class Model
     /** Dispose all items, remove all listeners */
     public void dispose()
     {
+        // Remove all listeners so they're no longer
+        // called..
         listeners.clear();
+        // .. as all items are removed:
         clear();
     }
 }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -952,4 +952,11 @@ public class Model
         for (ModelListener listener : listeners)
             listener.selectedSamplesChanged();
     }
+
+    /** Dispose all items, remove all listeners */
+    public void dispose()
+    {
+        listeners.clear();
+        clear();
+    }
 }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -609,8 +609,7 @@ public class Controller
         }
         // Stop update task
         model.stop();
-        model.removeListener(model_listener);
-        model.clear();
+        model.dispose();
         update_task.cancel(true);
         update_task = null;
     }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
@@ -472,7 +472,12 @@ public class Perspective extends SplitPane
         {
             logger.log(Level.WARNING, "Unable to flush preferences", ex);
         }
-        plot.dispose();
+        // Stop PVs etc. ASAP
         controller.stop();
+        // Then dispose plot
+        plot.dispose();
+        // Not specifically disposing property_panel.
+        // Their model listeners have been removed when controller stopped
+        // and 'disposed' model.
     }
 }


### PR DESCRIPTION
Primarily fixes #952, where the formula failed to handle 'optimized' data.
Fixed some import issues with older files that contain empty PV names or invalid time ranges.
Faster 'close'.