### PR TITLE
Do not display trailing ':' when there is no cause

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -302,12 +302,12 @@ public class DisplayRuntimeInstance implements AppInstance
                 final String exception_message;
 
                 if (ex.getCause() != null)
-                    exception_message = ex.getCause().getLocalizedMessage();
+                    exception_message = ":\n" + ex.getCause().getLocalizedMessage();
                 else
                     exception_message = "";
 
                 ExceptionDetailsErrorDialog.openError("Cannot load model",
-                        "Cannot load model from\n" + info.getPath() + ":\n" + exception_message, ex);
+                        "Cannot load model from\n" + info.getPath() + exception_message, ex);
 
                 display_info = Optional.empty();
                 Platform.runLater(() ->


### PR DESCRIPTION
(The message for the outer exception is always shown)