### PR TITLE
Display Builder: Boy import issues

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.prefs.BackingStoreException;
@@ -401,11 +401,13 @@ public class EditorGUI
         {
             // Enable/disable menu entries based on selection
             final List<Widget> widgets = editor.getWidgetSelectionHandler().getSelection();
+            final MenuItem delete = new ActionWapper(ActionDescription.DELETE);
             final MenuItem cut = new ActionWapper(ActionDescription.CUT);
             final MenuItem copy = new ActionWapper(ActionDescription.COPY);
             final MenuItem group = new CreateGroupAction(editor, widgets);
             if (widgets.size() < 0)
             {
+                delete.setDisable(true);
                 cut.setDisable(true);
                 copy.setDisable(true);
             }
@@ -417,7 +419,8 @@ public class EditorGUI
                 ungroup = new RemoveGroupAction(editor, null);
                 ungroup.setDisable(true);
             }
-            menu.getItems().setAll(cut,
+            menu.getItems().setAll(delete,
+                                   cut,
                                    copy,
                                    new PasteWidgets(this),
                                    new FindWidgetAction(node, editor),

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ public class Messages
     public static String Copy;
     public static String CreateGroup;
     public static String Cut;
+    public static String Delete;
     public static String Display;
     public static String DisplayApplicationMissingRight;
     public static String DisplayApplicationName;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,17 @@ public abstract class ActionDescription
     };
 
     /** Delete selected widgets */
+    public static final ActionDescription DELETE =
+        new ActionDescription("icons/delete.png", Messages.Delete + " [Delete]")
+    {
+        @Override
+        public void run(final DisplayEditor editor, final boolean selected)
+        {
+            editor.removeWidgets();
+        }
+    };
+
+    /** Delete selected widgets after copying to clipboard */
     public static final ActionDescription CUT =
         new ActionDescription("icons/cut_edit.png", Messages.Cut + " [" + PlatformInfo.SHORTCUT + "-X]")
     {

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -137,6 +137,7 @@ public class DisplayEditorInstance implements AppInstance
     {
         // Depending on number of selected widgets, allow grouping, ungrouping, morphing
         final List<Widget> selection = editor_gui.getDisplayEditor().getWidgetSelectionHandler().getSelection();
+        final ActionWapper delete = new ActionWapper(ActionDescription.DELETE);
         final ActionWapper cut = new ActionWapper(ActionDescription.CUT);
         final ActionWapper copy = new ActionWapper(ActionDescription.COPY);
         final MenuItem copy_properties = new CopyPropertiesAction(editor_gui.getDisplayEditor(), selection);
@@ -147,6 +148,7 @@ public class DisplayEditorInstance implements AppInstance
         final MenuItem front = new ActionWapper(ActionDescription.TO_FRONT);
         if (selection.size() <= 0)
         {
+            delete.setDisable(true);
             cut.setDisable(true);
             copy.setDisable(true);
             // OK to create (resp. 'start') a group with just one widget.
@@ -196,7 +198,8 @@ public class DisplayEditorInstance implements AppInstance
         show_props.setSelected(editor_gui.arePropertiesShown());
         show_props.setOnAction(event -> editor_gui.showProperties(! editor_gui.arePropertiesShown()));
 
-        menu.getItems().setAll(cut,
+        menu.getItems().setAll(delete,
+                               cut,
                                copy,
                                new PasteWidgets(getEditorGUI()),
                                copy_properties,

--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
@@ -10,6 +10,7 @@ AlignTop=Top-align selected widgets
 Copy=Copy
 CreateGroup=Create Group
 Cut=Cut
+Delete=Delete
 Display=Display
 DisplayApplicationMissingRight=Missing user rights to run Display Editor.\nThe application cannot be started.
 DisplayApplicationName=Display Editor

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -240,12 +240,11 @@ public class ModelReader
         return widgets;
     }
 
-    /** Read widget from XML
-     *  @param widget_xml Widget's XML element
-     *  @return Widget
+    /** @param widget_xml Widget's XML element
+     *  @return Widget type name
      *  @throws Exception on error
      */
-    private Widget readWidget(final Element widget_xml) throws Exception
+    private static String getWidgetType(final Element widget_xml) throws Exception
     {
         String type = widget_xml.getAttribute(XMLTags.TYPE);
         if (type.isEmpty())
@@ -256,6 +255,17 @@ public class ModelReader
             if (type.isEmpty())
                 throw new Exception("Missing widget type");
         }
+        return type;
+    }
+
+    /** Read widget from XML
+     *  @param widget_xml Widget's XML element
+     *  @return Widget
+     *  @throws Exception on error
+     */
+    private Widget readWidget(final Element widget_xml) throws Exception
+    {
+        final String type = getWidgetType(widget_xml);
         final Widget widget = createWidget(type, widget_xml);
 
         final ChildrenProperty children = ChildrenProperty.getChildren(widget);
@@ -291,24 +301,24 @@ public class ModelReader
 
     private Widget createPlaceholderWidget(final Element widget_xml)
     {
-        final String type = widget_xml.getAttribute(XMLTags.TYPE);
-        final PlaceholderWidget widget = new PlaceholderWidget(type);
         try
         {
+            final String type = getWidgetType(widget_xml);
+            final PlaceholderWidget widget = new PlaceholderWidget(type);
             logger.log(Level.FINE, "Adding placeholder PlaceholderWidget");
             widget.getConfigurator(readVersion(widget_xml)).configureFromXML(this, widget, widget_xml);
+            return widget;
         }
         catch (ParseAgainException ex)
         {
-            return null;
+            // ignore
         }
         catch (Exception ex)
         {
-            // ignore
+            // ignore but log
             logger.log(Level.SEVERE, ex.getMessage() + " while configuring PlaceholderWidget");
         }
-
-        return widget;
+        return null;
     }
 
     /** @param element Element

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,16 +104,36 @@ public class BoolButtonWidget extends WritablePVWidget
             if (! super.configureFromXML(model_reader, widget, xml))
                 return false;
 
-            final BoolButtonWidget button = (BoolButtonWidget) widget;
-            // If legacy widgets was configured to not use labels, clear them
-            XMLUtil.getChildBoolean(xml, "show_boolean_label").ifPresent(show ->
+            // BOY used 1.0.0, this button is at least 2.0.0
+            if (xml_version.getMajor() < 2)
             {
-                if (!show)
+                final BoolButtonWidget button = (BoolButtonWidget) widget;
+
+                // Translate 'toggle_button' into 'mode'.
+                if (! XMLUtil.getChildBoolean(xml, "toggle_button").orElse(true))
+                    button.propMode().setValue(Mode.PUSH);
+
+                // If legacy widgets was configured to not use labels, clear them
+                XMLUtil.getChildBoolean(xml, "show_boolean_label").ifPresent(show ->
                 {
-                    button.propOffLabel().setValue("");
-                    button.propOnLabel().setValue("");
+                    if (!show)
+                    {
+                        button.propOffLabel().setValue("");
+                        button.propOnLabel().setValue("");
+                    }
+                });
+
+                if (! button.propShowLED().getValue())
+                {
+                    // When LED indicator is hidden, BOY filled button with background color.
+                    // This implementation uses the on/off colors, so set those to old background.
+                    WidgetColor color = button.propBackgroundColor().getValue();
+                    button.propOffColor().setValue(color);
+                    // Darken for 'pressed' state
+                    color = new WidgetColor(color.getRed()*80/100, color.getGreen()*80/100, color.getBlue()*80/100);
+                    button.propOnColor().setValue(color);
                 }
-            });
+            }
             return true;
         }
     };

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BorderSupport.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BorderSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBorderColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBorderWidth;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propTransparent;
 
 import java.util.List;
 import java.util.Optional;
@@ -76,6 +77,12 @@ public class BorderSupport
         case  6: // BUTTON_RAISED
         case  7: // BUTTON_PRESSED
             widget.getProperty(propBorderColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
+            break;
+        case 14: // ROUND_RECTANGLE_BACKGROUND
+            // Forced the background color to be used even if 'transparent'
+            widget.checkProperty(propTransparent.getName())
+                  .ifPresent(trans -> trans.setValue(false));
+            break;
         }
 
         // Border used to be inside the bounds,

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -121,7 +121,11 @@ public class TextEntryWidget extends WritablePVWidget
                     // Might be NativeText or TextInput
                     if (type != null  &&  type.contains("Text"))
                     {
+                        // BOY 'TextInput' was at 2.0.0 or higher.
+                        // Down-grade to label 1.0.0 to handle legacy border etc.
+                        // for that version, not mistaking it for a Label version >= 2.0.0
                         xml.setAttribute("typeId", "org.csstudio.opibuilder.widgets.Label");
+                        xml.setAttribute("version", "1.0.0");
                         // XMLUtil.dump(xml);
                         throw new ParseAgainException();
                     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -213,6 +213,15 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         super.unregisterListeners();
     }
 
+    private void computeBackground()
+    {
+        // When LED is off, use the on/off colors for the background
+        if (model_widget.propShowLED().getValue() == false)
+            background = JFXUtil.shadedStyle(on_state == 0 ? model_widget.propOffColor().getValue() : model_widget.propOnColor().getValue());
+        else
+            background = JFXUtil.shadedStyle(model_widget.propBackgroundColor().getValue());
+    }
+
     private void stateChanged()
     {
         on_state = ((use_bit < 0) ? (rt_value != 0) : (((rt_value >> use_bit) & 1) == 1)) ? 1 : 0;
@@ -220,9 +229,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         value_label = state_labels[on_state];
         value_image = state_images[on_state];
 
-        // When LED is off, use the on/off colors for the background
-        if (model_widget.propShowLED().getValue() == false)
-            background = JFXUtil.shadedStyle(on_state == 0 ? model_widget.propOffColor().getValue() : model_widget.propOnColor().getValue());
+        computeBackground();
 
         dirty_value.mark();
         toolkit.scheduleUpdate(this);
@@ -281,7 +288,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
     private void representationChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
         foreground = JFXUtil.convert(model_widget.propForegroundColor().getValue());
-        background = JFXUtil.shadedStyle(model_widget.propBackgroundColor().getValue());
+
         state_colors = new Color[]
         {
             JFXUtil.convert(model_widget.propOffColor().getValue()),
@@ -291,6 +298,9 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         state_labels = new String[] { model_widget.propOffLabel().getValue(), model_widget.propOnLabel().getValue() };
         value_color = state_colors[on_state];
         value_label = state_labels[on_state];
+
+        computeBackground();
+
         dirty_representation.mark();
         toolkit.scheduleUpdate(this);
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,12 +101,19 @@ public class TabsRepresentation extends JFXBaseRepresentation<TabPane, TabsWidge
         if (toolkit.isEditMode())
             tabs.addEventFilter(MouseEvent.MOUSE_PRESSED, event ->
             {
-                for (Parent parent = tabs.getParent();  parent != null;  parent = parent.getParent())
-                    if (JFXRepresentation.MODEL_ROOT_ID.equals(parent.getId()))
-                    {
-                        parent.fireEvent(event);
-                        break;
-                    }
+                // As in 'group' widget, only do this when ALT is pressed,
+                // so ALT-rubberband will select inside the tab.
+                // Plain click still directly reaches the child widget in the current tab,
+                // or - if we hit the background of the tab - the tab widget itself.
+                // If we passed any click up to the model root, you could
+                // longer click on widgets inside the tab or the tab itself.
+                if (event.isAltDown())
+                    for (Parent parent = tabs.getParent();  parent != null;  parent = parent.getParent())
+                        if (JFXRepresentation.MODEL_ROOT_ID.equals(parent.getId()))
+                        {
+                            parent.fireEvent(event);
+                            break;
+                        }
             });
 
         return tabs;


### PR DESCRIPTION
Fixes some BOY display compatibility issues:

TextInput-without-PV-used-as-Label now gets the correct border.
Bool button colors.
Correct type name in 'placeholder' for unsupported BOY types.

While inspecting imported BOY 1_2_WidgetExamples.opi, noticed that Tab widget selection was broken since the 'alt-rubberband' support had been added in #805 