### PR TITLE
Widget info dialog update

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -111,7 +111,7 @@ public class EmbeddedDisplayWidget extends VisibleWidget
         CommonWidgetProperties.newStringPropertyDescriptor(
             WidgetPropertyCategory.DISPLAY, "group_name", Messages.EmbeddedDisplayWidget_GroupName);
 
-    static final WidgetPropertyDescriptor<DisplayModel> runtimeModel =
+    public static final WidgetPropertyDescriptor<DisplayModel> runtimeModel =
         new WidgetPropertyDescriptor<>(WidgetPropertyCategory.RUNTIME, "embedded_model", "Embedded Model")
         {
             @Override

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
@@ -51,7 +51,7 @@ public class WidgetInfoDialog extends Dialog<Boolean>
         public final VType value;
         public final String path;
 
-        public NameStateValue(final String name, final String state, final VType value, String path)
+        public NameStateValue(final String name, final String state, final VType value, final String path)
         {
             this.name = name;
             this.state = state;
@@ -97,7 +97,7 @@ public class WidgetInfoDialog extends Dialog<Boolean>
         setResultConverter(button -> true);
     }
 
-    private Tab createMacros(Macros orig_macros)
+    private Tab createMacros(final Macros orig_macros)
     {
         final Macros macros = (orig_macros == null) ? new Macros() : orig_macros;
         // Use text field to allow copying the name and value


### PR DESCRIPTION
Tweaks to #1038 

It introduced a 'path' notation like name.name.name.
Makes sense to somehow indicate the location of a widget in the hierarchy, but there isn't really a path notation API, so don't want to suggest that were by showing it like that.
Adding the widget type, since the name alone might not be useful, and showing both in the `"Name" (type)` notation that's already used in the dialog header, then simply showing the path as a comma-separated list of `"Name" (type), "Name" (type), ...`, with `[tabname]` for tabs.

![winfo](https://user-images.githubusercontent.com/1932421/71178898-180bd700-223d-11ea-8a97-1085cbd93147.png)

Also using  `ChildrenProperty` and making the embedded `runtimeProperty` of the navtabs and embedded widget accessible to avoid depending on string identifiers.