### PR TITLE
Issue 988

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/ca/JCA_Preferences.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/JCA_Preferences.java
@@ -41,6 +41,7 @@ public class JCA_Preferences
     private static final String LARGE_ARRAY_THRESHOLD = "large_array_threshold";
     private static final String DBE_PROPERTY_SUPPORTED = "dbe_property_supported";
     private static final String MONITOR_MASK = "monitor_mask";
+    private static final String NAME_SERVERS = "name_servers";
 
     private static final JCA_Preferences instance = new JCA_Preferences();
 
@@ -136,6 +137,9 @@ public class JCA_Preferences
         final String max_array_bytes = prefs.get(MAX_ARRAY_BYTES);
         setSystemProperty("com.cosylab.epics.caj.CAJContext.max_array_bytes", max_array_bytes);
         setSystemProperty("gov.aps.jca.jni.JNIContext.max_array_bytes", max_array_bytes);
+
+        final String name_servers = prefs.get(NAME_SERVERS);
+        setSystemProperty("com.cosylab.epics.caj.CAJContext.name_servers", name_servers);
 
         // gov.aps.jca.event.QueuedEventDispatcher avoids
         // deadlocks when calling JCA while receiving JCA callbacks.

--- a/core/pv/src/main/resources/pv_ca_preferences.properties
+++ b/core/pv/src/main/resources/pv_ca_preferences.properties
@@ -32,3 +32,6 @@ dbe_property_supported=false
 # Mask to use for subscriptions
 # VALUE, ALARM, ARCHIVE
 monitor_mask=VALUE
+
+# Name server list
+name_servers=localhost

--- a/core/pv/src/main/resources/pv_ca_preferences.properties
+++ b/core/pv/src/main/resources/pv_ca_preferences.properties
@@ -3,7 +3,7 @@
 # -------------------------
 
 # Channel Access address list
-addr_list=10.0.16.88
+addr_list=
 
 auto_addr_list=true
 
@@ -34,4 +34,4 @@ dbe_property_supported=false
 monitor_mask=VALUE
 
 # Name server list
-name_servers=localhost
+name_servers=


### PR DESCRIPTION
This allows for setting `org.phoebus.pv.ca/name_servers` in a `settings.ini` file when starting phoebus, addressing Issue 988