### PR TITLE
Build svg

### DIFF
--- a/app/display/representation-javafx/.classpath
+++ b/app/display/representation-javafx/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -119,6 +119,25 @@
 	<classpathentry exported="true" kind="lib" path="target/lib/spring-web-5.0.9.RELEASE.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/spring-webmvc-5.0.9.RELEASE.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/hibernate-validator-6.0.12.Final.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-anim-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-awt-util-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-bridge-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-constants-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-css-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-dom-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-ext-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-gvt-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-i18n-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-parser-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-script-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-svg-dom-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-svggen-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-transcoder-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-util-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/batik-xml-1.12.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/xml-apis-ext-1.3.04.jar"/>
+        <classpathentry exported="true" kind="lib" path="target/lib/xmlgraphics-commons-2.4.jar"/>
+
 	<!-- On Windows, need to add this:
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1-win.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -10,7 +10,6 @@
   <properties>
     <spring.boot-version>2.0.5.RELEASE</spring.boot-version>
     <preReleaseScripts>${project.basedir}/release_classpath.py</preReleaseScripts>
-    <batik.version>1.12</batik.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
#1023 and #1025 added SVG support, but didn't add the new test/resources folder to the .classpath, didn't list the new batik and XML libs in the dependencies .classpath, and set batik.version in both the parent pom and a lower pom.