### PR TITLE
PVA: Fix structure decoding based on 'change' bitset

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -282,7 +282,19 @@ abstract public class TCPHandler
                 // message handler from reading beyond message boundary.
                 final int actual_limit = receive_buffer.limit();
                 receive_buffer.limit(message_size);
-                handleMessage(receive_buffer);
+                try
+                {
+                    handleMessage(receive_buffer);
+                }
+                catch (Exception ex)
+                {
+                    // Once we fail to decode and handle a message,
+                    // it is likely that the server/client protocol gets
+                    // out of step and never recovers.
+                    // Still, log error and keep reading in case
+                    // the issue is limited to just this one message.
+                    logger.log(Level.WARNING, Thread.currentThread().getName() + " message error. Protocol might be broken from here on.", ex);
+                }
 
                 receive_buffer.limit(actual_limit);
                 // No matter if message handler read the complete message,

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
@@ -189,13 +189,14 @@ public class PVAStructure extends PVADataWithID
                 logger.log(Level.FINER, () -> "Getting data for indexed element " + i + ": " + se.getStructureName());
                 final int count = se.decodeElements(types, buffer);
                 logger.log(Level.FINER, () -> "Decoded elements " + i + ".." + (i + count));
-                to_decode.clear(index, index + count);
+                // Mark all struct elements i .. i+count (incl.) as read
+                to_decode.clear(i, i + count + 1);
             }
             else
             {
                 logger.log(Level.FINER, () -> "Getting data for indexed element " + i + ": " + element.formatType());
                 element.decode(types, buffer);
-                to_decode.clear(index);
+                to_decode.clear(i);
             }
             logger.log(Level.FINER, () -> "Remaining elements to read: " + to_decode);
 

--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -46,6 +46,7 @@ public class Messages
     public static String HelpAboutHdr;
     public static String HelpAboutColName;
     public static String HelpAboutColValue;
+    public static String HelpAboutEnv;
     public static String HelpAboutInst;
     public static String HelpAboutJava;
     public static String HelpAboutJfx;

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -174,6 +174,18 @@ public class OpenAbout implements MenuEntry
         area.setEditable(false);
         final Tab apps = new Tab(Messages.HelpAboutAppFea, area);
 
+        // Environment variables
+        final StringBuilder props_env = new StringBuilder();
+        System.getenv()
+              .keySet()
+              .stream()
+              .sorted()
+              .forEach(var ->  props_env.append(var).append(" = ").append(System.getenv(var)).append("\n"));
+
+        area = new TextArea(props_env.toString());
+        area.setEditable(false);
+        final Tab envs = new Tab(Messages.HelpAboutEnv, area);
+
         // System properties
         final StringBuilder props_text = new StringBuilder();
         System.getProperties()
@@ -209,7 +221,7 @@ public class OpenAbout implements MenuEntry
 
         final Tab prefs = new Tab(Messages.HelpAboutPrefs, new VBox(5, area, bottom_row));
 
-        final TabPane tabs = new TabPane(apps, props, prefs);
+        final TabPane tabs = new TabPane(apps, envs, props, prefs);
         return tabs;
     }
 

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -31,6 +31,7 @@ HelpAbout=About
 HelpAboutAppFea=Application Features
 HelpAboutColName=Name
 HelpAboutColValue=Value
+HelpAboutEnv=Environment Variables
 HelpAboutHdr=Installation Information
 HelpAboutInst=Installation Location
 HelpAboutJava=Java Version


### PR DESCRIPTION
Found this error when testing P4P gateway.

Since PVA (and also CAJ for `-Djca.use_env=true`) use environment variables, show those in Help/About.