### PR TITLE
PV range

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -265,8 +265,18 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
             final Display display_info = Display.displayOf(model_widget.runtimePropValue().getValue());
             if (display_info != null)
             {
-                new_min = display_info.getControlRange().getMinimum();
-                new_max = display_info.getControlRange().getMaximum();
+                // Should use the 'control' range but fall back to 'display' range
+                if (display_info.getControlRange().isFinite())
+                {
+                    new_min = display_info.getControlRange().getMinimum();
+                    new_max = display_info.getControlRange().getMaximum();
+                }
+                else
+                {
+                    new_min = display_info.getDisplayRange().getMinimum();
+                    new_max = display_info.getDisplayRange().getMaximum();
+                    // May also be empty, will fall back to 0..100
+                }
 
                 new_lolo = display_info.getAlarmRange().getMinimum();
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
@@ -245,8 +245,17 @@ public class ScrollBarRepresentation extends RegionBaseRepresentation<ScrollBar,
             final Display display_info = Display.displayOf(model_widget.runtimePropValue().getValue());
             if (display_info != null)
             {
-                min_val = display_info.getControlRange().getMinimum();
-                max_val = display_info.getControlRange().getMaximum();
+                // Use control range, falling back to display
+                if (display_info.getControlRange().isFinite())
+                {
+                    min_val = display_info.getControlRange().getMinimum();
+                    max_val = display_info.getControlRange().getMaximum();
+                }
+                else
+                {
+                    min_val = display_info.getDisplayRange().getMinimum();
+                    max_val = display_info.getDisplayRange().getMaximum();
+                }
                 final double delta = ( max_val - min_val );
                 block_val = delta / 10.0;
                 step_val = delta / 100.0;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -469,14 +469,18 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
 
             if (display_info != null)
             {
-                double infoMin = display_info.getControlRange().getMinimum();
-                double infoMax = display_info.getControlRange().getMaximum();
-
-                if (!Double.isNaN(infoMin) && !Double.isNaN(infoMax) && infoMin < infoMax)
+                // Use control range, falling back to display
+                if (display_info.getControlRange().isFinite())
                 {
-                    newMin = infoMin;
-                    newMax = infoMax;
+                    newMin = display_info.getControlRange().getMinimum();
+                    newMax = display_info.getControlRange().getMaximum();
                 }
+                else if (display_info.getDisplayRange().isFinite())
+                {
+                    newMin = display_info.getDisplayRange().getMinimum();
+                    newMax = display_info.getDisplayRange().getMaximum();
+                }
+                // else: Leave at 0..100
             }
         }
 

--- a/app/probe/src/main/java/org/phoebus/applications/probe/Messages.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/Messages.java
@@ -20,7 +20,9 @@ public class Messages
     // ---
     public static String Alarm;
     public static String Alarms;
+    public static String ControlRange;
     public static String Copy;
+    public static String DisplayRange;
     public static String EnumLbls;
     public static String Format;
     public static String Precision;
@@ -29,7 +31,6 @@ public class Messages
     public static String ProbeMenuPath;
     public static String PromptTxt;
     public static String PvNameLbl;
-    public static String Range;
     public static String Search;
     public static String TimeStamp;
     public static String Units;

--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -330,7 +330,8 @@ public class ProbeController {
             final Display dis = ((VNumber) value).getDisplay();
             buf.append(Messages.Units).append(dis.getUnit()).append("\n");
             buf.append(Messages.Format).append(dis.getFormat().format(0.123456789)).append("\n");
-            buf.append(Messages.Range).append(dis.getControlRange().getMinimum()).append(" .. ").append(dis.getControlRange().getMaximum()).append("\n");
+            buf.append(Messages.DisplayRange).append(dis.getDisplayRange().getMinimum()).append(" .. ").append(dis.getDisplayRange().getMaximum()).append("\n");
+            buf.append(Messages.ControlRange).append(dis.getControlRange().getMinimum()).append(" .. ").append(dis.getControlRange().getMaximum()).append("\n");
             buf.append(Messages.Warnings).append(dis.getWarningRange().getMinimum()).append(" .. ").append(dis.getWarningRange().getMaximum()).append("\n");
             buf.append(Messages.Alarms).append(dis.getAlarmRange().getMinimum()).append(" .. ").append(dis.getAlarmRange().getMaximum()).append("\n");
         }

--- a/app/probe/src/main/resources/org/phoebus/applications/probe/messages.properties
+++ b/app/probe/src/main/resources/org/phoebus/applications/probe/messages.properties
@@ -1,6 +1,8 @@
 Alarm=Alarm:
 Alarms=Alarms: 
+ControlRange=Control Range: 
 Copy=Copy PV to Clipboard
+DisplayRange=Display Range: 
 EnumLbls=Enumeration Labels:
 Format=Format: 
 Metadata=Metadata:
@@ -9,7 +11,6 @@ Probe=Probe
 ProbeMenuPath=Display
 PromptTxt=Enter PV Name
 PvNameLbl=PV Name: 
-Range=Range: 
 Search=Search
 TimeStamp=Time Stamp:
 Units=Units: 


### PR DESCRIPTION
 * Indicate both 'display' and 'control' range in Probe
 * Control widgets always used the 'control' range, but will now fall back to the 'display' range in case the ctrl range is empty

Displaying both ranges in probe is clearly useful.

The 'control' widgets should use the 'control' range, and still will when the records are correctly configured. EDM, however, always used the 'display' range, allowing established sites to leave the control limits undefined. By falling back to the 'display' range, (auto) converted EDM displays are allowed to function.