### PR TITLE
XYPlot: Support changing trace name

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import javafx.scene.control.Button;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -52,6 +49,7 @@ import org.epics.vtype.VNumberArray;
 import org.epics.vtype.VType;
 import org.phoebus.ui.javafx.UpdateThrottle;
 
+import javafx.scene.control.Button;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 
@@ -253,7 +251,8 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
 
         private void traceChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
         {
-            trace.setName(model_trace.traceName().getValue());
+            // Changed trace name requires layout of axes and legend
+            boolean need_layout = trace.setName(model_trace.traceName().getValue());
             trace.setType(map(model_trace.traceType().getValue()));
             trace.setColor(JFXUtil.convert(model_trace.traceColor().getValue()));
             trace.setWidth(model_trace.traceWidth().getValue());
@@ -265,7 +264,10 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
             final int desired = model_trace.traceYAxis().getValue();
             if (desired != trace.getYAxis())
                 plot.moveTrace(trace, desired);
-            plot.requestUpdate();
+            if (need_layout)
+                plot.requestCompleteUpdate();
+            else
+                plot.requestUpdate();
         };
 
         // PV changed value -> runtime updated X/Y value property -> valueChanged()

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -521,7 +521,8 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
         plot.setUpdateThrottle(dormant_time, unit);
     }
 
-    // Used to request a complete redraw of the plot with new layout of node,
+    // requestCompleteUpdate() used to be called 'requestLayout', overriding the JFX method,
+    // to also request a complete redraw of the plot with new layout of node,
     // but that creates loops:
     // layout -> compute new image -> set image -> trigger another layout
     // @Override
@@ -530,7 +531,13 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
     //     plot.requestLayout();
     // }
 
-    /** Request a complete redraw of the plot */
+    /** Request a complete redraw of the plot after new layout */
+    public void requestCompleteUpdate()
+    {
+        plot.requestLayout();
+    }
+
+    /** Request a complete redraw of the plot with current layout */
     public void requestUpdate()
     {
         plot.requestUpdate();

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Trace.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Trace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,10 @@ public interface Trace<XTYPE extends Comparable<XTYPE>>
     /** @return Name, i.e. label of this trace */
     public String getName();
 
-    /** @param name Name, i.e. label of this trace */
-    public void setName(final String name);
+    /** @param name Name, i.e. label of this trace
+     *  @return Did the name change?
+     */
+    public boolean setName(final String name);
 
     /** @return Units, may be "" */
     public String getUnits();

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/TraceImpl.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/TraceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -96,9 +96,12 @@ public class TraceImpl<XTYPE extends Comparable<XTYPE>> implements Trace<XTYPE>
 
     /** {@inheritDoc} */
     @Override
-    public void setName(final String name)
+    public boolean setName(final String name)
     {
-        this.name = Objects.requireNonNull(name);
+        if (this.name.equals(Objects.requireNonNull(name)))
+            return false;
+        this.name = name;
+        return true;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
If trace names change at runtime (rare, requires a script, but possible), this now triggers a re-layout to get correct legend placing.
Before, a lengthened trace name would overlap the following trace name in the legend.
 