### PR TITLE
Databrowser property panel UI delay fix

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DeleteAxes.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DeleteAxes.java
@@ -48,6 +48,7 @@ public class DeleteAxes extends MenuItem
                     final Alert dialog = new Alert(AlertType.WARNING);
                     dialog.setTitle(Messages.DeleteAxis);
                     dialog.setHeaderText(MessageFormat.format(Messages.DeleteAxisWarningFmt, axis.getName(), item.getName()));
+                    dialog.setResizable(true);
                     DialogHelper.positionDialog(dialog, node, -200, -200);
                     dialog.showAndWait();
                     return;

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DirectChoiceBoxTableCell.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DirectChoiceBoxTableCell.java
@@ -10,7 +10,7 @@ package org.csstudio.trends.databrowser3.ui.properties;
 import java.util.Objects;
 
 import javafx.collections.ObservableList;
-import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.CellEditEvent;
@@ -28,7 +28,7 @@ import javafx.scene.control.TableView;
 @SuppressWarnings("nls")
 public class DirectChoiceBoxTableCell<S, T> extends TableCell<S, T>
 {
-    private final ChoiceBox<T> choicebox;
+    private final ComboBox<T> choicebox;
 
     /** Flag to distinguish 'onAction' caused by user
      *  from call when setting value programmatically,
@@ -41,7 +41,17 @@ public class DirectChoiceBoxTableCell<S, T> extends TableCell<S, T>
      */
     public DirectChoiceBoxTableCell(final ObservableList<T> choices)
     {
-        choicebox = new ChoiceBox<T>(choices);
+        // Used to be ChoiceBox, which is like a ComboBox without
+        // 'edit' option and without border,
+        // but that resulted in high CPU usage deep inside JFX code
+        // when choices were added or removed while the choice box is
+        // in a table cell.
+        // https://github.com/shroffk/phoebus/issues/1015
+        //
+        // ComboBox doesn't have that problem,
+        // and with transparent background it looks like the choice box
+        choicebox = new ComboBox<>(choices);
+        choicebox.setStyle("-fx-background-color: transparent;");
     }
 
     @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DirectChoiceBoxTableCell.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DirectChoiceBoxTableCell.java
@@ -30,12 +30,6 @@ public class DirectChoiceBoxTableCell<S, T> extends TableCell<S, T>
 {
     private final ComboBox<T> choicebox;
 
-    /** Flag to distinguish 'onAction' caused by user
-     *  from call when setting value programmatically,
-     *  to prevent recursive updates
-     */
-    private boolean changing = false;
-
     /** Constructor
      *  @param choices Choices to offer, may be updated at runtime
      */
@@ -63,17 +57,17 @@ public class DirectChoiceBoxTableCell<S, T> extends TableCell<S, T>
             setGraphic(null);
         else
         {
-            changing = true;
             choicebox.setValue(value);
-            changing = false;
             setGraphic(choicebox);
 
             choicebox.setOnAction(event ->
             {
-                // Prevent loop from 'setValue' call above.
+                // 'onAction' is invoked from setValue as called above,
+                // but also when table updates its cells.
+                // Ignore those.
                 // Also ignore dummy updates to null which happen
                 // when the list of choices changes
-                if (changing ||
+                if (! choicebox.isShowing() ||
                     choicebox.getValue() == null)
                     return;
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
@@ -237,7 +237,7 @@ public class TracesTab extends Tab
             }
             // In case an axis _name_ changed, this needs to be shown
             // in the "Axis" column.
-            updateFromModel();
+            updateAxisNames();
         }
 
         @Override
@@ -352,10 +352,17 @@ public class TracesTab extends Tab
     private void updateFromModel()
     {
         trace_table.getItems().setAll(model.getItems());
+        updateAxisNames();
+    }
+
+    private void updateAxisNames()
+    {
         final List<String> names = new ArrayList<>(model.getAxes().size());
         for (AxisConfig ai : model.getAxes())
             names.add(ai.getName());
-        axis_names.setAll(names);
+
+        if (! names.equals(axis_names))
+            axis_names.setAll(names);
     }
 
     private void createTraceTable()


### PR DESCRIPTION
Default ChoiceBoxTableCell or ComboBoxTableCell require two clicks to activate.
Data browser has this been using its own DirectChoiceBoxTableCell, but turns out that the ChoiceBoxes in table cells caused deep calls into JFX code and lengthy UI delays when their items change.

Tried to work around this with ChoiceBox to no avail, then found that ComboBox doesn't exhibit the problem. So using the latter, with style that makes it look just like the ChoiceBox.

Fixes #1015

