### PR TITLE
CSSTUDIO-1166 Improvements to alarm guidance handling

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
@@ -93,12 +93,12 @@ public class AlarmContextMenuHelper
         //
         // Considered tool tip, but unclear how to attach TT to menu item.
         final AtomicInteger count = new AtomicInteger();
-        for (AlarmTreeItem<?> item : selection)
-        {
-            addGuidance(node, menu_items, item, count);
-            if (count.get() >= AlarmSystem.alarm_menu_max_items)
-                break;
+
+        // Add guidance menu item only if one single AlarmTreeItem is selected
+        if(selection.size() == 1 && selection.get(0).getGuidance() != null && !selection.get(0).getGuidance().isEmpty()){
+            addGuidance(node, menu_items, selection.get(0));
         }
+
         added.clear();
         count.set(0);
 
@@ -157,21 +157,9 @@ public class AlarmContextMenuHelper
 
     private void addGuidance(final Node node,
                              final List<MenuItem> menu_items,
-                             final AlarmTreeItem<?> item,
-                             final AtomicInteger count)
+                             final AlarmTreeItem<?> item)
     {
-        for (TitleDetail guidance : item.getGuidance())
-            if (added.add(guidance))
-                if (count.incrementAndGet() <= AlarmSystem.alarm_menu_max_items)
-                    menu_items.add(new ShowGuidanceAction(node, item, guidance));
-                else
-                {
-                    menu_items.add(createSkippedEntriesHint(node, "guidance messages"));
-                    return;
-                }
-
-        if (item.getParent() != null)
-            addGuidance(node, menu_items, item.getParent(), count);
+        menu_items.add(new ShowGuidanceAction(node, item));
     }
 
     private void addDisplays(final Node node,

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/ShowGuidanceAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/ShowGuidanceAction.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import javafx.scene.web.HTMLEditor;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.TitleDetail;
 import org.phoebus.ui.dialog.DialogHelper;
@@ -18,26 +21,28 @@ import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextArea;
 
+import java.util.List;
+
 /** Action that displays an AlarmTreeItem's guidance
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 class ShowGuidanceAction extends MenuItem
 {
+
     /** @param node Node to position dialog
-     *  @param item Alarm item
-     *  @param guidance Info to show
+     *  @param item Alarm item tha also holds guidance texts
      */
-    public ShowGuidanceAction(final Node node, final AlarmTreeItem<?> item, final TitleDetail guidance)
+    public ShowGuidanceAction(final Node node, final AlarmTreeItem<?> item)
     {
-        super(guidance.title, ImageCache.getImageView(ImageCache.class, "/icons/info.png"));
+        super("Guidance", ImageCache.getImageView(ImageCache.class, "/icons/info.png"));
         setOnAction(event ->
         {
             final Alert dialog = new Alert(AlertType.INFORMATION);
-            dialog.setTitle("Guidance for " + item.getName());
-            dialog.setHeaderText(guidance.title);
+            dialog.setTitle("Guidance");
+            dialog.setHeaderText("Guidance for " + item.getName());
 
-            final TextArea details = new TextArea(guidance.detail);
+            final TextArea details = new TextArea(getGuidanceTexts(item.getGuidance()));
             details.setEditable(false);
             details.setWrapText(true);
 
@@ -45,7 +50,18 @@ class ShowGuidanceAction extends MenuItem
 
             DialogHelper.positionDialog(dialog, node, -100, -50);
             dialog.setResizable(true);
+
             dialog.showAndWait();
         });
+    }
+
+    private String getGuidanceTexts(List<TitleDetail> guidance){
+        StringBuffer stringBuffer = new StringBuffer();
+        for(TitleDetail detail : guidance){
+            stringBuffer.append(detail.title).append("\n");
+            stringBuffer.append(detail.detail).append("\n\n");
+        }
+
+        return stringBuffer.toString();
     }
 }


### PR DESCRIPTION
A few changes to how guidance texts are handled in alarm views (table, tree).

- A guidance context menu item is included only for a "leaf" alarm item, and only if one single item is selected.
- The text of context menu item for guidance is always the same, i.e. not taken from the title of the guidance.
- When the guidance context menu item is selected, the pop-up will show all guidance texts configured for that alarm.

