### PR TITLE
Scan simulation: Check PVs

### DIFF
--- a/app/scan/model/src/main/java/org/csstudio/scan/info/SimulationResult.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/info/SimulationResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,15 @@ package org.csstudio.scan.info;
 /** Result of a scan simulation
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class SimulationResult
 {
-    final private double simulation_seconds;
+    /** Prefix used for error lines in the log */
+    public static String ERROR = "ERROR: ";
 
-    final private String simulation_log;
+    private final double simulation_seconds;
+
+    private final String simulation_log;
 
     /** Initialize
      *

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/simulation/SimulationDisplay.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/simulation/SimulationDisplay.java
@@ -26,8 +26,10 @@ import org.phoebus.ui.javafx.ImageCache;
 import javafx.application.Platform;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
+import javafx.scene.paint.Color;
 import javafx.stage.FileChooser.ExtensionFilter;
 
 /** Display {@link SimulationResult}
@@ -68,10 +70,30 @@ public class SimulationDisplay implements AppInstance
     // </commands>
     private final ListView<String> log = new ListView<>();
 
+    /** List cell that highlights 'error' lines */
+    private static class ColoredLine extends ListCell<String>
+    {
+        @Override
+        protected void updateItem(final String line, final boolean empty)
+        {
+            super.updateItem(line, empty);
+            if (line == null  ||  empty)
+                setText("");
+            else
+            {
+                setText(line);
+                if (line.startsWith(SimulationResult.ERROR))
+                    setTextFill(Color.DARKRED);
+                else
+                    setTextFill(Color.BLACK);            }
+        }
+    }
+
     public SimulationDisplay(final SimulationDisplayApplication app)
     {
         this.app = app;
 
+        log.setCellFactory(view -> new ColoredLine());
         log.setPlaceholder(new Label("Getting scan simulation..."));
         final DockItem tab = new DockItem(this, log);
         DockPane.getActiveDockPane().addTab(tab);

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/SimulationContext.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/SimulationContext.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import org.csstudio.scan.info.SimulationResult;
 import org.csstudio.scan.server.condition.WaitForDevicesCondition;
 import org.csstudio.scan.server.config.ScanConfig;
 import org.csstudio.scan.server.device.Device;
@@ -110,6 +111,15 @@ public class SimulationContext
         return device;
     }
 
+    /** Add error line to the simulation log
+     *  @param error Line describing the error
+     */
+    public void logError(final String error)
+    {
+        log_stream.print(SimulationResult.ERROR);
+        log_stream.println(error);
+    }
+
     /** Log information about the currently simulated command
      *  @param info End-user readable description what the command would do when executed
      *  @param seconds Estimated time in seconds that the command would take if executed
@@ -141,7 +151,7 @@ public class SimulationContext
             if (! connect.await(timeout.toMillis(), TimeUnit.MILLISECONDS))
                 for (Device device : real_devices.getDevices())
                     if (! device.isReady())
-                        log_stream.println("ERROR: Cannot access " + device);
+                        logError("Cannot access " + device);
 
             // Simulate commands
             simulate(scan);

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/device/SimulatedDevice.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/device/SimulatedDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -77,6 +77,7 @@ public class SimulatedDevice extends Device
     @Override
     public void write(final Object value) throws Exception
     {
+        // TODO Throw exception if value outside of permitted range
         if (value instanceof Number)
             this.value = VDouble.of( ((Number) value).doubleValue(), Alarm.none(), Time.now(), Display.none() );
         fireDeviceUpdate();

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2013-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,6 +62,7 @@ public class SimulateServlet extends HttpServlet
             final SimulationResult simulation = scan_server.simulateScan(scan_commands);
             // Return scan ID
             out.println("<simulation>");
+            // TODO Add separate <errors> section
             out.print("  <log>");
             out.print("<![CDATA[");
             out.print(simulation.getSimulationLog());

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -62,7 +62,6 @@ public class SimulateServlet extends HttpServlet
             final SimulationResult simulation = scan_server.simulateScan(scan_commands);
             // Return scan ID
             out.println("<simulation>");
-            // TODO Add separate <errors> section
             out.print("  <log>");
             out.print("<![CDATA[");
             out.print(simulation.getSimulationLog());

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ScanServerImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ScanServerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2019 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,6 +135,7 @@ public class ScanServerImpl implements ScanServer
     public SimulationResult simulateScan(final String commands_as_xml)
             throws Exception
     {
+        logger.log(Level.INFO, "Starting simulation...");
         try
         (   // Create Jython interpreter for this scan
             final JythonSupport jython = new JythonSupport();
@@ -153,7 +154,7 @@ public class ScanServerImpl implements ScanServer
 
             // Simulate
             final SimulationContext simulation = new SimulationContext(jython, log_out);
-            simulation.simulate(scan);
+            simulation.performSimulation(scan);
 
             // Close log
             log_out.println("--------");
@@ -169,6 +170,7 @@ public class ScanServerImpl implements ScanServer
             scan.clear();
             commands.clear();
 
+            logger.log(Level.INFO, "Completed simulation.");
             return new SimulationResult(simulation.getSimulationSeconds(), log_text);
         }
         catch (Exception ex)

--- a/services/scan-server/src/main/resources/examples/scan_config.xml
+++ b/services/scan-server/src/main/resources/examples/scan_config.xml
@@ -46,7 +46,8 @@
        This check, however, needs to read the current value of the PV,
        so it also needs some timeout.
        Similarly, the Log command uses this timeout to fetch the current
-       value of the devices to log.
+       value of the devices to log
+       and the simulation uses this to await the connection of all PVs.
    -->
   <read_timeout>20</read_timeout>
   

--- a/services/scan-server/src/test/java/org/csstudio/scan/server/WaitForDevicesTest.java
+++ b/services/scan-server/src/test/java/org/csstudio/scan/server/WaitForDevicesTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.scan.server;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.csstudio.scan.device.DeviceInfo;
+import org.csstudio.scan.server.condition.WaitForDevicesCondition;
+import org.csstudio.scan.server.device.DeviceContext;
+import org.junit.Test;
+
+/** Junit test of {@link WaitForDevicesCondition}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class WaitForDevicesTest
+{
+    @Test
+    public void testWaitForDevices() throws Exception
+    {
+        final DeviceContext devices = new DeviceContext();
+        devices.addPVDevice(new DeviceInfo("loc://x(1)"));
+        devices.addPVDevice(new DeviceInfo("loc://y(2)"));
+
+        devices.startDevices();
+        try
+        {
+            final WaitForDevicesCondition connect = new WaitForDevicesCondition(devices.getDevices());
+            final long start = System.currentTimeMillis();
+            final boolean connected = connect.await(5, TimeUnit.SECONDS);
+            final long end = System.currentTimeMillis();
+            System.out.println("Connected to local PVs within " + (end-start) + "ms");
+            assertThat(connected, equalTo(true));
+        }
+        finally
+        {
+            devices.stopDevices();
+        }
+    }
+
+    @Test
+    public void testTimeoutDevices() throws Exception
+    {
+        final DeviceContext devices = new DeviceContext();
+        devices.addPVDevice(new DeviceInfo("loc://x(1)"));
+        devices.addPVDevice(new DeviceInfo("bogus_pv_name"));
+
+        devices.startDevices();
+        try
+        {
+            final WaitForDevicesCondition connect = new WaitForDevicesCondition(devices.getDevices());
+            final long start = System.currentTimeMillis();
+            final boolean connected = connect.await(3, TimeUnit.SECONDS);
+            final long end = System.currentTimeMillis();
+            System.out.println("Timed out after " + (end-start) + "ms");
+            assertThat(connected, equalTo(false));
+        }
+        finally
+        {
+            devices.stopDevices();
+        }
+    }
+}


### PR DESCRIPTION
Simulation checks if all PVs referenced by a scan are accessible.
Warns about missing PVs, then simulates as before.