### PR TITLE
Display Builder Editor - icon for MultiLineInputDialog on text proper…

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -452,7 +452,7 @@ public class PropertyPanelSection extends GridPane
                 final Button open_editor = new Button("...");
                 open_editor.setOnAction(event ->
                 {
-                    final MultiLineInputDialog dialog = new MultiLineInputDialog(macro_prop.getSpecification());
+                    final MultiLineInputDialog dialog = new MultiLineInputDialog(open_editor, macro_prop.getSpecification());
                     DialogHelper.positionDialog(dialog, open_editor, -600, 0);
                     final Optional<String> result = dialog.showAndWait();
                     if (!result.isPresent())


### PR DESCRIPTION
…ties
Related generally to #896.
A small correction in Editor - get the proper dialog icon.