### PR TITLE
PVA bool support

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.epics.pva.data.PVAArray;
+import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAByteArray;
 import org.epics.pva.data.PVAData;
 import org.epics.pva.data.PVADoubleArray;
@@ -38,6 +39,7 @@ import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
 import org.epics.vtype.Display;
 import org.epics.vtype.Time;
+import org.epics.vtype.VBoolean;
 import org.epics.vtype.VNumber;
 import org.epics.vtype.VNumberArray;
 import org.epics.vtype.VString;
@@ -112,6 +114,11 @@ public class PVAStructureHelper
                 return decodeScalarField(struct, union_field);
             else if (union_field instanceof PVAArray)
                 return decodeNTArrayField(struct, union_field);
+        }
+        else if (field instanceof PVABool)
+        {
+            final PVABool bool = (PVABool) field;
+            return VBoolean.of(bool.get(), Alarm.none(), Time.now());
         }
         // TODO: not really sure how to handle arbitrary structures -- no solid use cases yet...
 

--- a/core/pva/src/test/resources/bool.py
+++ b/core/pva/src/test/resources/bool.py
@@ -1,0 +1,15 @@
+# Example PVA server for custom boolean (not NT type)
+from time import sleep
+from pvaccess import PvObject, BOOLEAN, PvaServer
+
+
+pv = PvObject({'value': BOOLEAN })
+server = PvaServer('bool', pv)
+
+print("\nServes 'bool'")
+
+value = True
+while True:
+    pv['value'] = value
+    value = not value
+    sleep(1)

--- a/core/pva/src/test/resources/demo.db
+++ b/core/pva/src/test/resources/demo.db
@@ -39,4 +39,12 @@ record(compress, "waveform$(N)")
   field(ALG, "Circular Buffer")
 }
 
-
+# "Boolean" i.e. binary records use NTEnum,
+# i.e. a structure with type name 'enum_t' and int index,
+# not a 'boolean' data type
+record(bi, "bool$(N)")
+{
+  field(ZNAM, "false")
+  field(ONAM, "true")
+  field(PINI, "YES")
+}

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 
 import org.epics.util.array.ListNumber;
 import org.epics.vtype.Display;
+import org.epics.vtype.VBoolean;
 import org.epics.vtype.VDouble;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VEnumArray;
@@ -147,6 +148,8 @@ public class FormatOptionHandler
         }
         else if (value instanceof VTable)
             return formatTable((VTable) value);
+        else if (value instanceof VBoolean)
+            return Boolean.toString(((VBoolean)value).getValue());
 
         return "<" + value.getClass().getName() + ">";
     }


### PR DESCRIPTION
Example of 'boolean' record (actually NTEnum).
Support decoding a 'bool' element of a PVA structure to allow peeking into custom structures.

#1108 