### PR TITLE
Fix logging-ui timezone to search in UTC but display in system defaul…

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -152,7 +152,7 @@ public class AlarmLogSearchJob implements JobRunnable {
                                 }
                                 if (message_time != null) {
                                     Instant instant = LocalDateTime.parse(message_time.asText(), formatter)
-				    .atZone(ZoneId.of("UTC")).toInstant().atZone(ZoneId.systemDefault()).toInstant();
+				        .atZone(ZoneId.of("UTC")).toInstant().atZone(ZoneId.systemDefault()).toInstant();
                                     alarmMessage.setMessage_time(instant);
                                 }
                                 if (alarmMessage.getPv() == null) {

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -47,8 +47,8 @@ public class AlarmLogSearchJob implements JobRunnable {
     private final BiConsumer<String, Exception> errorHandler;
 
     private final ObjectMapper objectMapper;
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-            .withZone(ZoneId.systemDefault());
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+            .withZone(ZoneId.of("UTC"));
     private final PreferencesReader prefs = new PreferencesReader(AlarmLogTableApp.class,
             "/alarm_logging_preferences.properties");
 
@@ -147,12 +147,12 @@ public class AlarmLogSearchJob implements JobRunnable {
                                         AlarmLogTableType.class);
                                 if (time != null) {
                                     Instant instant = LocalDateTime.parse(time.asText(), formatter)
-                                            .atZone(ZoneId.systemDefault()).toInstant();
+					.atZone(ZoneId.of("UTC")).toInstant().atZone(ZoneId.systemDefault()).toInstant();
                                     alarmMessage.setInstant(instant);
                                 }
                                 if (message_time != null) {
                                     Instant instant = LocalDateTime.parse(message_time.asText(), formatter)
-                                            .atZone(ZoneId.systemDefault()).toInstant();
+				    .atZone(ZoneId.of("UTC")).toInstant().atZone(ZoneId.systemDefault()).toInstant();
                                     alarmMessage.setMessage_time(instant);
                                 }
                                 if (alarmMessage.getPv() == null) {


### PR DESCRIPTION
…t timezone

There are 2 issues with alarm-logging-UI.
1) Timestamps shown for time & message_time were in UTC while expectation is for them to be in system-default.  
2) While searching between 'from' and 'to', logging-ui used system-default timezone so the table wasn't displaying the recent ES logs. 

Both these issues are resolved with this code change.