### PR TITLE
Csstudio 1183

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/SVGHelper.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/SVGHelper.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 
 /**
  * Helper class to load SVG files. It is based on the following post on Stackoverflow:
- * https://stackoverflow.com/questions/12436274/svg-image-in-javafx-2-2
+ * https://stackoverflow.com/questions/12436274/svg-image-in-javafx-2-2.
  *
  * The dependency to Apache Batik inflates the size of the lib folder by ~3 MB.
  *
@@ -48,12 +48,17 @@ public class SVGHelper {
     /**
      * Loads SVG file as an {@link Image}.
      * @param fileStream Non-null input stream to SVG file.
+     * @param width The wanted width of the image.
+     * @param height The wanted height of the image.
      * @return A {@link Image} object if all goes well.
      */
-    public static Image loadSVG(InputStream fileStream) throws Exception{
+    public static Image loadSVG(InputStream fileStream, Float width, Float height) throws Exception{
         TranscoderInput input = new TranscoderInput(fileStream);
         try {
+            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_WIDTH, width);
+            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_HEIGHT, height);
             bufferedImageTranscoder.transcode(input, null);
+
             return SwingFXUtils.toFXImage(bufferedImageTranscoder.getBufferedImage(), null);
         } catch (TranscoderException e) {
             throw new Exception("Unable to transcode SVG file", e);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/SVGHelper.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/SVGHelper.java
@@ -27,7 +27,7 @@ import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.transcoder.image.ImageTranscoder;
 
 import java.awt.image.BufferedImage;
-import java.io.InputStream;
+import java.io.*;
 
 /**
  * Helper class to load SVG files. It is based on the following post on Stackoverflow:
@@ -39,24 +39,23 @@ import java.io.InputStream;
  */
 public class SVGHelper {
 
-    private static BufferedImageTranscoder bufferedImageTranscoder;
-
-    static{
-        bufferedImageTranscoder = new BufferedImageTranscoder();
-    }
-
     /**
-     * Loads SVG file as an {@link Image}.
+     * Loads SVG file as an {@link Image}. The resolution of the generated image is determined by the
+     * width and height parameters. Consequently scaling to a much larger size will result in "pixelation".
+     * Client code is hence advised to reload the SVG resource using the new width and height when
+     * the container widget is resized.
+     *
      * @param fileStream Non-null input stream to SVG file.
      * @param width The wanted width of the image.
      * @param height The wanted height of the image.
-     * @return A {@link Image} object if all goes well.
+     * @return A {@link Image} object if the input stream can be parsed and transcoded.
      */
-    public static Image loadSVG(InputStream fileStream, Float width, Float height) throws Exception{
+    public static Image loadSVG(InputStream fileStream, double width, double height) throws Exception{
+        BufferedImageTranscoder bufferedImageTranscoder = new BufferedImageTranscoder();
         TranscoderInput input = new TranscoderInput(fileStream);
-        try {
-            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_WIDTH, width);
-            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_HEIGHT, height);
+        try{
+            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_WIDTH, (float)width);
+            bufferedImageTranscoder.addTranscodingHint(ImageTranscoder.KEY_HEIGHT, (float)height);
             bufferedImageTranscoder.transcode(input, null);
 
             return SwingFXUtils.toFXImage(bufferedImageTranscoder.getBufferedImage(), null);

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/SVGHelperTest.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/SVGHelperTest.java
@@ -37,7 +37,7 @@ public class SVGHelperTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.svg");
 
         try {
-            Image image = SVGHelper.loadSVG(is);
+            Image image = SVGHelper.loadSVG(is, 400f, 400f);
 
             assertTrue(image.getHeight() > 0);
             assertTrue(image.getWidth() > 0);
@@ -53,7 +53,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperPngFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.png");
-        SVGHelper.loadSVG(is);
+        SVGHelper.loadSVG(is, 400f, 400f);
     }
 
     /**
@@ -63,7 +63,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperJpgFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.jpg");
-        SVGHelper.loadSVG(is);
+        SVGHelper.loadSVG(is, 400f, 400f);
     }
 
     /**
@@ -73,7 +73,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperGifFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.gif");
-        SVGHelper.loadSVG(is);
+        SVGHelper.loadSVG(is, 400f, 400f);
     }
 
     /**
@@ -83,6 +83,6 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperTiffFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.tiff");
-        SVGHelper.loadSVG(is);
+        SVGHelper.loadSVG(is, 400f, 400f);
     }
 }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/SVGHelperTest.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/SVGHelperTest.java
@@ -37,7 +37,7 @@ public class SVGHelperTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.svg");
 
         try {
-            Image image = SVGHelper.loadSVG(is, 400f, 400f);
+            Image image = SVGHelper.loadSVG(is, 400d, 400d);
 
             assertTrue(image.getHeight() > 0);
             assertTrue(image.getWidth() > 0);
@@ -53,7 +53,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperPngFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.png");
-        SVGHelper.loadSVG(is, 400f, 400f);
+        SVGHelper.loadSVG(is, 400d, 400d);
     }
 
     /**
@@ -63,7 +63,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperJpgFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.jpg");
-        SVGHelper.loadSVG(is, 400f, 400f);
+        SVGHelper.loadSVG(is, 400d, 400d);
     }
 
     /**
@@ -73,7 +73,7 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperGifFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.gif");
-        SVGHelper.loadSVG(is, 400f, 400f);
+        SVGHelper.loadSVG(is, 400d, 400d);
     }
 
     /**
@@ -83,6 +83,6 @@ public class SVGHelperTest {
     @Test(expected = Exception.class)
     public void testSVGHelperTiffFile() throws Exception{
         InputStream is = getClass().getClassLoader().getResourceAsStream("interlock.tiff");
-        SVGHelper.loadSVG(is, 400f, 400f);
+        SVGHelper.loadSVG(is, 400d, 400d);
     }
 }


### PR DESCRIPTION
Improved support for SVG in symbol widget.
When a symbol widget containing a SVG resource is resized, the underlying SVG must be reloaded (=re-transcoded). A side effect is that SVG resources are maintained by the image cache using a key suffixed with the width and height.