### PR TITLE
Allow hiding the menu; save/load via memento

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -99,6 +99,7 @@ public class PhoebusApplication extends Application {
     public static final String LAST_OPENED_FILE = "last_opened_file",
                                DEFAULT_APPLICATION = "default_application",
                                SHOW_TABS = "show_tabs",
+                               SHOW_MENU = "show_menu",
                                SHOW_TOOLBAR = "show_toolbar";
 
     /** Menu item for top resources */
@@ -106,6 +107,9 @@ public class PhoebusApplication extends Application {
 
     /** Menu item to show/hide tabs */
     private CheckMenuItem show_tabs;
+
+    /** Menu bar, may be hidden via memento */
+    private MenuBar menuBar;
 
     /** Tool bar, may be hidden */
     private ToolBar toolbar;
@@ -246,7 +250,7 @@ public class PhoebusApplication extends Application {
         monitor.beginTask(Messages.MonitorTaskUi, 4);
 
         main_stage = new Stage();
-        final MenuBar menuBar = createMenu(main_stage);
+        menuBar = createMenu(main_stage);
         toolbar = createToolbar();
         createTopResourcesMenu();
 
@@ -709,6 +713,27 @@ public class PhoebusApplication extends Application {
         return toolBar;
     }
 
+    /** @return <code>true</code> if menu is visible */
+    boolean isMenuVisible()
+    {
+        final BorderPane layout = DockStage.getLayout(main_stage);
+        final VBox top = (VBox) layout.getTop();
+        return top.getChildren().contains(menuBar);
+    }
+
+    private void showMenu(final boolean show)
+    {
+        final BorderPane layout = DockStage.getLayout(main_stage);
+        final VBox top = (VBox) layout.getTop();
+        if (show)
+        {
+            if (! top.getChildren().contains(menuBar))
+                top.getChildren().add(0, menuBar);
+        }
+        else
+            top.getChildren().remove(menuBar);
+    }
+
     /** @return <code>true</code> if toolbar is visible */
     boolean isToolbarVisible()
     {
@@ -974,6 +999,7 @@ public class PhoebusApplication extends Application {
                 DockPane.alwaysShowTabs(show);
                 show_tabs.setSelected(show);
             });
+            memento.getBoolean(SHOW_MENU).ifPresent(this::showMenu);
             memento.getBoolean(SHOW_TOOLBAR).ifPresent(show ->
             {
                 showToolbar(show);
@@ -1037,7 +1063,7 @@ public class PhoebusApplication extends Application {
         // Save current state, _before_ tabs are closed and thus
         // there's nothing left to save
         final File memfile = XMLMementoTree.getDefaultFile();
-        MementoHelper.saveState(memfile, last_opened_file, default_application, isToolbarVisible());
+        MementoHelper.saveState(memfile, last_opened_file, default_application, isMenuVisible(), isToolbarVisible());
 
         if (!closeStages(stages))
             return false;

--- a/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutMenuItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutMenuItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -118,7 +118,7 @@ class SaveLayoutMenuItem extends MenuItem
         // Save in background thread
         JobManager.schedule("Save " + memento_filename, monitor ->
         {
-            MementoHelper.saveState(memento_file, null, null, phoebus.isToolbarVisible());
+            MementoHelper.saveState(memento_file, null, null, phoebus.isMenuVisible(), phoebus.isToolbarVisible());
 
             // After the layout has been saved,
             // update menu to include the newly saved layout

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -305,11 +305,13 @@ public class MementoHelper
      *  @param memento_file The file the memento xml is stored in.
      *  @param last_opened_file The last opened file.
      *  @param default_application The default application name.
+     *  @param show_menu Show menu?
      *  @param show_toolbar Show toolbar?
      */
     public static void saveState(final File memento_file,
                                  final File last_opened_file,
                                  final String default_application,
+                                 final boolean show_menu,
                                  final boolean show_toolbar)
     {
         logger.log(Level.INFO, "Persisting state to " + memento_file);
@@ -323,6 +325,7 @@ public class MementoHelper
             if (default_application != null)
                 memento.setString(PhoebusApplication.DEFAULT_APPLICATION, default_application);
             memento.setBoolean(PhoebusApplication.SHOW_TABS, DockPane.isAlwaysShowingTabs());
+            memento.setBoolean(PhoebusApplication.SHOW_MENU, show_menu);
             memento.setBoolean(PhoebusApplication.SHOW_TOOLBAR, show_toolbar);
 
             // Persist each stage (window) and its tabs


### PR DESCRIPTION
Allows hiding/showing the menu.
Not added as a menu option, because unclear how user would then show the menu after accidentally hiding it.

Meant to be used by editing the memento to create a kiosk-like setup:
Create a layout with locked panes, disable tags, disable toolbar, close product.
In the memento, change "show_menu" from "true" to "false".
When now running phoebus, it loads the memento and the layout is pretty bare, with all the user can do is mostly close the app.