### PR TITLE
pvxs countdown

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/MonitorListener.java
+++ b/core/pva/src/main/java/org/epics/pva/client/MonitorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,9 @@ public interface MonitorListener
      *  while inside this method.
      *  For example, the array data of a `PVA*Array`
      *  may be reused after this method has been called.
+     *
+     *  <p>When the server cancels the subscription,
+     *  the changes, overruns and data will be <code>null</code>.
      *
      *  @param channel Channel that received an update
      *  @param changes Elements of the structure that changed

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -140,9 +140,13 @@ public class PVAClientMain
     private static void monitor(final List<String> names) throws Exception
     {
         final PVAClient pva = new PVAClient();
+        final CountDownLatch done = new CountDownLatch(1);
         final MonitorListener listener = (ch, changes, overruns, data) ->
         {
-            System.out.println(ch.getName() + " = " + data);
+            if (data == null)
+                done.countDown();
+            else
+                System.out.println(ch.getName() + " = " + data);
         };
         for (String name : names)
             pva.getChannel(name, (ch, state) ->
@@ -162,11 +166,9 @@ public class PVAClientMain
                 }
             });
 
-        // Wait forever
-        synchronized (PVAClientMain.class)
-        {
-            PVAClientMain.class.wait();
-        }
+        // Wait forever unless server closes the subscription
+        done.await();
+        pva.close();
     }
 
     /** Get value for each PV on the list, then close PV


### PR DESCRIPTION
New C++ PVA server 'countdown' example sends 6 monitors and then destroys the monitor.
Handle that in the PVA client, and in the higher-level PV lib indicate it like a disconnected channel.

