### PR TITLE
Data Browser: Allow limiting the number of concurrent archive requests

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ public class Preferences
      */
     final public static String
         ARCHIVE_FETCH_DELAY = "archive_fetch_delay",
+        CONCURRENT_REQUESTS = "concurrent_requests",
         ARCHIVE_RESCALE = "archive_rescale",
         ARCHIVES = "archives",
         URLS = "urls",
@@ -69,6 +70,7 @@ public class Preferences
     }
 
     public static int archive_fetch_delay;
+    public static int concurrent_requests;
     public static ArchiveRescale archive_rescale = ArchiveRescale.STAGGER;
     public static List<ArchiveDataSource> archive_urls;
     public static List<ArchiveDataSource> archives;
@@ -94,6 +96,8 @@ public class Preferences
         final PreferencesReader prefs = new PreferencesReader(Activator.class, "/databrowser_preferences.properties");
 
         archive_fetch_delay = prefs.getInt(ARCHIVE_FETCH_DELAY);
+
+        concurrent_requests = prefs.getInt(CONCURRENT_REQUESTS);
 
         String enum_name = prefs.get(ARCHIVE_RESCALE);
         try

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -97,7 +97,8 @@ public class Preferences
 
         archive_fetch_delay = prefs.getInt(ARCHIVE_FETCH_DELAY);
 
-        concurrent_requests = prefs.getInt(CONCURRENT_REQUESTS);
+        // Allow at least one at a time
+        concurrent_requests = Math.max(1, prefs.getInt(CONCURRENT_REQUESTS));
 
         String enum_name = prefs.get(ARCHIVE_RESCALE);
         try

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -37,6 +37,20 @@ trace_type=AREA
 # while interactively zooming and panning
 archive_fetch_delay=500
 
+# Number of concurrent archive fetch requests.
+# When more requests are necessary, the background jobs
+# will wait until the previously submitted jobs complete,
+# to limit the number of concurrent requests.
+#
+# Ideally, the number can be high, but to limit the number
+# of concurrent requests to for example an RDB,
+# this value can be lowered.
+#
+# Note that this does not apply to 'exporting' data
+# in spreadsheet form, where data for N channels is still
+# collected by reading from N concurrent archive readers. 
+concurrent_requests=1000
+
 # Number of binned samples to request for optimized archive access.
 # Negative values scale the display width,
 # i.e. -3 means: 3 times Display pixel width.


### PR DESCRIPTION
Default allows 1000 concurrent requests, i.e. no practical change, but can now configured to a few or only 1.