### PR TITLE
Cf patches

### DIFF
--- a/app/channel/views/.classpath
+++ b/app/channel/views/.classpath
@@ -7,6 +7,8 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-types"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/app-channel-channelfinder"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/app-channel-utility"/>
 </classpath>

--- a/app/channel/views/pom.xml
+++ b/app/channel/views/pom.xml
@@ -27,5 +27,15 @@
       <artifactId>core-ui</artifactId>
       <version>4.6.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-pv</artifactId>
+      <version>4.6.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-types</artifactId>
+      <version>4.6.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ChannelTree.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ChannelTree.java
@@ -33,6 +33,9 @@ public class ChannelTree implements AppInstance {
             tab = new DockItem(this, loader.load());
             controller = loader.getController();
             controller.setClient(app.getClient());
+            tab.addClosedNotification(() -> {
+                controller.dispose();
+            });
             DockPane.getActiveDockPane().addTab(tab);
         } catch (IOException e) {
             Logger.getLogger(getClass().getName()).log(Level.WARNING, "Cannot load UI", e);

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelFinderController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelFinderController.java
@@ -11,8 +11,8 @@ import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import javafx.application.Platform;
 
 /**
- * A basic controller for any ui performing channelfinder queries. The
- * controller takes care of performing the query off the ui thread using
+ * A basic controller for any UI performing channelfinder queries. The
+ * controller takes care of performing the query off the UI thread using
  * {@link Job}s and then invokes the setChannels method on the UI thread after
  * the query has been completed.
  * 
@@ -43,5 +43,9 @@ public abstract class ChannelFinderController {
 
     }
 
+    /**
+     * Set a new list of channels. This method is called after the successful execution of a channelfinder query. 
+     * @param channels - the new list of channels
+     */
     public abstract void setChannels(Collection<Channel> channels);
 }

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
@@ -13,10 +13,8 @@ import org.phoebus.channelfinder.Property;
 import org.phoebus.channelfinder.Tag;
 import org.phoebus.channelfinder.utility.AddProperty2ChannelsJob;
 import org.phoebus.channelfinder.utility.AddTag2ChannelsJob;
-import org.phoebus.channelfinder.utility.ChannelSearchJob;
 import org.phoebus.channelfinder.utility.RemovePropertyChannelsJob;
 import org.phoebus.channelfinder.utility.RemoveTagChannelsJob;
-import org.phoebus.framework.adapter.AdapterFactory;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.selection.SelectionService;
@@ -25,7 +23,6 @@ import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
-import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyModel.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyModel.java
@@ -22,6 +22,8 @@ class ChannelTreeByPropertyModel {
     private ChannelTreeByPropertyNode root;
     final String query;
     private final boolean showChannelNames;
+    // Flag instructing the model to connect to the leaf pv's
+    private final boolean connect;
 
     List<Channel> allChannels;
     List<String> properties;
@@ -30,7 +32,7 @@ class ChannelTreeByPropertyModel {
     List<PV> nodePVs;
     Map<String, VType> nodePVValues;
 
-    public ChannelTreeByPropertyModel(String query, Collection<Channel> allChannels, List<String> properties, boolean showChannelNames) {
+    public ChannelTreeByPropertyModel(String query, Collection<Channel> allChannels, List<String> properties, boolean showChannelNames, boolean connect) {
         if (allChannels == null) {
             allChannels = Collections.emptyList();
         }
@@ -45,6 +47,7 @@ class ChannelTreeByPropertyModel {
 
         this.query = query;
         this.showChannelNames = showChannelNames;
+        this.connect = connect;
         this.root = new ChannelTreeByPropertyNode(this, null, query);
     }
 
@@ -54,6 +57,10 @@ class ChannelTreeByPropertyModel {
 
     public boolean isShowChannelNames() {
         return showChannelNames;
+    }
+
+    public boolean isConnect() {
+        return connect;
     }
 
     public void dispose() {

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyModel.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyModel.java
@@ -3,18 +3,32 @@ package org.phoebus.channel.views.ui;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.epics.vtype.VType;
 import org.phoebus.channelfinder.Channel;
 import org.phoebus.channelfinder.ChannelUtil;
+import org.phoebus.pv.PV;
+import org.phoebus.pv.PVPool;
 
+/**
+ * Model for the Channel Tree built using properties
+ * @author Kunal Shroff
+ */
 class ChannelTreeByPropertyModel {
 
-    List<Channel> allChannels;
-    List<String> properties;
     private ChannelTreeByPropertyNode root;
     final String query;
     private final boolean showChannelNames;
+
+    List<Channel> allChannels;
+    List<String> properties;
+    
+    // PVs represented by this three
+    List<PV> nodePVs;
+    Map<String, VType> nodePVValues;
 
     public ChannelTreeByPropertyModel(String query, Collection<Channel> allChannels, List<String> properties, boolean showChannelNames) {
         if (allChannels == null) {
@@ -25,6 +39,10 @@ class ChannelTreeByPropertyModel {
         // have a value for all properties
         this.allChannels = new ArrayList<Channel>(ChannelUtil.filterbyProperties(allChannels, properties));
         this.properties = properties;
+
+        this.nodePVs = new ArrayList<PV>();
+        this.nodePVValues = new HashMap<String, VType>();
+
         this.query = query;
         this.showChannelNames = showChannelNames;
         this.root = new ChannelTreeByPropertyNode(this, null, query);
@@ -36,5 +54,10 @@ class ChannelTreeByPropertyModel {
 
     public boolean isShowChannelNames() {
         return showChannelNames;
+    }
+
+    public void dispose() {
+        nodePVs.forEach(pv -> PVPool.releasePV(pv));
+        nodePVs.clear();
     }
 }

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
@@ -40,6 +40,13 @@ public class ChannelTreeByPropertyNode {
     // Parent of the node, or null if root
     private final ChannelTreeByPropertyNode parentNode;
 
+    /**
+     * Create the node in the channel tree ordered by a set of properties
+     * @param model
+     * @param parentNode
+     * @param displayName
+     * @param connect
+     */
     public ChannelTreeByPropertyNode(ChannelTreeByPropertyModel model, ChannelTreeByPropertyNode parentNode, String displayName) {
         this.model = model;
         this.parentNode = parentNode;
@@ -63,16 +70,18 @@ public class ChannelTreeByPropertyNode {
             for (Channel channel : parentNode.nodeChannels) {
                 if (this.displayName.equals(channel.getName())) {
                     nodeChannels.add(channel);
-                    try {
-                        final PV pv = PVPool.getPV(channel.getName());
-                        pv.onValueEvent().throttleLatest(100, TimeUnit.MILLISECONDS).subscribe(value -> {
-                            this.model.nodePVValues.put(pv.getName(), value);
-                        });
-                        this.model.nodePVs.add(pv);
-                    } catch (Exception e) {
-                        e.printStackTrace();
+                    if(this.model.isConnect())
+                    {
+                        try {
+                            final PV pv = PVPool.getPV(channel.getName());
+                            pv.onValueEvent().throttleLatest(100, TimeUnit.MILLISECONDS).subscribe(value -> {
+                                this.model.nodePVValues.put(pv.getName(), value);
+                            });
+                            this.model.nodePVs.add(pv);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
                     }
-                    
                 }
             }
         } else {

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
@@ -132,30 +132,32 @@ public class ChannelTreeByPropertyNode {
 
     public String getDisplayName()
     {
-        if (model.nodePVValues.containsKey(displayName))
-        {
-            return displayName + formatVType(model.nodePVValues.get(displayName));
-        }
         return displayName;
     }
-    
+
+    public String getDisplayValue()
+    {
+        if (model.nodePVValues.containsKey(displayName))
+        {
+            return formatVType(model.nodePVValues.get(displayName));
+        }
+        return null;
+    }
+
     private String formatVType(VType value )
     {
         Alarm alarm = Alarm.alarmOf(value);
         StringBuffer sb = new StringBuffer();
-        sb.append(" [ ")
-          .append(FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true));
+        sb.append(FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true));
         if (!alarm.getSeverity().equals(AlarmSeverity.NONE)) 
         {
-            sb.append(" ");
             sb.append(alarm.getSeverity().toString());
         }
         if (!alarm.getStatus().equals(AlarmStatus.NONE))
         {
-            sb.append(" ");
+            sb.append(" - ");
             sb.append(alarm.getStatus().toString());
         }
-        sb.append(" ] ");
         return sb.toString();
     }
 

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeByPropertyNode.java
@@ -5,9 +5,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmSeverity;
+import org.epics.vtype.AlarmStatus;
+import org.epics.vtype.VType;
 import org.phoebus.channelfinder.Channel;
 import org.phoebus.channelfinder.ChannelUtil;
+import org.phoebus.pv.PV;
+import org.phoebus.pv.PVPool;
+import org.phoebus.ui.vtype.FormatOption;
+import org.phoebus.ui.vtype.FormatOptionHandler;
 
 public class ChannelTreeByPropertyNode {
 
@@ -17,11 +26,12 @@ public class ChannelTreeByPropertyNode {
 
     // Channels represented by this node and down
     private List<Channel> nodeChannels;
+
     // 0 for root, 1 for children, 2 for grandchildren...
     private final int depth;
-    // null for root, first property value for children, second property value
-    // for grandchildren,
-    // channelName for leaf
+    // null for root,
+    // first property value for children, second property value for grandchildren,....
+    // channelName (pv value) for leaf
     private final String displayName;
     // Next property value for root and descendents, names of channels for first
     // to last node,
@@ -53,6 +63,16 @@ public class ChannelTreeByPropertyNode {
             for (Channel channel : parentNode.nodeChannels) {
                 if (this.displayName.equals(channel.getName())) {
                     nodeChannels.add(channel);
+                    try {
+                        final PV pv = PVPool.getPV(channel.getName());
+                        pv.onValueEvent().throttleLatest(100, TimeUnit.MILLISECONDS).subscribe(value -> {
+                            this.model.nodePVValues.put(pv.getName(), value);
+                        });
+                        this.model.nodePVs.add(pv);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    
                 }
             }
         } else {
@@ -87,7 +107,8 @@ public class ChannelTreeByPropertyNode {
      *
      * @return property name or null if leaf node
      */
-    public String getPropertyName() {
+    public String getPropertyName()
+    {
         // Root node does not have any property associated with it
         if (depth == 0)
             return null;
@@ -100,8 +121,33 @@ public class ChannelTreeByPropertyNode {
         return model.properties.get(index);
     }
 
-    public String getDisplayName() {
+    public String getDisplayName()
+    {
+        if (model.nodePVValues.containsKey(displayName))
+        {
+            return displayName + formatVType(model.nodePVValues.get(displayName));
+        }
         return displayName;
+    }
+    
+    private String formatVType(VType value )
+    {
+        Alarm alarm = Alarm.alarmOf(value);
+        StringBuffer sb = new StringBuffer();
+        sb.append(" [ ")
+          .append(FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true));
+        if (!alarm.getSeverity().equals(AlarmSeverity.NONE)) 
+        {
+            sb.append(" ");
+            sb.append(alarm.getSeverity().toString());
+        }
+        if (!alarm.getStatus().equals(AlarmStatus.NONE))
+        {
+            sb.append(" ");
+            sb.append(alarm.getStatus().toString());
+        }
+        sb.append(" ] ");
+        return sb.toString();
     }
 
     public List<String> getChildrenNames() {

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -88,6 +87,9 @@ public class ChannelTreeController extends ChannelFinderController {
         reconstructTree();
     }
 
+    /**
+     * Dispose the existing model, recreate a new one and 
+     */
     @FXML
     private void reconstructTree() {
         dispose();

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
@@ -20,6 +20,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SelectionMode;
@@ -43,7 +44,7 @@ public class ChannelTreeController extends ChannelFinderController {
     @FXML
     Button configure;
     @FXML
-    Button connect;
+    CheckBox connect;
     @FXML
     TreeView<ChannelTreeByPropertyNode> treeView;
 
@@ -53,10 +54,7 @@ public class ChannelTreeController extends ChannelFinderController {
 
     @FXML
     public void initialize() {
-
-        if(model != null) {
-            model.dispose();
-        }
+        dispose();
         treeView.setCellFactory(f -> new ChannelTreeCell());
         treeView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         treeView.getSelectionModel().selectedItemProperty().addListener((obs, oldSelection, newSelection) -> {
@@ -68,7 +66,10 @@ public class ChannelTreeController extends ChannelFinderController {
 
     @FXML
     public void dispose() {
-        model.dispose();
+        if(model != null)
+        {
+            model.dispose();
+        }
     }
 
     public void setQuery(String string) {
@@ -87,13 +88,13 @@ public class ChannelTreeController extends ChannelFinderController {
         reconstructTree();
     }
 
+    @FXML
     private void reconstructTree() {
-        if (model != null)
-            model.dispose();
-        model = new ChannelTreeByPropertyModel(query.getText(), channels, orderedProperties, true);
+        dispose();
+        model = new ChannelTreeByPropertyModel(query.getText(), channels, orderedProperties, true, connect.isSelected());
         ChannelTreeItem root = new ChannelTreeItem(model.getRoot());
         treeView.setRoot(root);
-        connect();
+        refreshPvValues();
     }
 
     /**
@@ -114,11 +115,10 @@ public class ChannelTreeController extends ChannelFinderController {
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     /**
-     * Connect the pv's and append their live values to the tree view of the
+     * Refreshes the values of the leaf pv's and append their live values to the tree view of the
      * channels.
      */
-    @FXML
-    public void connect() {
+    public void refreshPvValues() {
         scheduler.scheduleAtFixedRate(treeView::refresh, 0, 400, TimeUnit.MILLISECONDS);
     }
 

--- a/app/channel/views/src/main/resources/org/phoebus/channel/views/ui/ChannelTree.fxml
+++ b/app/channel/views/src/main/resources/org/phoebus/channel/views/ui/ChannelTree.fxml
@@ -5,7 +5,8 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TreeView?>
+<?import javafx.scene.control.TreeTableColumn?>
+<?import javafx.scene.control.TreeTableView?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
@@ -37,11 +38,19 @@
          <GridPane.margin>
             <Insets left="2.0" right="2.0" />
          </GridPane.margin></Button>
-    <TreeView fx:id="treeView" onContextMenuRequested="#createContextMenu" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="5" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="ALWAYS" />
       <CheckBox fx:id="connect" mnemonicParsing="false" onAction="#reconstructTree" text="Show Values" GridPane.columnIndex="4">
          <GridPane.margin>
             <Insets left="2.0" right="2.0" />
          </GridPane.margin>
       </CheckBox>
+      <TreeTableView fx:id="treeTableView" onContextMenuRequested="#createContextMenu" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="5" GridPane.rowIndex="1">
+        <columns>
+          <TreeTableColumn fx:id="node" minWidth="150.0" prefWidth="150.0" />
+          <TreeTableColumn fx:id="value" minWidth="100.0" prefWidth="100.0" />
+        </columns>
+         <columnResizePolicy>
+            <TreeTableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+         </columnResizePolicy>
+      </TreeTableView>
   </children>
 </GridPane>

--- a/app/channel/views/src/main/resources/org/phoebus/channel/views/ui/ChannelTree.fxml
+++ b/app/channel/views/src/main/resources/org/phoebus/channel/views/ui/ChannelTree.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TreeView?>
@@ -9,26 +10,38 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 
-<GridPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.102" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.channel.views.ui.ChannelTreeController">
+<GridPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.channel.views.ui.ChannelTreeController">
   <columnConstraints>
     <ColumnConstraints minWidth="10.0" prefWidth="60.0" />
     <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
-    <ColumnConstraints minWidth="10.0" prefWidth="60" />
-      <ColumnConstraints minWidth="10.0" prefWidth="100.0" />
+    <ColumnConstraints minWidth="50.0" />
+      <ColumnConstraints minWidth="50.0" />
+      <ColumnConstraints minWidth="50.0" />
   </columnConstraints>
   <rowConstraints>
     <RowConstraints minHeight="10.0" prefHeight="30.0" />
     <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="ALWAYS" />
   </rowConstraints>
   <children>
-    <Label maxHeight="-Infinity" minHeight="-Infinity" prefHeight="25.0" text="Query: " GridPane.halignment="RIGHT"  />
-    <TextField fx:id="query" maxHeight="-Infinity" minHeight="-Infinity" onAction="#search" prefHeight="25.0" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="NEVER" />
+    <Label maxHeight="-Infinity" minHeight="-Infinity" prefHeight="25.0" text="Query: " GridPane.halignment="RIGHT" />
+    <TextField fx:id="query" maxHeight="-Infinity" minHeight="-Infinity" onAction="#search" prefHeight="25.0" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="NEVER">
+         <GridPane.margin>
+            <Insets right="2.0" />
+         </GridPane.margin></TextField>
     <Button fx:id="search" maxHeight="-Infinity" minHeight="-Infinity" mnemonicParsing="false" onAction="#search" prefHeight="25.0" text="Search" GridPane.columnIndex="2">
       <GridPane.margin>
-        <Insets left="2.0" />
+        <Insets left="2.0" right="2.0" />
       </GridPane.margin>
     </Button>
-      <Button fx:id="configure" mnemonicParsing="false" onAction="#configure" text="Configure" GridPane.columnIndex="3" />
-    <TreeView fx:id="treeView" onContextMenuRequested="#createContextMenu" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="4" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="ALWAYS" />
+      <Button fx:id="configure" mnemonicParsing="false" onAction="#configure" text="Configure" GridPane.columnIndex="3">
+         <GridPane.margin>
+            <Insets left="2.0" right="2.0" />
+         </GridPane.margin></Button>
+    <TreeView fx:id="treeView" onContextMenuRequested="#createContextMenu" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="5" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="ALWAYS" />
+      <CheckBox fx:id="connect" mnemonicParsing="false" onAction="#reconstructTree" text="Show Values" GridPane.columnIndex="4">
+         <GridPane.margin>
+            <Insets left="2.0" right="2.0" />
+         </GridPane.margin>
+      </CheckBox>
   </children>
 </GridPane>

--- a/core/framework/src/main/java/org/phoebus/framework/adapter/AdapterService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/adapter/AdapterService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
 /**
  * A service which manages the conversion of different types of selection from one type to another.
@@ -21,7 +22,13 @@ public class AdapterService {
 
     private static ServiceLoader<AdapterFactory> loader;
 
+    /**
+     * A map where the key is a type mapped to a list of adapter that can convert to this type.
+     */
     private static Map<Class, List<AdapterFactory>> adapters = new HashMap<Class, List<AdapterFactory>>();
+    /**
+     * A map where the key is a type mapped to a list of adapters that can process this type to other types.
+     */
     private static Map<Class, List<AdapterFactory>> adaptables = new HashMap<Class, List<AdapterFactory>>();
 
     static {
@@ -75,7 +82,9 @@ public class AdapterService {
         if(adapterType.isInstance(adaptableObject)) {
             return Optional.of(adapterType.cast(adaptableObject));
         }
-        List<AdapterFactory> factories = AdapterService.getAdaptersforAdaptable(adapterType);
+        List<AdapterFactory> factories = AdapterService.getAdaptersforAdaptable(adaptableObject.getClass()).stream().filter(factory -> {
+            return factory.getAdapterList().contains(adapterType);
+        }).collect(Collectors.toList());
         return factories.get(0).adapt(adaptableObject, adapterType);
         
     }

--- a/core/framework/src/main/java/org/phoebus/framework/adapter/AdapterService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/adapter/AdapterService.java
@@ -64,8 +64,8 @@ public class AdapterService {
      * @return List of {@link AdapterFactory}s that can handle cls
      */
     public static List<AdapterFactory> getAdaptersforAdaptable(Class cls) {
-        if(adaptables.get(cls.getName()) != null) {
-            return adaptables.get(cls.getName());
+        if(adaptables.get(cls) != null) {
+            return adaptables.get(cls);
         } else {
             return Collections.emptyList();
         }

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
@@ -41,9 +41,13 @@ public class ContextMenuService {
     }
 
     /**
-     *
-     * @param selectionType
-     * @return
+     * Using the current selection from the {@link SelectionService} and checking
+     * the {@link AdapterService} for all additionally supported types via adapters.
+     * The {@link ContextMenuService} returns a list of context menu actions
+     * supported for the current selection.
+     * 
+     * @return A list of {@link ContextMenuEntry}'s supported for the current
+     *         selection
      */
     public List<ContextMenuEntry> listSupportedContextMenuEntries() {
         // List of types of the current selection


### PR DESCRIPTION
Update channel finder views
1. the cf tree now has the ability to connect to the underlying pv's and show the live values in the tree. The pv connections are only created when the node is expanded however the disposing of the pv's only happens when the tree recreated.


![image](https://user-images.githubusercontent.com/2111304/72094440-70863f80-32e4-11ea-82b9-fc820e8f18b3.png)

2. the context menu have been fixed and updated to properly use the selection service and the adapter service.

