### PR TITLE
PVA: Decode sub-element access like 'pva://pv3/b/a'

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,8 +55,8 @@ public class PVAStructureHelper
         final Optional<Integer> elementIndex = name_helper.getElementIndex();
 
         if (! name_helper.getField().equals("value"))
-        {   // Fetch data from a sub-field
-            final PVAData field = struct.get(name_helper.getField());
+        {   // Fetch data from a sub-(sub-sub-)field
+            final PVAData field = struct.locate(name_helper.getField());
             if (field instanceof PVAStructure)
                 actual = (PVAStructure) field;
             else if (field instanceof PVANumber)
@@ -66,7 +66,7 @@ public class PVAStructureHelper
         }
 
         // Handle element references in arrays
-        if(elementIndex.isPresent())
+        if (elementIndex.isPresent())
         {
             final PVAData field = struct.get(name_helper.getField());
             if (field instanceof PVAStructureArray)
@@ -228,7 +228,8 @@ public class PVAStructureHelper
      * @return {@link VType}
      * @throws Exception
      */
-    private static VType decodeNTArray(PVAStructure struct, Integer index) throws Exception {
+    private static VType decodeNTArray(PVAStructure struct, Integer index) throws Exception
+    {
         final PVAData field = struct.get("value");
         if (field instanceof PVADoubleArray)
         {

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -308,6 +308,43 @@ public class PVAStructure extends PVADataWithID
         return null;
     }
 
+    /** Get structure element by path
+    *
+    *  <p>Performs descending search of this structure
+    *
+    *  @param dot_path "element.sub-element.sub-sub-element.final"
+    *  @return Located "final" element or <code>null</code>
+    *  @param <PVA> PVAData or subclass
+     * @throws Exception on error, for example a sub-element
+     *         that is not a structure and prevents further descent.
+    */
+    public <PVA extends PVAData> PVA locate(final String dot_path) throws Exception
+    {
+        PVAStructure sub = this;
+        int start = 0;
+        while (start < dot_path.length())
+        {
+            final int dot = dot_path.indexOf('.', start);
+            if (dot < 0)
+            {   // No more dot, get last (or maybe only) path element
+                final String element = dot_path.substring(start);
+                return sub.get(element);
+            }
+            final String element = dot_path.substring(start, dot);
+            if (element.isEmpty())
+                throw new Exception("Empty path element in '" + dot_path + "'");
+            final PVAData sub_element = sub.get(element);
+            if (sub_element == null)
+                throw new Exception("Cannot locate '" + element + "' for '" + dot_path + "'");
+            if (! (sub_element instanceof PVAStructure))
+                throw new Exception("Element '" + element + "' of '" + dot_path + "' is not a structure");
+            sub = (PVAStructure) sub_element;
+
+            start = dot + 1;
+        }
+        throw new Exception("Cannot locate '" + dot_path + "'");
+    }
+
     /** Get structure element by index
      *
      *  <p>Starting at a top-level structure, index 0
@@ -562,4 +599,3 @@ public class PVAStructure extends PVADataWithID
         }
     }
 }
-

--- a/core/pva/src/test/resources/server.py
+++ b/core/pva/src/test/resources/server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# pvaPy-based demo server for custom structure
+#
+# Test by reading 'pva://pv3', 'pva://pv3/b', 'pva://pv3/b/a'
+
+from time import sleep
+from pvaccess import PvObject, INT, PvaServer
+
+inner = {'value': INT }
+outer = {'a': inner }
+pv = PvObject({'b': outer })
+server = PvaServer('pv3', pv)
+
+print("\nServes:")
+print("pv3 structure")
+print("    structure b")
+print("        structure a")
+print("            int value 3")
+
+x = 1
+while True:
+    pv['b.a.value'] = x
+    print(x)
+    server.update(pv)
+    sleep(1)
+    x = x + 1
+
+


### PR DESCRIPTION
Add PVAStructure.locate() helper to locate sub-elements via dot-path,
then use that in VType PV.

When for example using 'pva://pv3/b/a' as a PV with the included pvaPy demo server, it will read the 'value'. Time stamp, alarm, display info will be empty/default.

#1098

