### PR TITLE
Scan abort

### DIFF
--- a/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ExecutableScan.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ExecutableScan.java
@@ -561,21 +561,20 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
         }
         finally
         {
-            // TODO Move into try{
-            end_ms = System.currentTimeMillis();
-
-            // Assert that the state is 'done'
-            // to exclude this scan from the engine.hasPendingScans() information
-            state.getAndUpdate(current ->
-            {
-                if (current.isDone())
-                    return current;
-                logger.log(Level.WARNING, "Scan state was %s, changing to Failed", current.toString());
-                return ScanState.Failed;
-            });
-
             try
             {
+                end_ms = System.currentTimeMillis();
+
+                // Assert that the state is 'done'
+                // to exclude this scan from the engine.hasPendingScans() information
+                state.getAndUpdate(current ->
+                {
+                    if (current.isDone())
+                        return current;
+                    logger.log(Level.WARNING, "Scan state was %s, changing to Failed", current.toString());
+                    return ScanState.Failed;
+                });
+
                 // Final status PV update.
                 if (device_active.isPresent())
                 {
@@ -589,9 +588,9 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
                     logger.log(Level.INFO, this + " sets "  + device_active.get() + " = " + active);
                 }
             }
-            catch (Exception ex) // TODO Throwable
+            catch (Throwable ex)
             {
-                logger.log(Level.WARNING, "Final Scan status PV update failed", ex);
+                logger.log(Level.WARNING, "Scan finalization failed", ex);
             }
 
             // Stop devices

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ExecutableScan.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ExecutableScan.java
@@ -506,6 +506,7 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
                 ScanCommandUtil.write(this, device_active.get(), Double.valueOf(1.0));
                 ScanCommandUtil.write(this, device_progress.get(), Double.valueOf(0.0));
                 getDevice(device_finish.get()).write("Starting ...");
+                logger.log(Level.INFO, this + " sets "  + device_active.get() + " = 1.0");
             }
 
             try
@@ -560,6 +561,7 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
         }
         finally
         {
+            // TODO Move into try{
             end_ms = System.currentTimeMillis();
 
             // Assert that the state is 'done'
@@ -584,9 +586,10 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
                     // Update to "anything else running?"
                     final int active = engine.hasPendingScans() ? 1 : 0;
                     ScanCommandUtil.write(this, device_active.get(), active);
+                    logger.log(Level.INFO, this + " sets "  + device_active.get() + " = " + active);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) // TODO Throwable
             {
                 logger.log(Level.WARNING, "Final Scan status PV update failed", ex);
             }
@@ -752,14 +755,22 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
         }
     }
 
-    /** Ask for execution to stop */
-    public void abort()
+    /** Mark for abort
+     *  @return Previous scan state
+     */
+    public ScanState prepareAbort()
     {
         // Set state to aborted unless it is already 'done'
-        final ScanState previous = state.getAndUpdate((current_state)  ->  current_state.isDone() ? current_state : ScanState.Aborted);
+        return state.getAndUpdate((current_state)  ->  current_state.isDone() ? current_state : ScanState.Aborted);
+    }
+
+    /** Abort scan
+     *  @param previous Previous state from `prepareAbort()`
+     */
+    public void doAbort(final ScanState previous)
+    {
         if (previous.isDone())
             return;
-
         logger.log(Level.INFO, "Abort " + this + " (" + previous + ")");
 
         // Interrupt, except when already aborted, failed, ..


### PR DESCRIPTION
When a running scan ends, it optionally updates the scan-active PV, clearing it when all done, leaving it set  when there are still other idle or running scans.
On 'abort all', that running scan could find other idle scans in the queue which are soon aborted, but by then the scan-active PV was already set.

Change order of 'abort all', also first marking all scans to be aborted, then aborting them, to keep the scan-active PV consistent.