### PR TITLE
MEDM converter

### DIFF
--- a/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
@@ -193,9 +193,14 @@ public class Converter
                     new TextUpdate2Model(adlWidget, colorMap, parentModel);
                 else if (widgetType.equals("valuator"))
                     new Valuator2Model(adlWidget, colorMap, parentModel);
-                // TODO Add all the widgets
+                else if (widgetType.equals("children"))
+                {
+                    // TODO 'children' is not quite the same as 'composite'
+                    new Composite2Model(adlWidget, colorMap, parentModel);
+                }
                 else
                 {
+                    // TODO Add all the widgets
                     logger.log(Level.WARNING, "Ignoring #" + adlWidget.getObjectNr() + " " + widgetType);
                     new Placeholder(adlWidget, colorMap, parentModel);
                 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
@@ -28,6 +28,7 @@ import org.csstudio.opibuilder.adl2boy.translator.ChoiceButton2Model;
 import org.csstudio.opibuilder.adl2boy.translator.Composite2Model;
 import org.csstudio.opibuilder.adl2boy.translator.Display2Model;
 import org.csstudio.opibuilder.adl2boy.translator.Image2Model;
+import org.csstudio.opibuilder.adl2boy.translator.Indicator2Model;
 import org.csstudio.opibuilder.adl2boy.translator.Menu2Model;
 import org.csstudio.opibuilder.adl2boy.translator.MessageButton2Model;
 import org.csstudio.opibuilder.adl2boy.translator.Meter2Model;
@@ -193,6 +194,8 @@ public class Converter
                     new TextUpdate2Model(adlWidget, colorMap, parentModel);
                 else if (widgetType.equals("valuator"))
                     new Valuator2Model(adlWidget, colorMap, parentModel);
+                else if (widgetType.equals("indicator"))
+                    new Indicator2Model(adlWidget, colorMap, parentModel);
                 else if (widgetType.equals("children"))
                 {
                     // TODO 'children' is not quite the same as 'composite'

--- a/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
@@ -233,6 +233,12 @@ public class Converter
             if (output_dir != null)
             {
                 logger.log(Level.INFO, "Copying file " + input + " into " + output_dir);
+                final File target = new File(output_dir, new File(input).getName());
+                if (target.exists() && force)
+                {
+                    logger.log(Level.INFO, "Overwriting existing file " + target);
+                    target.delete();
+                }
                 FileHelper.copy(new File(input), output_dir);
                 return;
             }

--- a/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/display/converter/medm/Converter.java
@@ -323,6 +323,12 @@ public class Converter
             files.remove(0);
         }
 
+        if (output_dir != null  &&  force  && !output_dir.exists())
+        {
+            logger.log(Level.INFO, "Creating output directory " + output_dir);
+            output_dir.mkdirs();
+        }
+
         for (String file : files)
         {
             try

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
@@ -417,10 +417,14 @@ public abstract class AbstractADL2Model<WM extends Widget>
         for (int ii = 0; ii < argList.length; ii++) {
             String[] argParts = argList[ii].split("=");
             if (argParts.length == 1)
-            {   // Pass X=""
-                if (strBuff.length() != 0)
-                    strBuff.append(", ");
-                strBuff.append(argParts[0]).append("=\"\"");
+            {
+                if (! argParts[0].isEmpty())
+                {   // Pass X=""
+                    if (strBuff.length() != 0)
+                        strBuff.append(", ");
+                    strBuff.append(argParts[0]).append("=\"\"");
+                }
+                // else: Empty
             }
             else if (argParts.length == 2)
             {

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
@@ -395,9 +395,7 @@ public abstract class AbstractADL2Model<WM extends Widget>
         try
         {
             String resArgs = removeParentMacros(args);
-            Macros macIn = null;
-            macIn = Macros.fromSimpleSpec(resArgs);
-            return macIn;
+            return Macros.fromSimpleSpec(resArgs);
         }
         catch (Throwable ex)
         {
@@ -418,15 +416,23 @@ public abstract class AbstractADL2Model<WM extends Widget>
         StringBuffer strBuff = new StringBuffer();
         for (int ii = 0; ii < argList.length; ii++) {
             String[] argParts = argList[ii].split("=");
-            if (argParts.length != 2)
-                logger.log(Level.WARNING, "Erroneous macro setting in " + args);
-            else
+            if (argParts.length == 1)
+            {   // Pass X=""
+                if (strBuff.length() != 0)
+                    strBuff.append(", ");
+                strBuff.append(argParts[0]).append("=\"\"");
+            }
+            else if (argParts.length == 2)
+            {
                 if (!argParts[1].replaceAll(" ", "").equals(
                         "$(" + argParts[0].trim() + ")")) {
                     if (strBuff.length() != 0)
                         strBuff.append(", ");
                     strBuff.append(argList[ii]);
                 }
+            }
+            else
+                logger.log(Level.WARNING, "Erroneous macro setting in " + args);
         }
         String resArgs = strBuff.toString();
         return resArgs;

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Composite2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Composite2Model.java
@@ -6,6 +6,10 @@
 
 package org.csstudio.opibuilder.adl2boy.translator;
 
+import static org.csstudio.display.converter.medm.Converter.logger;
+
+import java.util.logging.Level;
+
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.properties.WidgetColor;
@@ -73,17 +77,22 @@ public class Composite2Model extends AbstractADL2Model<Widget> {
         {
             final GroupWidget group = (GroupWidget) widgetModel;
 
-            Converter.convertChildren(compositeWidget.getChildWidgets(), widgetModel, colorMap);
-
-            // Move child positions to be relative to group
-            final int compositeX = widgetModel.propX().getValue();
-            final int compositeY = widgetModel.propY().getValue();
-
-            for (Widget model : group.runtimeChildren().getValue())
+            if (compositeWidget.getChildWidgets() != null)
             {
-                model.propX().setValue(model.propX().getValue() - compositeX);
-                model.propY().setValue(model.propY().getValue() - compositeY);
+                Converter.convertChildren(compositeWidget.getChildWidgets(), widgetModel, colorMap);
+
+                // Move child positions to be relative to group
+                final int compositeX = widgetModel.propX().getValue();
+                final int compositeY = widgetModel.propY().getValue();
+
+                for (Widget model : group.runtimeChildren().getValue())
+                {
+                    model.propX().setValue(model.propX().getValue() - compositeX);
+                    model.propY().setValue(model.propY().getValue() - compositeY);
+                }
             }
+            else
+                logger.log(Level.WARNING, "Empty composite");
         }
     }
 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Indicator2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Indicator2Model.java
@@ -1,0 +1,36 @@
+/*************************************************************************\
+* Copyright (c) 2010  UChicago Argonne, LLC
+* This file is distributed subject to a Software License Agreement found
+* in the file LICENSE that is included with this distribution.
+/*************************************************************************/
+
+package org.csstudio.opibuilder.adl2boy.translator;
+
+import org.csstudio.display.builder.model.ChildrenProperty;
+import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.properties.WidgetColor;
+import org.csstudio.display.builder.model.widgets.TextUpdateWidget;
+import org.csstudio.utility.adlparser.fileParser.ADLWidget;
+import org.csstudio.utility.adlparser.fileParser.widgets.Indicator;
+
+// TODO Better 'indicator' representation than TextUpdate
+public class Indicator2Model extends AbstractADL2Model<TextUpdateWidget> {
+
+    public Indicator2Model(ADLWidget adlWidget, WidgetColor[] colorMap, Widget parentModel) throws Exception {
+        super(adlWidget, colorMap, parentModel);
+    }
+
+    @Override
+    public void processWidget(ADLWidget adlWidget) throws Exception {
+        Indicator inticator = new Indicator(adlWidget);
+        setADLObjectProps(inticator, widgetModel);
+        setADLMonitorProps(inticator, widgetModel);
+    }
+
+    @Override
+    public void makeModel(ADLWidget adlWidget,
+            Widget parentModel) {
+        widgetModel = new TextUpdateWidget();
+        ChildrenProperty.getChildren(parentModel).addChild(widgetModel);
+    }
+}

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/MessageButton2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/MessageButton2Model.java
@@ -19,10 +19,14 @@ import org.csstudio.display.builder.model.properties.ActionInfos;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WritePVActionInfo;
 import org.csstudio.display.builder.model.widgets.ActionButtonWidget;
+import org.csstudio.display.builder.model.widgets.BoolButtonWidget;
+import org.csstudio.display.builder.model.widgets.BoolButtonWidget.Mode;
+import org.csstudio.display.builder.model.widgets.VisibleWidget;
 import org.csstudio.utility.adlparser.fileParser.ADLWidget;
 import org.csstudio.utility.adlparser.fileParser.widgets.MessageButton;
 
-public class MessageButton2Model extends AbstractADL2Model<ActionButtonWidget> {
+@SuppressWarnings("nls")
+public class MessageButton2Model extends AbstractADL2Model<VisibleWidget> {
 
     public MessageButton2Model(ADLWidget adlWidget, WidgetColor[] colorMap, Widget parentModel) throws Exception {
         super(adlWidget, colorMap, parentModel);
@@ -34,42 +38,80 @@ public class MessageButton2Model extends AbstractADL2Model<ActionButtonWidget> {
         setADLObjectProps(messageButtonWidget, widgetModel);
         setADLControlProps(messageButtonWidget, widgetModel);
 
-        widgetModel.propText().setValue(messageButtonWidget.getLabel());
-
-        final List<ActionInfo> actions = new ArrayList<>();
-
-        String press_msg = messageButtonWidget.getPress_msg();
-        if ( (press_msg != null) && !press_msg.isEmpty())
-            actions.add(new WritePVActionInfo("Write", messageButtonWidget.getAdlControl().getChan(), press_msg));
-        String release_msg = messageButtonWidget.getRelease_msg();
-        if ( (release_msg != null) && !(release_msg.equals("")))
+        if (widgetModel instanceof BoolButtonWidget)
         {
-            // TODO Need new widget support for writing value on button release.
-            // Bool button writes 0/1, not arbitrary values
+            final BoolButtonWidget bool_button = (BoolButtonWidget) widgetModel;
 
-            logger.log(Level.WARNING, "Message Button '" + messageButtonWidget.getLabel() + "' release_msg='" +  release_msg + "' is ignored. Only writing press_msg='" + press_msg + "' to " + messageButtonWidget.getAdlControl().getChan());
-//            widgetModel.setPropertyValue(ActionButtonModel.PROP_TOGGLE_BUTTON, true);
-//            ActionsInput ai = widgetModel.getActionsInput();
-//            WritePVAction wpvAction = new WritePVAction();
-//            wpvAction.setPropertyValue(WritePVAction.PROP_PVNAME, messageButtonWidget.getAdlControl().getChan());
-//            wpvAction.setPropertyValue(WritePVAction.PROP_VALUE, release_msg);
-//            ai.addAction(wpvAction);
-//            widgetModel.setPropertyValue(ActionButtonModel.PROP_RELEASED_ACTION_INDEX, actionIndex);
+            // Don't show LED.
+            bool_button.propShowLED().setValue(false);
+
+            // In either state, show the 'text' and 'background color'
+            bool_button.propOnLabel().setValue(messageButtonWidget.getLabel());
+            bool_button.propOffLabel().setValue(messageButtonWidget.getLabel());
+
+            WidgetColor color = bool_button.propBackgroundColor().getValue();
+            bool_button.propOffColor().setValue(color);
+            // Darken for 'pressed' state
+            color = new WidgetColor(color.getRed()*80/100, color.getGreen()*80/100, color.getBlue()*80/100);
+            bool_button.propOnColor().setValue(color);
         }
+        else
+        {
+            final ActionButtonWidget action_button = (ActionButtonWidget) widgetModel;
+            action_button.propText().setValue(messageButtonWidget.getLabel());
+            final List<ActionInfo> actions = new ArrayList<>();
 
-        widgetModel.propActions().setValue(new ActionInfos(actions));
+            final String message;
+            final String press_msg = messageButtonWidget.getPress_msg();
+            final String release_msg = messageButtonWidget.getRelease_msg();
+            if (!press_msg.isEmpty()  &&  release_msg.isEmpty())
+                message = press_msg;
+            else if (press_msg.isEmpty()  &&  !release_msg.isEmpty())
+            {
+                logger.log(Level.FINE, "Message Button '" + messageButtonWidget.getLabel() + "' has no press_msg, so release_msg='" +  release_msg + "' is written to " + messageButtonWidget.getAdlControl().getChan());
+                message = release_msg;
+            }
+            else if (!press_msg.isEmpty()  &&  !release_msg.isEmpty())
+            {
+                logger.log(Level.WARNING, "Message Button '" + messageButtonWidget.getLabel() + "' release_msg='" +  release_msg + "' is ignored. Only writing press_msg='" + press_msg + "' to " + messageButtonWidget.getAdlControl().getChan());
+                message = press_msg;
+            }
+            else
+            {
+                logger.log(Level.WARNING, "Message Button '" + messageButtonWidget.getLabel() + "' has neither press_msg nor release_msg, writing empty string to " + messageButtonWidget.getAdlControl().getChan());;
+                message = "";
+            }
+            actions.add(new WritePVActionInfo("Write", messageButtonWidget.getAdlControl().getChan(), message));
 
-
-//        String color_mode = messageButtonWidget.getColor_mode();
-//        if ( color_mode.equals("static") ||
-//             color_mode.equals("discrete") )
-//            widgetModel.setPropertyValue(CommonWidgetProperties.propBorderAlarmSensitive, false);
+            widgetModel.propActions().setValue(new ActionInfos(actions));
+        }
     }
 
     @Override
     public void makeModel(ADLWidget adlWidget,
             Widget parentModel) {
-        widgetModel =  new ActionButtonWidget();
+
+        // Turn 'message' button that writes 0/1 into 'bool' button
+        MessageButton messageButtonWidget = new MessageButton(adlWidget);
+        String press_msg = messageButtonWidget.getPress_msg();
+        String release_msg = messageButtonWidget.getRelease_msg();
+        if ("1".equals(press_msg)  &&  "0".equals(release_msg))
+        {
+            final BoolButtonWidget bool_button = new BoolButtonWidget();
+            bool_button.propMode().setValue(Mode.PUSH);
+            logger.log(Level.FINE, "Message button for press=1, release=0 converted into boolean push button");
+            widgetModel = bool_button;
+        }
+        else if ("0".equals(press_msg)  &&  "1".equals(release_msg))
+        {
+            final BoolButtonWidget bool_button = new BoolButtonWidget();
+            bool_button.propMode().setValue(Mode.PUSH_INVERTED);
+            logger.log(Level.FINE, "Message button for press=0, release=1 converted into inverted boolean push button");
+            widgetModel = bool_button;
+        }
+        else // Messages other than 0,1 need action button
+            widgetModel =  new ActionButtonWidget();
+
         ChildrenProperty.getChildren(parentModel).addChild(widgetModel);
     }
 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/RelatedDisplay2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/RelatedDisplay2Model.java
@@ -29,7 +29,6 @@ import org.phoebus.framework.macros.Macros;
  *
  */
 public class RelatedDisplay2Model extends AbstractADL2Model<ActionButtonWidget> {
-    // MenuButtonModel menuModel = new MenuButtonModel();
 
     public RelatedDisplay2Model(ADLWidget adlWidget, WidgetColor[] colorMap,
             Widget parentModel) throws Exception {
@@ -38,8 +37,6 @@ public class RelatedDisplay2Model extends AbstractADL2Model<ActionButtonWidget> 
 
     @Override
     public void makeModel(ADLWidget adlWidget, Widget parentModel){
-        final RelatedDisplay rdWidget = new RelatedDisplay(adlWidget);
-        final RelatedDisplayItem[] rdDisplays = rdWidget.getRelatedDisplayItems();
         widgetModel = new ActionButtonWidget();
         ChildrenProperty.getChildren(parentModel).addChild(widgetModel);
     }
@@ -57,21 +54,23 @@ public class RelatedDisplay2Model extends AbstractADL2Model<ActionButtonWidget> 
 
         final List<ActionInfo> actions = new ArrayList<>();
         final RelatedDisplayItem[] displays = rdWidget.getRelatedDisplayItems();
-        if (displays == null  ||  displays.length < 0)
-            return;
-        // For menu, always new tab because menu button doesn't
-        // allow user to use 'Ctrl' etc at runtime.
-        // Users can always close the new tab, but have no other way
-        // to get new tab.
-        final Target target = displays.length == 1 ? Target.REPLACE : Target.TAB;
-        for (RelatedDisplayItem display : displays)
+        if (displays != null  &&  displays.length > 0)
         {
-            final ActionInfo action = createOpenDisplayAction(display, target);
-            if (action != null)
-                actions.add(action);
+            // For menu, always new tab because menu button doesn't
+            // allow user to use 'Ctrl' etc at runtime.
+            // Users can always close the new tab, but have no other way
+            // to get new tab.
+            final Target target = displays.length == 1 ? Target.REPLACE : Target.TAB;
+            for (RelatedDisplayItem display : displays)
+            {
+                final ActionInfo action = createOpenDisplayAction(display, target);
+                if (action != null)
+                    actions.add(action);
+            }
+
+            widgetModel.propActions().setValue(new ActionInfos(actions));
         }
 
-        widgetModel.propActions().setValue(new ActionInfos(actions));
         String label = rdWidget.getLabel();
         if (label != null)
         {

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/ParserADL.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/ParserADL.java
@@ -74,8 +74,11 @@ public final class ParserADL {
                     }else if(line.contains("{") && !line.contains("textix=")){ //$NON-NLS-1$
                         children = new ADLWidget(line,children, lineNr++);
                     }else if (line.contains("}")&& !line.contains("textix=")){ //$NON-NLS-1$
-                        children.getParent().addObject(children);
-                        children = children.getParent();
+                        if (children.getParent() != null)
+                        {
+                            children.getParent().addObject(children);
+                            children = children.getParent();
+                        }
                     }else{
                         boolean dirtyLine = (line.length()-line.replaceAll("\"", "").length())%2==1;
                         if(storeDirtyLine!=null&&dirtyLine && lineNumber==(lastDirtyLine+1)){

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPen.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPen.java
@@ -75,6 +75,8 @@ public class ADLPen extends WidgetPart {
                     setLineColor(FileLine.getIntValue(row[1]));
                 }else if(FileLine.argEquals(row[0], "chan")){ //$NON-NLS-1$
                     setChannel(FileLine.getTrimmedValue(row[1]));
+                }else if(FileLine.argEquals(row[0], "utilChan")){ //$NON-NLS-1$
+                    // Ignore
                 }else {
                     throw new WrongADLFormatException(Messages.ADLMonitor_WrongADLFormatException_Parameter_Begin+row[0]+Messages.ADLMonitor_WrongADLFormatException_Parameter_End+parameter);
                 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPlotData.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPlotData.java
@@ -1,6 +1,9 @@
 package org.csstudio.utility.adlparser.fileParser.widgetParts;
 
+import static  org.csstudio.display.converter.medm.Converter.logger;
+
 import java.util.ArrayList;
+import java.util.logging.Level;
 
 import org.csstudio.utility.adlparser.fileParser.ADLResource;
 import org.csstudio.utility.adlparser.fileParser.ADLWidget;
@@ -67,6 +70,9 @@ public class ADLPlotData extends WidgetPart {
                     setAxisStyle(FileLine.getTrimmedValue(row[1]));
                 }else if(FileLine.argEquals(row[0], "rangeStyle")){ //$NON-NLS-1$
                     setRangeStyle(FileLine.getTrimmedValue(row[1]));
+                }else if(FileLine.argEquals(row[0], "timeFormat")){ //$NON-NLS-1$
+                    // Ignore
+                    logger.log(Level.WARNING, "Ignoring " + parameter.getLine());
                 }else {
                     throw new WrongADLFormatException(Messages.ADLControl_WrongADLFormatException_Parameter_Begin+parameter+Messages.ADLControl_WrongADLFormatException_Parameter_End);
                 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPlotcom.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgetParts/ADLPlotcom.java
@@ -85,6 +85,8 @@ public class ADLPlotcom extends WidgetPart {
                 }else if(FileLine.argEquals(row[0], "bclr")){ //$NON-NLS-1$
                     set_bclr(FileLine.getIntValue(row[1]));
                     set_isBackColorDefined(true);
+                }else if(FileLine.argEquals(row[0], "package")){ //$NON-NLS-1$
+                    // Ignore
                 }else {
                      throw new WrongADLFormatException(Messages.ADLObject_WrongADLFormatException_Parameter_Begin+fileLine+Messages.ADLObject_WrongADLFormatException_Parameter_End);
                 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgets/MessageButton.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/utility/adlparser/fileParser/widgets/MessageButton.java
@@ -16,14 +16,14 @@ import org.csstudio.utility.adlparser.internationalization.Messages;
  *
  */
 public class MessageButton extends ADLAbstractWidget {
-    private String label = new String();;
-    private String press_msg = new String();
-    private String release_msg = new String();
-    private String color_mode = new String("static");
+    private String label = "";
+    private String press_msg = "";
+    private String release_msg = "";
+    private String color_mode = "static";
 
     public MessageButton(ADLWidget adlWidget) {
         super(adlWidget);
-        name = new String("message button");
+        name = "message button";
         try {
             for (ADLWidget childWidget : adlWidget.getObjects()) {
 

--- a/app/display/model/src/main/resources/examples/controls_toggle_buttons.bob
+++ b/app/display/model/src/main/resources/examples/controls_toggle_buttons.bob
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<display version="1.0.0">
+<display version="2.0.0">
   <name>Toggle Buttons</name>
-  <grid_visible>true</grid_visible>
   <widget type="label" version="2.0.0">
     <name>Label</name>
     <text>Button Widgets</text>
@@ -26,7 +25,7 @@
   <widget type="label" version="2.0.0">
     <name>Label_2</name>
     <text>Images</text>
-    <y>350</y>
+    <y>460</y>
     <width>641</width>
     <height>30</height>
     <font>
@@ -189,7 +188,7 @@
     <name>Boolean Button_5</name>
     <pv_name>loc://boolTest(0)</pv_name>
     <bit>-1</bit>
-    <y>420</y>
+    <y>530</y>
     <width>90</width>
     <height>60</height>
     <off_label></off_label>
@@ -212,7 +211,7 @@
   <widget type="label" version="2.0.0">
     <name>Label_10</name>
     <text>Bit -1</text>
-    <y>490</y>
+    <y>600</y>
     <width>90</width>
     <background_color>
       <color red="204" green="255" blue="204">
@@ -225,14 +224,14 @@
     <name>Label_11</name>
     <text>The Boolean Button Widget can use two images
 to represent the on/off state.</text>
-    <y>380</y>
+    <y>490</y>
     <width>410</width>
     <height>40</height>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_12</name>
     <text>The color of the on/off state is then ignored, it only applies to the LED-type blob used when no image is provided.</text>
-    <y>520</y>
+    <y>630</y>
     <width>510</width>
     <height>50</height>
     <font>
@@ -258,12 +257,10 @@ to represent the on/off state.</text>
     <x>580</x>
     <y>80</y>
     <height>20</height>
-    <off_label>OFF</off_label>
     <off_color>
       <color red="60" green="100" blue="60">
       </color>
     </off_color>
-    <on_label>ON</on_label>
     <on_color>
       <color red="60" green="255" blue="60">
       </color>
@@ -341,12 +338,10 @@ to represent the on/off state.</text>
     <x>580</x>
     <y>109</y>
     <height>20</height>
-    <off_label>OFF</off_label>
     <off_color>
       <color red="60" green="100" blue="60">
       </color>
     </off_color>
-    <on_label>ON</on_label>
     <on_color>
       <color red="60" green="255" blue="60">
       </color>
@@ -359,12 +354,10 @@ to represent the on/off state.</text>
     <x>580</x>
     <y>139</y>
     <height>20</height>
-    <off_label>OFF</off_label>
     <off_color>
       <color red="60" green="100" blue="60">
       </color>
     </off_color>
-    <on_label>ON</on_label>
     <on_color>
       <color red="60" green="255" blue="60">
       </color>
@@ -377,12 +370,10 @@ to represent the on/off state.</text>
     <x>580</x>
     <y>169</y>
     <height>20</height>
-    <off_label>OFF</off_label>
     <off_color>
       <color red="60" green="100" blue="60">
       </color>
     </off_color>
-    <on_label>ON</on_label>
     <on_color>
       <color red="60" green="255" blue="60">
       </color>
@@ -395,11 +386,66 @@ to represent the on/off state.</text>
     <x>580</x>
     <y>230</y>
     <height>20</height>
-    <off_label>OFF</off_label>
-    <on_label>ON</on_label>
     <on_color>
       <color name="MAJOR" red="255" green="0" blue="0">
       </color>
     </on_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_20</name>
+    <text>'Push' versions automatically release</text>
+    <y>330</y>
+    <width>420</width>
+    <height>30</height>
+    <font>
+      <font name="Header 2" family="Liberation Sans" style="BOLD" size="18.0">
+      </font>
+    </font>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_6</name>
+    <pv_name>loc://boolTest(0)</pv_name>
+    <bit>3</bit>
+    <y>360</y>
+    <width>90</width>
+    <off_label>OFF</off_label>
+    <on_label>ON</on_label>
+    <show_led>false</show_led>
+    <mode>1</mode>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_7</name>
+    <pv_name>loc://boolTest(0)</pv_name>
+    <bit>2</bit>
+    <x>110</x>
+    <y>360</y>
+    <width>90</width>
+    <off_label>OFF</off_label>
+    <on_label>ON</on_label>
+    <show_led>false</show_led>
+    <mode>1</mode>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_8</name>
+    <pv_name>loc://boolTest(0)</pv_name>
+    <bit>1</bit>
+    <x>220</x>
+    <y>360</y>
+    <width>90</width>
+    <off_label>OFF</off_label>
+    <on_label>ON</on_label>
+    <show_led>false</show_led>
+    <mode>1</mode>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_9</name>
+    <pv_name>loc://boolTest(0)</pv_name>
+    <x>330</x>
+    <y>360</y>
+    <width>90</width>
+    <off_label>OFF</off_label>
+    <on_label>ON</on_label>
+    <show_led>false</show_led>
+    <mode>1</mode>
   </widget>
 </display>

--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -31,4 +31,11 @@ JAR=`echo ${TOP}/product-*.jar`
 # To get one instance, use server mode
 OPT="-server 4918"
 
-java -jar $JAR $OPT "$@" &
+if [ "x$1" == "x-main" ]
+then
+  # Run MEDM converter etc. in foreground
+  java -jar $JAR $OPT "$@"
+else
+  # Run UI as separate thread
+  java -jar $JAR $OPT "$@" &
+fi


### PR DESCRIPTION
Fixes #1082 by adding a '-force' option to the MEDM converter and having the launcher script run it in the invoking shell process.

Fixes 'button' version issue mentioned in https://github.com/areaDetector/ADCore/issues/411 and while at it tried to make most of the 'synapps' displays convert without fatal errors.

Remaining issues that won't be fixed:
 * No support for 'octal' number format -> Shows decimal.
 * Macro 'args' in MEDM file must be comma-separated as also shown in https://epics.anl.gov/EpicsDocumentation/ExtensionsManuals/MEDM/MEDM.html MEDM manual. Not supporting space-separated list of macros.
 * While the explicit MEDM 'composite' is converted, the MEDM 'children' object that contains a similar nested arrangement of grouped widgets is simply turned into a group of widgets, likely missing some intended behavior. 