### PR TITLE
databrowser: Save font settings

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/XMLPersistence.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/XMLPersistence.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -445,6 +445,7 @@ public class XMLPersistence
         if (style.contains("italic"))
             code |= 2;
         buf.append(code);
+        writer.writeCharacters(buf.toString());
         writer.writeEndElement();
     }
 


### PR DESCRIPTION
Fix bug that omitted actual font info from <xxx_font> tags.
Was importing fonts from *.plt files alright, but wrote empty <xxx_font> tags.