### PR TITLE
Display Editor: Align selected widgets to Grid / menu item

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -246,7 +246,8 @@ public class DisplayEditor
             createMenuItem(ActionDescription.ALIGN_RIGHT),
             createMenuItem(ActionDescription.ALIGN_TOP),
             createMenuItem(ActionDescription.ALIGN_MIDDLE),
-            createMenuItem(ActionDescription.ALIGN_BOTTOM));
+            createMenuItem(ActionDescription.ALIGN_BOTTOM),
+            createMenuItem(ActionDescription.ALIGN_GRID));
         align.setTooltip(new Tooltip(Messages.Align));
 
         final MenuButton size = new MenuButton(null, null,

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -222,7 +222,10 @@ public class DisplayEditor
         toolkit.setZoomListener(zl);
         zoom_levels.setOnAction(event ->
         {
-            final String actual = requestZoom(zoom_levels.getValue());
+            final String before = zoom_levels.getValue();
+            if (before == null)
+                return;
+            final String actual = requestZoom(before);
             // Java 9 results in IndexOutOfBoundException
             // when combo is updated within the action handler,
             // so defer to another UI tick
@@ -297,6 +300,7 @@ public class DisplayEditor
         @Override
         public void accept(String zoom_level)
         {
+            zoom_levels.getSelectionModel().clearSelection();
             zoom_levels.getEditor().setText(zoom_level);
             edit_tools.getTransforms().setAll(widget_parent.getTransforms());
         }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
@@ -20,6 +20,7 @@ public class Messages
     public static String Align;
     public static String AlignBottom;
     public static String AlignCenter;
+    public static String AlignGrid;
     public static String AlignLeft;
     public static String AlignMiddle;
     public static String AlignRight;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -24,6 +24,8 @@ import org.phoebus.ui.javafx.PlatformInfo;
 import org.phoebus.ui.undo.CompoundUndoableAction;
 import org.phoebus.ui.undo.UndoableActionManager;
 
+import javafx.geometry.Point2D;
+
 /** Description of an action
  *
  *  Wraps the functionality, i.e. icon, tool tip, and what to execute,
@@ -352,6 +354,29 @@ public abstract class ActionDescription
             for (Widget w : widgets)
                 undo.execute(new SetWidgetPropertyAction<>(w.propY(),
                                                            max - w.propHeight().getValue()));
+        }
+    };
+
+    /** Align widgets on the grid constraint */
+    public static final ActionDescription ALIGN_GRID =
+        new ActionDescription("icons/grid.png", Messages.AlignGrid)
+    {
+        @Override
+        public void run(final DisplayEditor editor, final boolean selected)
+        {
+            final List<Widget> widgets = editor.getWidgetSelectionHandler().getSelection();
+            final UndoableActionManager undo = editor.getUndoableActionManager();
+            for (Widget w : widgets)
+            {
+                int x = w.propX().getValue();
+                int y = w.propY().getValue();
+                Point2D constr = editor.getSelectedWidgetUITracker().gridConstrain(x, y);
+                x = (int)constr.getX();
+                y = (int)constr.getY();
+                // Keeping it simple, two actions (possible enhancement use one action for both coordinates)
+                undo.execute(new SetWidgetPropertyAction<>(w.propX(), x));
+                undo.execute(new SetWidgetPropertyAction<>(w.propY(), y));
+            }
         }
     };
 

--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
@@ -3,6 +3,7 @@ AddWidget=Add Widget
 Align=Align
 AlignBottom=Bottom-align selected widgets
 AlignCenter=Center-align selected widgets
+AlignGrid=Align selected widgets to Grid
 AlignLeft=Left-align selected widgets
 AlignMiddle=Middle-align selected widgets
 AlignRight=Right-align selected widgets


### PR DESCRIPTION
See #679 This PR adds a menu item for "Align selected widgets to Grid".
It also enhances the zoom combo box function (the selected item is now cleared when zoom is requested by mouse, to be able to select any new level from items list).