### PR TITLE
CSSTUDIO-1189 action target Standalone not handled correctly in edit …

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/ActionsDialog.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/ActionsDialog.java
@@ -428,7 +428,12 @@ public class ActionsDialog extends Dialog<ActionInfos>
         {
             open_display_description.setText(info.getDescription());
             open_display_path.setText(info.getFile());
-            open_display_targets.getToggles().get(info.getTarget().ordinal()).setSelected(true);
+            // Mapping is needed if bob file was created in CS Studio/Eclipse
+            Target target = info.getTarget();
+            if(target.equals(Target.STANDALONE)){
+                target = Target.WINDOW;
+            }
+            open_display_targets.getToggles().get(target.ordinal()).setSelected(true);
             open_display_pane.setText(info.getPane());
             open_display_macros.setMacros(info.getMacros());
         }


### PR DESCRIPTION
Bob files created in Display Builder in CS Studio/Eclipse specifying "Standalone" as the open display action target trigger an exception when action dialog is opened.

This fixes the issue.