### PR TITLE
Fix Scan editor memory leak

### DIFF
--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/Palette.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/Palette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,15 +9,15 @@ package org.csstudio.scan.ui.editor;
 
 import static org.csstudio.scan.ScanSystem.logger;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 
 import org.csstudio.scan.command.ScanCommand;
 import org.csstudio.scan.command.ScanCommandFactory;
 import org.phoebus.ui.undo.UndoableActionManager;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TitledPane;
 import javafx.scene.input.Dragboard;
@@ -30,27 +30,36 @@ import javafx.scene.input.TransferMode;
 public class Palette extends TitledPane
 {
     /** Singleton list of all commands */
-    private static final ObservableList<ScanCommand> commands;
+    private static final List<ScanCommand> commands;
 
     static
     {
-        commands = FXCollections.observableArrayList();
+        commands = new ArrayList<>();
         for (String id : ScanCommandFactory.getCommandIDs())
             try
             {
-                    commands.add(ScanCommandFactory.createCommandForID(id));
+                commands.add(ScanCommandFactory.createCommandForID(id));
             }
             catch (Exception ex)
             {
                 logger.log(Level.WARNING, "Cannot create command", ex);
             }
+        // Sort by command name
         Collections.sort(commands, (a, b) -> a.getCommandName().compareTo(b.getCommandName()));
     }
 
-    private final ListView<ScanCommand> command_list = new ListView<>(commands);
+    private final ListView<ScanCommand> command_list = new ListView<>();
 
     public Palette(final Model model, final UndoableActionManager undo)
     {
+        // `commands` was originally an OberservableList,
+        // directly used by the ListView.
+        // That caused this ListView to register itself as a listener
+        // to the static `commands`, resulting in a memory leak.
+        // Now the content of the singleton `commands` is copied into
+        // the items of this command_list, allowing for complete GC
+        // of the ListView and all list cells when the palette is closed.
+        command_list.getItems().setAll(commands);
         command_list.setCellFactory(view -> new PaletteCell(model, undo));
 
         setText("Scan Command Palette");

--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,6 +52,7 @@ public class Messages
     public static String HelpAboutJfx;
     public static String HelpAboutMenuPath;
     public static String HelpAboutOpenLocation;
+    public static String HelpAboutPID;
     public static String HelpAboutPrefs;
     public static String HelpAboutSysFea;
     public static String HelpAboutTitle;

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -120,11 +120,12 @@ public class OpenAbout implements MenuEntry
         infos.add(Arrays.asList(Messages.HelpJavaHome, System.getProperty("java.home")));
         infos.add(Arrays.asList(Messages.HelpAboutJava, System.getProperty("java.specification.vendor") + " " + System.getProperty("java.runtime.version")));
         infos.add(Arrays.asList(Messages.HelpAboutJfx, System.getProperty("javafx.runtime.version")));
+        infos.add(Arrays.asList(Messages.HelpAboutPID, Long.toString(ProcessHandle.current().pid())));
 
         // Display in TableView
         final TableView<List<String>> info_table = new TableView<>(infos);
         info_table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
-        info_table.setPrefHeight(260.0);
+        info_table.setPrefHeight(290.0);
 
         final TableColumn<List<String>, String> name_col = new TableColumn<>(Messages.HelpAboutColName);
         name_col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().get(0)));

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -38,6 +38,7 @@ HelpAboutJava=Java Version
 HelpAboutJfx=JavaFX Version
 HelpAboutMenuPath=Help/About
 HelpAboutOpenLocation=Open file browser for this location
+HelpAboutPID=Process ID
 HelpAboutPrefs=Preference Settings
 HelpAboutSysFea=System Properties
 HelpAboutTitle=About


### PR DESCRIPTION
The "Palette" lists all scan commands. It determines that list once, and then reuses it for each instance of the scan editor.

That list of commands was originally an `ObservableList` for direct use in a `ListView`.
This, however, means that the `ListView` registers as a listener with the observable list, and when the scan editor and palette are closed, the static list of commands still holds on to the listener, the list view, the list cells etc.

Fix memory leak by using a plain list and then setting the `ListView.getItems().setAll(..)` from the list.


While looking at memory leaks in phoebus instances and trying to attach profiler, found that it always takes some trickery to figure out which of the copies running at a beam line are what process ID, so now showing the process ID in the Help/About dialog.