### PR TITLE
Csstudio 1188 Empty CD URL trigger exceptions

### DIFF
--- a/app/channel/channelfinder/src/main/java/org/phoebus/channelfinder/ChannelFinderClientImpl.java
+++ b/app/channel/channelfinder/src/main/java/org/phoebus/channelfinder/ChannelFinderClientImpl.java
@@ -232,6 +232,10 @@ public class ChannelFinderClientImpl implements ChannelFinderClient {
          * @return {@link ChannelFinderClientImpl}
          */
         public ChannelFinderClient create() throws ChannelFinderException {
+            if(this.uri == null || this.uri.toString().isEmpty()){
+                log.warning("Cannot create a channel finder client as URL is null or empty");
+                return null;
+            }
             log.info("Creating a channelfinder client to : " + this.uri);
             if (this.protocol.equalsIgnoreCase("http")) { //$NON-NLS-1$
                 this.clientConfig = new DefaultClientConfig();

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/autocomplete/CFProposalProvider.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/autocomplete/CFProposalProvider.java
@@ -24,10 +24,15 @@ public class CFProposalProvider implements PVProposalProvider {
     private static final Logger log = Logger.getLogger(CFProposalProvider.class.getName());
     private ChannelFinderClient client = null;
     private boolean active = true;
+    private static List<Proposal> EMPTY_RESULT = Collections.emptyList();
 
     public CFProposalProvider() {
         if (client == null) {
             client = ChannelFinderService.getInstance().getClient();
+            if(client == null){
+                log.log(Level.WARNING, "CF proposal provider got null CF client!");
+                return;
+            }
             try {
                 client.getAllTags();
             } catch (Exception e) {
@@ -46,6 +51,9 @@ public class CFProposalProvider implements PVProposalProvider {
 
     @Override
     public List<Proposal> lookup(String searchString) {
+        if(client == null){
+            return EMPTY_RESULT;
+        }
         // TODO this needs the v3.0.2 of channelfinder
         if (active) {
             Map<String, String> searchMap = new HashMap<String, String>();

--- a/app/save-and-restore/ui/pom.xml
+++ b/app/save-and-restore/ui/pom.xml
@@ -123,7 +123,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.23.4</version>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/core/framework/pom.xml
+++ b/core/framework/pom.xml
@@ -13,5 +13,11 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <openjfx.version>13.0.1</openjfx.version>
     <jackson.version>2.10.1</jackson.version>
     <batik.version>1.12</batik.version>
+    <mockito.version>2.23.4</mockito.version>
     <!--<maven.repo.local>${project.build.directory}/.m2</maven.repo.local> -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -31,6 +31,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
An empty CF URL trigger exceptions and breaks editor for widgets supporting a PV property.

Admittedly a corner case, but fixed here anyways.

Also some corrections to pom files with references to Mockito.